### PR TITLE
Fix expo-router v6 module resolution error

### DIFF
--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true)
+  return {
+    presets: ['babel-preset-expo'],
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,9 @@
     "@clerk/clerk-expo": "^2.0.0",
     "@tanstack/react-query": "^5.0.0",
     "expo": "~54.0.0",
+    "expo-auth-session": "~7.0.10",
     "expo-constants": "~18.0.13",
+    "expo-crypto": "~15.0.8",
     "expo-font": "~14.0.11",
     "expo-notifications": "~0.32.16",
     "expo-router": "~6.0.23",
@@ -29,7 +31,9 @@
     "zustand": "^4.5.0"
   },
   "overrides": {
-    "expo-font": "~14.0.11"
+    "expo-font": "~14.0.11",
+    "expo-auth-session": "~7.0.10",
+    "expo-crypto": "~15.0.8"
   },
   "devDependencies": {
     "@babel/core": "^7.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,9 @@
         "@clerk/clerk-expo": "^2.0.0",
         "@tanstack/react-query": "^5.0.0",
         "expo": "~54.0.0",
+        "expo-auth-session": "~7.0.10",
         "expo-constants": "~18.0.13",
+        "expo-crypto": "~15.0.8",
         "expo-font": "~14.0.11",
         "expo-notifications": "~0.32.16",
         "expo-router": "~6.0.23",
@@ -235,6 +237,36 @@
         "expo": "*"
       }
     },
+    "app/node_modules/expo-auth-session": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-7.0.10.tgz",
+      "integrity": "sha512-XDnKkudvhHSKkZfJ+KkodM+anQcrxB71i+h0kKabdLa5YDXTQ81aC38KRc3TMqmnBDHAu0NpfbzEVd9WDFY3Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.11",
+        "expo-crypto": "~15.0.8",
+        "expo-linking": "~8.0.10",
+        "expo-web-browser": "~15.0.10",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "app/node_modules/expo-crypto": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.8.tgz",
+      "integrity": "sha512-aF7A914TB66WIlTJvl5J6/itejfY78O7dq3ibvFltL9vnTALJ/7LYHvLT4fwmx9yUNS6ekLBtDGWivFWnj2Fcw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "app/node_modules/expo-font": {
       "version": "55.0.4",
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.4.tgz",
@@ -245,6 +277,20 @@
       },
       "peerDependencies": {
         "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "app/node_modules/expo-linking": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
+      "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-constants": "~18.0.12",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
         "react": "*",
         "react-native": "*"
       }


### PR DESCRIPTION
## Summary

Fixes `Error: Cannot find module 'expo-router/internal/routing'` that occurs after the Expo SDK 51 → 54 upgrade.

### Root Cause

The error was caused by:
1. **Missing `babel.config.js`** — SDK 54 requires explicit babel config with `babel-preset-expo`
2. **Missing peer dependencies** — `expo-auth-session` and `expo-crypto` (required by `@clerk/clerk-expo`) were not installed
3. **Stale metro cache** — cached bundles from SDK 51 referenced `expo-router/internal/routing` which doesn't exist in expo-router v6

### Fixes Applied
- Added `app/babel.config.js` with `babel-preset-expo`
- Added `expo-auth-session` (~7.0.10) and `expo-crypto` (~15.0.8) to dependencies
- Added npm `overrides` for `expo-font`, `expo-auth-session`, `expo-crypto` to handle monorepo version hoisting
- Cleared metro cache (`.expo`, metro temp files)

## Test plan
- [x] `npx expo start --no-dev --clear` starts Metro Bundler successfully
- [x] React Compiler enabled in output
- [x] No module resolution errors
- [x] Backend tests: 212 pass, 0 fail
- [ ] Test on Expo Go (iOS/Android)

https://claude.ai/code/session_018kbbRsJcgNuiU4opLZnBMy