### PR TITLE
Fix expo-router v6 require.context error in monorepo

### DIFF
--- a/app/app/gmail/index.tsx
+++ b/app/app/gmail/index.tsx
@@ -16,7 +16,7 @@ WebBrowser.maybeCompleteAuthSession()
 
 const GOOGLE_CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID ?? ''
 
-discovery is the OpenID config endpoint
+// discovery is the OpenID config endpoint
 const discovery = {
   authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
   tokenEndpoint: 'https://oauth2.googleapis.com/token',

--- a/app/app/usage/index.tsx
+++ b/app/app/usage/index.tsx
@@ -60,15 +60,10 @@ export default function UsageScreen() {
       })}
       <Card style={styles.infoCard}>
         <Text style={styles.infoTitle}>ℹ️ Configuring limits</Text>
-        <Text style={styles.infoText}>Set these env vars on the backend to override defaults:{'
-'}{'
-'}
-          <Text style={styles.envVar}>RATE_LIMIT_RPM</Text>{'  '}requests/min{'
-'}
-          <Text style={styles.envVar}>RATE_LIMIT_TOKENS_DAY</Text>{'  '}tokens/day{'
-'}
-          <Text style={styles.envVar}>RATE_LIMIT_COST_DAY</Text>{'  '}max USD/day{'
-'}
+        <Text style={styles.infoText}>Set these env vars on the backend to override defaults:{'\n'}{'\n'}
+          <Text style={styles.envVar}>RATE_LIMIT_RPM</Text>{'  '}requests/min{'\n'}
+          <Text style={styles.envVar}>RATE_LIMIT_TOKENS_DAY</Text>{'  '}tokens/day{'\n'}
+          <Text style={styles.envVar}>RATE_LIMIT_COST_DAY</Text>{'  '}max USD/day{'\n'}
           <Text style={styles.envVar}>RATE_LIMIT_CONCURRENT</Text>{'  '}parallel tasks
         </Text>
       </Card>

--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,6 +1,18 @@
+const { expoRouterBabelPlugin } = require('babel-preset-expo/build/expo-router-plugin')
+
 module.exports = function (api) {
   api.cache(true)
   return {
     presets: ['babel-preset-expo'],
+    overrides: [
+      {
+        // Force expo-router env var inlining for _ctx files in node_modules.
+        // In a monorepo, babel-preset-expo skips process.env replacement for node_modules,
+        // but expo-router's _ctx files need process.env.EXPO_ROUTER_APP_ROOT resolved
+        // to a static string for Metro's require.context() to work.
+        test: /node_modules[\\/]expo-router[\\/]_ctx/,
+        plugins: [expoRouterBabelPlugin],
+      },
+    ],
   }
 }

--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -6,13 +6,17 @@ const monorepoRoot = path.resolve(projectRoot, '..')
 
 const config = getDefaultConfig(projectRoot)
 
-// Watch all files in the monorepo
+// Monorepo support: watch all workspace folders
 config.watchFolders = [monorepoRoot]
 
-// Resolve modules from both the app and monorepo root
+// Resolve modules from both the app workspace and monorepo root
 config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(monorepoRoot, 'node_modules'),
 ]
+
+// Ensure Metro knows the project root is the app workspace (not monorepo root)
+// This is critical for expo-router to correctly resolve EXPO_ROUTER_APP_ROOT
+config.projectRoot = projectRoot
 
 module.exports = config


### PR DESCRIPTION
## Summary

Fixes the `Error: Cannot find module 'expo-router/internal/routing'` / `Invalid call: process.env.EXPO_ROUTER_APP_ROOT` error that occurs after the Expo SDK 54 upgrade in a monorepo setup.

### Root Cause

In a monorepo, `babel-preset-expo` skips `process.env` inlining for files in `node_modules` (`isNodeModule=true` disables both the `expoRouterBabelPlugin` and `expoInlineEnvVars` plugin). However, expo-router's `_ctx.ios.js` (and other platform variants) use `process.env.EXPO_ROUTER_APP_ROOT` as the first argument to `require.context()`. Metro's static analysis requires this to be a string literal — when it's not replaced, the bundler throws:

```
SyntaxError: node_modules/expo-router/_ctx.ios.js: Invalid call at line 2: process.env.EXPO_ROUTER_APP_ROOT
First argument of `require.context` should be a string denoting the directory to require.
```

### Fix

- **`babel.config.js`**: Added a babel `overrides` entry that applies `expoRouterBabelPlugin` specifically to files matching `node_modules/expo-router/_ctx*`. This ensures `process.env.EXPO_ROUTER_APP_ROOT` is replaced with the computed relative path during the babel transform, before Metro's collect-dependencies step.

- **`metro.config.js`**: Added explicit `projectRoot` for monorepo clarity.

### Also Fixed
- `app/app/gmail/index.tsx:19`: Missing `//` comment prefix (syntax error that only surfaces during bundling)
- `app/app/usage/index.tsx:63-72`: Unterminated string constants in JSX — multiline `{'\n'}` expressions were split across actual line breaks

## Test plan
- [x] `npx expo export --platform ios` — bundle succeeds (4.03 MB, 1267 modules)
- [x] `npx expo start --no-dev --clear` — Metro starts with React Compiler enabled
- [x] Backend tests: 212 pass, 0 fail
- [ ] Test on Expo Go (iOS/Android)

https://claude.ai/code/session_018kbbRsJcgNuiU4opLZnBMy