### PR TITLE
feat(backend): OpenAI-compatible + custom LLM providers (DeepSeek, Kimi, Qwen, MiniMax, Ollama)

### DIFF
--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -32,9 +32,27 @@ export async function orgRoutes(app: FastifyInstance) {
     culture: z.string().optional(),
     deployMode: z.enum(['cloud', 'local']).optional(),
     cloudProvider: z.enum(['aws', 'aws_ch', 'gcp', 'gcp_ch', 'azure', 'oracle']).optional(),
-    preferredLlm: z.enum(['claude', 'gpt4o', 'gemini']).optional(),
+    // Legacy preset key (mobile onboarding) — widened to accept any catalogue value.
+    preferredLlm: z.string().optional(),
+    // Explicit model selection (web onboarding): provider + model id, with optional
+    // per-org credentials for hosted OpenAI-compatible / custom providers.
+    llmProvider: z.string().optional(),
+    llmModel: z.string().optional(),
+    llmApiKey: z.string().optional(),
+    llmBaseUrl: z.string().optional(),
     firstAgentRole: z.string().optional(),
   })
+
+  // Map the legacy preferredLlm preset to a concrete provider + model.
+  const PRESET_LLM: Record<string, { provider: string; model: string }> = {
+    gpt4o:  { provider: 'openai', model: 'gpt-4o' },
+    gemini: { provider: 'google', model: 'gemini-2.0-flash' },
+    claude: { provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
+  }
+  function resolveLlm(body: z.infer<typeof OrgSchema>): { provider: string; model: string } {
+    if (body.llmProvider && body.llmModel) return { provider: body.llmProvider, model: body.llmModel }
+    return PRESET_LLM[body.preferredLlm ?? 'claude'] ?? PRESET_LLM.claude
+  }
 
   app.get('/api/orgs', async (req) => {
     const userId = (req as any).auth?.userId ?? ''
@@ -43,7 +61,12 @@ export async function orgRoutes(app: FastifyInstance) {
   app.post('/api/orgs', async (req, reply) => {
     const userId = (req as any).auth?.userId ?? 'anon'
     const body = OrgSchema.parse(req.body)
-    const org = { id: randomUUID(), name: body.name, description: body.description ?? null, logoUrl: body.logoUrl ?? null, ownerId: userId, createdAt: new Date(), mission: body.mission ?? null, culture: body.culture ?? null, deployMode: body.deployMode ?? null, cloudProvider: body.cloudProvider ?? null, preferredLlm: body.preferredLlm ?? null, deployConfig: {} }
+    const llm = resolveLlm(body)
+    // Persist per-org credentials for the chosen provider (consumed by the LLM router).
+    const deployConfig: Record<string, string> = {}
+    if (body.llmApiKey)  deployConfig[`${llm.provider}_api_key`]  = body.llmApiKey
+    if (body.llmBaseUrl) deployConfig[`${llm.provider}_base_url`] = body.llmBaseUrl
+    const org = { id: randomUUID(), name: body.name, description: body.description ?? null, logoUrl: body.logoUrl ?? null, ownerId: userId, createdAt: new Date(), mission: body.mission ?? null, culture: body.culture ?? null, deployMode: body.deployMode ?? null, cloudProvider: body.cloudProvider ?? null, preferredLlm: body.preferredLlm ?? null, deployConfig }
     await db.insert(schema.organisations).values(org)
 
     // 0. Create org membership for owner
@@ -85,12 +108,8 @@ export async function orgRoutes(app: FastifyInstance) {
       personality: 'Direct, strategic. Routes tasks efficiently. Speaks in first person.',
       cv: null,
       termsOfReference: arturitoTOR,
-      llmProvider: body.preferredLlm === 'gpt4o' ? 'openai'
-                 : body.preferredLlm === 'gemini' ? 'google'
-                 : 'anthropic',
-      llmModel: body.preferredLlm === 'gpt4o' ? 'gpt-4o'
-              : body.preferredLlm === 'gemini' ? 'gemini-2.0-flash'
-              : 'claude-sonnet-4-20250514',
+      llmProvider: llm.provider,
+      llmModel: llm.model,
       skills: [],
       status: 'idle',
       avatarEmoji: '🎯',
@@ -117,8 +136,8 @@ export async function orgRoutes(app: FastifyInstance) {
         name: tmpl.name, role: tmpl.role,
         personality: null, cv: null,
         termsOfReference: `You are ${tmpl.name}, ${tmpl.role} at ${body.name}.`,
-        llmProvider: 'anthropic',
-        llmModel: 'claude-sonnet-4-20250514',
+        llmProvider: llm.provider,
+        llmModel: llm.model,
         skills: [], status: 'idle',
         avatarEmoji: tmpl.emoji, agentType: 'standard',
         advisorPersona: null, memoryLongTerm: null,

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -97,12 +97,13 @@ export async function executeAgentTask(opts: {
     const model    = agent.llmModel    ?? 'claude-sonnet-4-20250514'
     const provider = agent.llmProvider ?? 'anthropic'
     const orgApiKey = org?.deployConfig?.[`${provider}_api_key`] as string | undefined
+    const baseURL   = org?.deployConfig?.[`${provider}_base_url`] as string | undefined
     const messages = [...conversationHistory, { role: 'user' as const, content: input }]
     const start = Date.now()
     let rawOutput = ''
 
     const result = await streamLLM({
-      provider, model, system: systemPrompt, messages, orgApiKey,
+      provider, model, system: systemPrompt, messages, orgApiKey, baseURL,
       onToken: (chunk) => { rawOutput += chunk; onToken?.(chunk) },
     })
 
@@ -133,7 +134,7 @@ export async function executeAgentTask(opts: {
           const synthesisInput = buildSynthesisPrompt(input, cleanedOutput, delegations)
           const synthResult = await streamLLM({
             provider, model, system: systemPrompt, messages: [{ role: 'user', content: synthesisInput }],
-            orgApiKey, onToken: (chunk) => onToken?.(chunk),
+            orgApiKey, baseURL, onToken: (chunk) => onToken?.(chunk),
           })
           cleanedOutput = synthResult.output
         }

--- a/backend/src/services/llm-router.ts
+++ b/backend/src/services/llm-router.ts
@@ -1,6 +1,9 @@
 // ─── Multi-Model LLM Router ──────────────────────────────────────────────────────
-// Unified streaming interface across Anthropic, OpenAI, Google Gemini
-// Provider is resolved from agent.llmProvider + agent.llmModel
+// Unified streaming interface across Anthropic, Google Gemini, and any
+// OpenAI-compatible provider (OpenAI, DeepSeek, Kimi/Moonshot, Qwen, MiniMax,
+// Ollama, or a fully custom endpoint).
+// Provider is resolved from agent.llmProvider + agent.llmModel; per-org API key
+// and base URL come from org.deployConfig ('<provider>_api_key' / '<provider>_base_url').
 
 import Anthropic from '@anthropic-ai/sdk'
 
@@ -13,6 +16,7 @@ export interface LLMStreamOpts {
   maxTokens?: number
   onToken: (chunk: string) => void
   orgApiKey?: string
+  baseURL?: string   // override base URL for OpenAI-compatible / custom providers
 }
 
 export interface LLMUsage { inputTokens: number; outputTokens: number }
@@ -37,6 +41,22 @@ export const COST_RATES: Record<string, { input: number; output: number }> = {
   'gemini-2.0-flash':          { input: 0.000000075, output: 0.0000003 },
   'gemini-1.5-pro':            { input: 0.00000125,  output: 0.000005 },
   'gemini-1.5-flash':          { input: 0.000000075, output: 0.0000003 },
+  // DeepSeek (OpenAI-compatible)
+  'deepseek-chat':             { input: 0.00000027,  output: 0.0000011 },
+  'deepseek-reasoner':         { input: 0.00000055,  output: 0.00000219 },
+  // Kimi / Moonshot (OpenAI-compatible)
+  'kimi-k2-0905-preview':      { input: 0.0000006,   output: 0.0000025 },
+  'moonshot-v1-32k':           { input: 0.0000012,   output: 0.0000012 },
+  // Qwen / Alibaba DashScope (OpenAI-compatible)
+  'qwen-max':                  { input: 0.0000016,   output: 0.0000064 },
+  'qwen-plus':                 { input: 0.0000004,   output: 0.0000012 },
+  'qwen-turbo':                { input: 0.00000005,  output: 0.0000002 },
+  // MiniMax (OpenAI-compatible)
+  'MiniMax-Text-01':           { input: 0.0000002,   output: 0.0000011 },
+  // Ollama / self-hosted models run locally — no per-token cost
+  'llama3.3':                  { input: 0,           output: 0 },
+  'qwen2.5':                   { input: 0,           output: 0 },
+  'mistral':                   { input: 0,           output: 0 },
 }
 
 export function calcCost(model: string, input: number, output: number): number {
@@ -45,7 +65,7 @@ export function calcCost(model: string, input: number, output: number): number {
   return input * rates.input + output * rates.output
 }
 
-export const MODEL_CATALOGUE = {
+export const MODEL_CATALOGUE: Record<string, { id: string; label: string; tier: string }[]> = {
   anthropic: [
     { id: 'claude-sonnet-4-20250514',  label: 'Claude Sonnet 4',   tier: 'balanced' },
     { id: 'claude-opus-4-6',           label: 'Claude Opus 4',     tier: 'power' },
@@ -59,6 +79,39 @@ export const MODEL_CATALOGUE = {
     { id: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash', tier: 'fast' },
     { id: 'gemini-1.5-pro',   label: 'Gemini 1.5 Pro',   tier: 'power' },
   ],
+  deepseek: [
+    { id: 'deepseek-chat',     label: 'DeepSeek V3',  tier: 'balanced' },
+    { id: 'deepseek-reasoner', label: 'DeepSeek R1',  tier: 'power' },
+  ],
+  moonshot: [
+    { id: 'kimi-k2-0905-preview', label: 'Kimi K2',          tier: 'power' },
+    { id: 'moonshot-v1-32k',      label: 'Moonshot v1 32k',  tier: 'balanced' },
+  ],
+  qwen: [
+    { id: 'qwen-max',   label: 'Qwen Max',   tier: 'power' },
+    { id: 'qwen-plus',  label: 'Qwen Plus',  tier: 'balanced' },
+    { id: 'qwen-turbo', label: 'Qwen Turbo', tier: 'fast' },
+  ],
+  minimax: [
+    { id: 'MiniMax-Text-01', label: 'MiniMax Text 01', tier: 'balanced' },
+  ],
+  ollama: [
+    { id: 'llama3.3', label: 'Llama 3.3 (local)', tier: 'balanced' },
+    { id: 'qwen2.5',  label: 'Qwen 2.5 (local)',  tier: 'balanced' },
+    { id: 'mistral',  label: 'Mistral (local)',   tier: 'fast' },
+  ],
+}
+
+// OpenAI-compatible providers: same chat-completions wire format, different host.
+// A per-org base URL (deployConfig['<provider>_base_url']) overrides these defaults,
+// which is also how the fully-custom 'custom' provider is driven.
+export const OPENAI_COMPATIBLE_BASE_URLS: Record<string, string> = {
+  openai:   'https://api.openai.com/v1',
+  deepseek: 'https://api.deepseek.com/v1',
+  moonshot: 'https://api.moonshot.ai/v1',
+  qwen:     'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+  minimax:  'https://api.minimax.io/v1',
+  ollama:   'http://localhost:11434/v1',
 }
 
 // ─ Anthropic stream ────────────────────────────────────────────────────
@@ -84,10 +137,18 @@ async function streamAnthropic(opts: LLMStreamOpts): Promise<LLMResult> {
   }
 }
 
-// ─ OpenAI stream ─────────────────────────────────────────────────────
-async function streamOpenAI(opts: LLMStreamOpts): Promise<LLMResult> {
-  const apiKey = opts.orgApiKey ?? process.env.OPENAI_API_KEY
-  if (!apiKey) throw new Error('OPENAI_API_KEY not set')
+// ─ OpenAI-compatible stream (OpenAI, DeepSeek, Kimi, Qwen, MiniMax, Ollama, custom) ─
+// Resolves the base URL in priority order: explicit opts.baseURL → per-provider
+// default → OpenAI. Ollama needs no key; every other provider requires one.
+export function resolveBaseURL(opts: LLMStreamOpts): string {
+  return opts.baseURL ?? OPENAI_COMPATIBLE_BASE_URLS[opts.provider] ?? OPENAI_COMPATIBLE_BASE_URLS.openai
+}
+
+async function streamOpenAICompatible(opts: LLMStreamOpts, provider: string): Promise<LLMResult> {
+  const baseURL = resolveBaseURL(opts)
+  // OpenAI keeps its env fallback; other hosted providers rely on the per-org key.
+  const apiKey = opts.orgApiKey ?? (provider === 'openai' ? process.env.OPENAI_API_KEY : undefined)
+  if (!apiKey && provider !== 'ollama') throw new Error(`No API key configured for provider "${provider}"`)
 
   const body = {
     model: opts.model,
@@ -100,12 +161,15 @@ async function streamOpenAI(opts: LLMStreamOpts): Promise<LLMResult> {
     ],
   }
 
-  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+
+  const res = await fetch(`${baseURL.replace(/\/$/, '')}/chat/completions`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(body),
   })
-  if (!res.ok) throw new Error(`OpenAI error ${res.status}`)
+  if (!res.ok) throw new Error(`${provider} error ${res.status}`)
 
   const reader = res.body!.getReader()
   const decoder = new TextDecoder()
@@ -130,7 +194,7 @@ async function streamOpenAI(opts: LLMStreamOpts): Promise<LLMResult> {
       } catch {}
     }
   }
-  return { output, model: opts.model, provider: 'openai', usage: { inputTokens, outputTokens } }
+  return { output, model: opts.model, provider, usage: { inputTokens, outputTokens } }
 }
 
 // ─ Google Gemini stream ─────────────────────────────────────────────
@@ -187,9 +251,22 @@ export async function streamLLM(opts: LLMStreamOpts): Promise<LLMResult> {
   const { withSpan } = await import('./telemetry')
   return withSpan('llm.call', { 'llm.provider': opts.provider, 'llm.model': opts.model }, async () => {
     switch (opts.provider) {
-      case 'openai':  return streamOpenAI(opts)
-      case 'google':  return streamGemini(opts)
-      default:        return streamAnthropic(opts)
+      case 'google':    return streamGemini(opts)
+      case 'anthropic': return streamAnthropic(opts)
+      case 'openai':
+      case 'deepseek':
+      case 'moonshot':
+      case 'qwen':
+      case 'minimax':
+      case 'ollama':
+        return streamOpenAICompatible(opts, opts.provider)
+      case 'custom':
+        if (!opts.baseURL) throw new Error('custom provider requires a baseURL')
+        return streamOpenAICompatible(opts, 'custom')
+      default:
+        // Unknown provider with an explicit baseURL → treat as OpenAI-compatible custom.
+        if (opts.baseURL) return streamOpenAICompatible(opts, opts.provider)
+        return streamAnthropic(opts)
     }
   })
 }

--- a/backend/src/tests/llm-router.test.ts
+++ b/backend/src/tests/llm-router.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { calcCost, COST_RATES, MODEL_CATALOGUE } from '../services/llm-router.ts'
+import { calcCost, COST_RATES, MODEL_CATALOGUE, OPENAI_COMPATIBLE_BASE_URLS, resolveBaseURL } from '../services/llm-router.ts'
 
 describe('calcCost', () => {
   it('calculates cost for claude-sonnet-4', () => {
@@ -61,5 +61,43 @@ describe('MODEL_CATALOGUE', () => {
         assert.ok(m.id in COST_RATES, `Missing cost rate for ${m.id}`)
       }
     }
+  })
+
+  it('includes the new OpenAI-compatible providers', () => {
+    for (const p of ['deepseek', 'moonshot', 'qwen', 'minimax', 'ollama']) {
+      assert.ok(p in MODEL_CATALOGUE, `Provider ${p} missing from catalogue`)
+    }
+  })
+})
+
+describe('OpenAI-compatible providers', () => {
+  it('has a base URL for every hosted OpenAI-compatible provider', () => {
+    for (const p of ['openai', 'deepseek', 'moonshot', 'qwen', 'minimax', 'ollama']) {
+      assert.ok(OPENAI_COMPATIBLE_BASE_URLS[p], `No base URL for ${p}`)
+    }
+  })
+
+  it('resolveBaseURL prefers an explicit override', () => {
+    const url = resolveBaseURL({ provider: 'deepseek', model: 'x', system: '', messages: [], onToken: () => {}, baseURL: 'https://my.proxy/v1' })
+    assert.equal(url, 'https://my.proxy/v1')
+  })
+
+  it('resolveBaseURL falls back to the provider default', () => {
+    const url = resolveBaseURL({ provider: 'deepseek', model: 'x', system: '', messages: [], onToken: () => {} })
+    assert.equal(url, OPENAI_COMPATIBLE_BASE_URLS.deepseek)
+  })
+
+  it('resolveBaseURL falls back to OpenAI for an unknown provider', () => {
+    const url = resolveBaseURL({ provider: 'mystery', model: 'x', system: '', messages: [], onToken: () => {} })
+    assert.equal(url, OPENAI_COMPATIBLE_BASE_URLS.openai)
+  })
+
+  it('calculates cost for a DeepSeek model', () => {
+    const cost = calcCost('deepseek-chat', 1000, 500)
+    assert.ok(Math.abs(cost - (1000 * 0.00000027 + 500 * 0.0000011)) < 1e-12)
+  })
+
+  it('treats local Ollama models as free', () => {
+    assert.equal(calcCost('llama3.3', 100000, 50000), 0)
   })
 })


### PR DESCRIPTION
## What

Extends the LLM router beyond Anthropic / OpenAI / Gemini to **any OpenAI-compatible provider**, plus a fully custom endpoint:

- **DeepSeek**, **Kimi (Moonshot)**, **Qwen (DashScope)**, **MiniMax**, **Ollama** (local), and **`custom`** (bring-your-own base URL)
- They all speak OpenAI's `chat/completions` wire format, so the existing OpenAI streamer is generalised to take a base URL — **no new dependencies**.

## Changes

**`llm-router.ts`**
- `LLMStreamOpts.baseURL?` added (non-breaking, optional)
- `streamOpenAI` → `streamOpenAICompatible(opts, provider)` driven by `resolveBaseURL()` (explicit override → per-provider default → OpenAI)
- `OPENAI_COMPATIBLE_BASE_URLS` map; Ollama needs no API key
- `MODEL_CATALOGUE` + `COST_RATES` expanded (Ollama local models = free)
- `streamLLM` routes the new providers; unknown provider **+ explicit baseURL** is treated as OpenAI-compatible; default still Anthropic (back-compat)

**`agent-executor.ts`**
- Resolves `deployConfig['<provider>_base_url']` (mirrors existing `_api_key`) and threads it through both `streamLLM` calls

**`POST /api/orgs` (`all.ts`)**
- `preferredLlm` widened from a 3-value enum to a string (legacy presets still map via `resolveLlm()`)
- Accepts explicit `llmProvider` / `llmModel` and per-org `llmApiKey` / `llmBaseUrl` (persisted into `deployConfig`)
- Arturito + first specialist agent inherit the chosen provider/model

**Tests** — catalogue membership, base-URL resolution, and cost coverage for the new providers.

## Verification

- ✅ `tsc --noEmit` clean
- ✅ `llm-router.test.ts` 16/16, `org-001.test.ts` 5/5 (the changed areas)
- ⚠️ Some unrelated suites fail **locally** under Node 26 with `ERR_MODULE_NOT_FOUND: src/db/client` — pre-existing (reproduces on `main`); CI runs Node 22 and is unaffected.

## Notes

- `/api/models` already serves `MODEL_CATALOGUE`, so the web model picker becomes data-driven for free.
- Takes effect in production only after the **Fly backend redeploys**.
- Ollama's default base URL is `localhost:11434` — only reachable from a self-hosted/local backend, not from Fly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)