### PR TITLE
fix(ci): repair Deploy workflow (secrets not allowed in job-level if)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,25 +12,29 @@ jobs:
   deploy-backend:
     name: Deploy backend → Fly.io
     runs-on: ubuntu-latest
-    # Only runs when secret is configured
-    if: ${{ secrets.FLY_API_TOKEN != '' }}
+    # NOTE: `secrets` cannot be referenced in a job-level `if:` (it makes the
+    # workflow file invalid). Expose the token as env and gate the step instead.
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy
+        # Skip when the Fly token isn't configured (e.g. forks / PRs)
+        if: ${{ env.FLY_API_TOKEN != '' }}
         # --remote-only = Fly builds the Docker image in the cloud
-        # No local npm install / tsc needed here at all
         run: flyctl deploy --remote-only --app 7ei-backend
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         working-directory: backend
 
   deploy-web:
     name: Deploy web → Vercel
     runs-on: ubuntu-latest
-    if: ${{ secrets.VERCEL_TOKEN != '' }}
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -39,12 +43,11 @@ jobs:
           node-version: '20'
 
       - name: Install web dependencies
+        if: ${{ env.VERCEL_TOKEN != '' }}
         run: npm install --legacy-peer-deps
         working-directory: web
 
       - name: Deploy to Vercel
-        run: npx vercel --prod --token=${{ secrets.VERCEL_TOKEN }} --yes
+        if: ${{ env.VERCEL_TOKEN != '' }}
+        run: npx vercel --prod --token="$VERCEL_TOKEN" --yes
         working-directory: web
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Problem

Every `Deploy` workflow run has been failing at **0s** with *"This run likely failed because of a workflow file issue"* — so merges to `main` deployed **nothing** (backend never auto-redeployed; web was deployed by hand).

Cause: the jobs gated on `if: ${{ secrets.FLY_API_TOKEN != '' }}` / `secrets.VERCEL_TOKEN`. The **`secrets` context is not allowed in a job-level `if:`**, which makes the entire workflow file invalid — it fails to parse before any job runs (which is also why it errored on feature-branch pushes despite `branches: [main]`).

## Fix

- Move tokens into job-level `env:` (where `secrets` **is** allowed).
- Gate the deploy **steps** with `if: ${{ env.<TOKEN> != '' }}` (step-level `if` can read `env`).
- Preserves the original "skip when unconfigured" intent for forks/PRs.

Also aligned the `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` repo secrets to the current `7ei-mission-control-app` project (they predated it), so the auto web-deploy targets the right project.

## Verification

- Pushing this branch produced **no** failed `Deploy` run (the invalid file used to fail on every push) → the file now parses.
- On merge to `main`, `Deploy` will run for real: backend → Fly, web → Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)