### PR TITLE
feat: Org Settings + document upload → summary → shared knowledge

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,11 +12,13 @@
         "@clerk/fastify": "^2.0.0",
         "@fastify/cors": "^11.0.0",
         "@fastify/helmet": "^13.0.0",
+        "@fastify/multipart": "^10.0.0",
         "@fastify/websocket": "^11.0.0",
         "@libsql/client": "^0.14.0",
         "dotenv": "^16.0.0",
         "drizzle-orm": "^0.45.2",
         "fastify": "^5.0.0",
+        "officeparser": "^7.1.0",
         "redis": "^4.7.0",
         "zod": "^3.23.0"
       },
@@ -56,6 +58,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/@clerk/backend": {
       "version": "2.33.5",
@@ -1039,6 +1051,12 @@
         "fast-uri": "^3.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/cors": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
@@ -1058,6 +1076,22 @@
         "fastify-plugin": "^5.0.0",
         "toad-cache": "^3.7.0"
       }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
@@ -1147,6 +1181,29 @@
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-10.0.0.tgz",
+      "integrity": "sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
       }
     },
     "node_modules/@fastify/proxy-addr": {
@@ -1352,6 +1409,271 @@
         "win32"
       ]
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@neon-rs/load": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
@@ -1429,6 +1751,29 @@
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -1455,6 +1800,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/abort-controller": {
@@ -1555,6 +1909,12 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1635,6 +1995,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/delayed-stream": {
@@ -2165,6 +2542,30 @@
         "node": ">= 8"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/file-type": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
+      "integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/find-my-way": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
@@ -2384,6 +2785,32 @@
         "ms": "^2.0.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.5.tgz",
+      "integrity": "sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2398,6 +2825,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/js-base64": {
       "version": "3.7.8",
@@ -2593,6 +3026,40 @@
         }
       }
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/officeparser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/officeparser/-/officeparser-7.1.0.tgz",
+      "integrity": "sha512-BkN+nQeOWNiwo8ZNesikbtvIKV/ZhB7RlcLmZNdfYrrlaJsceB9zS+YOK+ElaZVKj9vOLQfUvlyByRmoJm6KBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "fflate": "^0.8.2",
+        "file-type": "^22.0.1",
+        "pdfjs-dist": "5.6.205",
+        "tesseract.js": "^7.0.0"
+      },
+      "bin": {
+        "officeparser": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harshankur"
+      },
+      "peerDependenciesMeta": {
+        "puppeteer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -2609,6 +3076,28 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.6.205",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.96",
+        "node-readable-to-web-readable-stream": "^0.4.2"
       }
     },
     "node_modules/pino": {
@@ -2725,6 +3214,12 @@
         "@redis/search": "1.2.0",
         "@redis/time-series": "1.1.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -2925,6 +3420,22 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/swr": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
@@ -2937,6 +3448,30 @@
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "license": "Apache-2.0"
     },
     "node_modules/thread-stream": {
       "version": "4.0.0",
@@ -2957,6 +3492,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tr46": {
@@ -3447,6 +4000,18 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -3467,6 +4032,12 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
@@ -3525,6 +4096,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,11 +18,13 @@
     "@clerk/fastify": "^2.0.0",
     "@fastify/cors": "^11.0.0",
     "@fastify/helmet": "^13.0.0",
+    "@fastify/multipart": "^10.0.0",
     "@fastify/websocket": "^11.0.0",
     "@libsql/client": "^0.14.0",
     "dotenv": "^16.0.0",
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.0.0",
+    "officeparser": "^7.1.0",
     "redis": "^4.7.0",
     "zod": "^3.23.0"
   },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import Fastify, { type FastifyError } from 'fastify'
 import cors from '@fastify/cors'
 import helmet from '@fastify/helmet'
 import websocket from '@fastify/websocket'
+import multipart from '@fastify/multipart'
 import { clerkPlugin } from '@clerk/fastify'
 import { setupDatabase } from './db/setup'
 import { dbClient, db, schema } from './db/client'
@@ -47,6 +48,7 @@ async function start() {
   })
 
   await app.register(websocket)
+  await app.register(multipart, { limits: { fileSize: 25 * 1024 * 1024 } })  // 25 MB document uploads
   await app.register(clerkPlugin)
   await setupDatabase()
   await ensureIndex()  // Pinecone (non-blocking)

--- a/backend/src/routes/knowledge.ts
+++ b/backend/src/routes/knowledge.ts
@@ -3,6 +3,7 @@ import { db, schema } from '../db/client'
 import { eq } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
 import { upsertDocument, deleteDocument, searchKnowledge } from '../services/vector-search'
+import { extractText, summariseToMarkdown } from '../services/document-ingest'
 
 export async function knowledgeRoutes(app: FastifyInstance) {
   // Browse Google Drive folder
@@ -119,5 +120,66 @@ export async function knowledgeRoutes(app: FastifyInstance) {
     const item = await db.query.knowledgeItems.findFirst({ where: eq(schema.knowledgeItems.id, itemId) })
     if (!item) return reply.code(404).send({ error: 'Not found' })
     return { content: item.content, name: item.name, mimeType: item.mimeType }
+  })
+
+  // Ingest an uploaded document (PDF/DOCX/PPTX/XLSX/TXT/MD): extract text →
+  // summarise to Markdown via the org's LLM → store as a knowledge item (+RAG).
+  // ?target=mission|culture|knowledge labels the summary. Returns the summary so
+  // the web client can drop it into the corresponding org field for review.
+  app.post('/api/orgs/:orgId/knowledge/ingest-file', async (req, reply) => {
+    const { orgId } = req.params as any
+    const target = ((req.query as any)?.target as string) ?? 'knowledge'
+
+    const data = await (req as any).file?.()
+    if (!data) return reply.code(400).send({ error: 'No file uploaded' })
+    const filename: string = data.filename ?? 'upload'
+    const buffer: Buffer = await data.toBuffer()
+
+    // Extract text
+    let text: string
+    try {
+      text = await extractText(buffer, filename)
+    } catch (err) {
+      req.log.warn({ err }, 'document extraction failed')
+      return reply.code(422).send({ error: 'Could not read this file type' })
+    }
+    if (!text || !text.trim()) return reply.code(422).send({ error: 'No readable text found in file' })
+
+    // Resolve the org's configured model (+ per-org key/base URL) for summarisation
+    const org = await db.query.organisations.findFirst({ where: eq(schema.organisations.id, orgId) })
+    const agent = await db.query.agents.findFirst({ where: eq(schema.agents.orgId, orgId) })
+    const provider = agent?.llmProvider ?? 'anthropic'
+    const model = agent?.llmModel ?? 'claude-sonnet-4-20250514'
+    const dc = (org?.deployConfig ?? {}) as Record<string, string>
+
+    let summary: string
+    try {
+      ;({ summary } = await summariseToMarkdown({
+        text, filename, target, provider, model,
+        orgApiKey: dc[`${provider}_api_key`], baseURL: dc[`${provider}_base_url`],
+      }))
+    } catch (err) {
+      req.log.warn({ err }, 'summarisation failed')
+      return reply.code(502).send({ error: 'Summarisation failed — check the org LLM API key' })
+    }
+
+    // Store the summary as a shared knowledge item
+    const item = {
+      id: randomUUID(), orgId,
+      name: `${filename} — summary`,
+      type: 'summary', mimeType: 'text/markdown',
+      externalId: null, externalUrl: null, parentId: null,
+      content: summary, backend: 'upload', createdAt: new Date(),
+    }
+    await db.insert(schema.knowledgeItems).values(item)
+
+    // Fire-and-forget RAG embedding (no-op until Pinecone is configured)
+    if (process.env.PINECONE_API_KEY) {
+      upsertDocument({ id: item.id, orgId, text: summary, name: item.name, type: 'summary' })
+        .catch(err => console.warn('Embed failed (non-critical):', err))
+    }
+
+    reply.code(201)
+    return { summary, item, target }
   })
 }

--- a/backend/src/services/document-ingest.ts
+++ b/backend/src/services/document-ingest.ts
@@ -1,0 +1,73 @@
+// ─── Document ingestion ──────────────────────────────────────────────────────
+// Extract text from an uploaded file (PDF / DOCX / PPTX / XLSX / TXT / MD) and
+// summarise it into clean Markdown via the org's configured LLM. The summary is
+// stored as a knowledge item and (optionally) written into mission/culture.
+
+import { convert } from 'officeparser'
+import { streamLLM } from './llm-router'
+
+// Input budget for summarisation (~15k tokens). Large docs are clipped; a future
+// pass could map-reduce instead. Surfaced to the caller via wasClipped.
+export const MAX_SUMMARY_INPUT_CHARS = 60_000
+
+const PLAIN_TEXT_EXTS = new Set(['txt', 'md', 'markdown', 'csv', 'tsv', 'log', 'json'])
+
+export function fileExtension(filename: string): string {
+  return (filename.split('.').pop() ?? '').toLowerCase()
+}
+
+// Extract raw text from a file buffer. Plain-text formats are decoded directly;
+// everything else goes through officeparser (pdf/docx/pptx/xlsx/odt/odp/ods).
+export async function extractText(buffer: Buffer, filename: string): Promise<string> {
+  const ext = fileExtension(filename)
+  if (PLAIN_TEXT_EXTS.has(ext)) return buffer.toString('utf-8')
+  // officeparser v7: convert any supported binary doc (pdf/docx/pptx/xlsx/odt…) to plain
+  // text. From a Buffer the file type can't be sniffed, so pass it via parseConfig.fileType.
+  const { value } = await convert(buffer, 'text', { parseConfig: { fileType: ext as any } })
+  return (typeof value === 'string' ? value : String(value ?? '')).trim()
+}
+
+const TARGET_LABELS: Record<string, string> = {
+  mission: 'Mission & Vision',
+  culture: 'Culture & Principles',
+  knowledge: 'reference knowledge',
+}
+
+export function summaryInstruction(target: string): string {
+  const label = TARGET_LABELS[target] ?? 'reference knowledge'
+  return [
+    `You are a precise document summariser for an organisation's shared knowledge base.`,
+    `Produce a clean, well-structured **Markdown** summary of the document provided.`,
+    `It will be stored as the organisation's "${label}" and read by every AI agent, so be faithful and self-contained.`,
+    `Use headings and bullet points; preserve key facts, figures, names, dates, and decisions; drop boilerplate.`,
+    `Output ONLY the Markdown summary — no preamble, no code fences.`,
+  ].join(' ')
+}
+
+export async function summariseToMarkdown(opts: {
+  text: string
+  filename: string
+  target: string
+  provider: string
+  model: string
+  orgApiKey?: string
+  baseURL?: string
+}): Promise<{ summary: string; wasClipped: boolean }> {
+  const wasClipped = opts.text.length > MAX_SUMMARY_INPUT_CHARS
+  const clipped = opts.text.slice(0, MAX_SUMMARY_INPUT_CHARS)
+  const userMsg = `Document filename: ${opts.filename}\n\n=== DOCUMENT CONTENT ===\n${clipped}`
+
+  const result = await streamLLM({
+    provider: opts.provider,
+    model: opts.model,
+    system: summaryInstruction(opts.target),
+    messages: [{ role: 'user', content: userMsg }],
+    orgApiKey: opts.orgApiKey,
+    baseURL: opts.baseURL,
+    onToken: () => {},
+  })
+
+  let summary = result.output.trim()
+  if (wasClipped) summary += `\n\n_— summary based on the first ${MAX_SUMMARY_INPUT_CHARS.toLocaleString()} characters of the document._`
+  return { summary, wasClipped }
+}

--- a/backend/src/tests/document-ingest.test.ts
+++ b/backend/src/tests/document-ingest.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { extractText, fileExtension, summaryInstruction, MAX_SUMMARY_INPUT_CHARS } from '../services/document-ingest.ts'
+
+describe('document-ingest', () => {
+  it('fileExtension lowercases and takes the last segment', () => {
+    assert.equal(fileExtension('Report.FINAL.PDF'), 'pdf')
+    assert.equal(fileExtension('notes.md'), 'md')
+    assert.equal(fileExtension('noext'), 'noext')
+  })
+
+  it('extractText reads plain text + markdown directly (no parser)', async () => {
+    const md = '# Mission\n\nBuild the best AI org platform.'
+    assert.equal(await extractText(Buffer.from(md, 'utf-8'), 'mission.md'), md)
+    const txt = 'plain culture notes'
+    assert.equal(await extractText(Buffer.from(txt, 'utf-8'), 'culture.txt'), txt)
+  })
+
+  it('summaryInstruction reflects the target label and demands Markdown-only', () => {
+    const mission = summaryInstruction('mission')
+    assert.match(mission, /Mission & Vision/)
+    assert.match(mission, /Markdown/)
+    assert.match(mission, /ONLY/)
+    // Unknown target falls back to generic label
+    assert.match(summaryInstruction('whatever'), /reference knowledge/)
+  })
+
+  it('has a sane summarisation input budget', () => {
+    assert.ok(MAX_SUMMARY_INPUT_CHARS >= 10_000)
+  })
+})

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -19,7 +19,7 @@ async function apiFetch<T>(path: string, token: string | null, opts?: RequestIni
   return res.json()
 }
 
-type Org = { id: string; name: string; description?: string }
+type Org = { id: string; name: string; description?: string; mission?: string; culture?: string }
 type Agent = { id: string; name: string; role: string; status: string; avatarEmoji: string; agentType: string; llmModel: string; skills: string[] }
 type Task = { id: string; title: string; status: string; costUsd?: number; tokensUsed?: number; priority: string; createdAt: string; agentId: string; projectId?: string }
 type Project = { id: string; name: string; description?: string; createdAt: string }
@@ -32,7 +32,7 @@ const STATUS_C: Record<string, string> = { idle: '#555', active: '#22c55e', paus
 const JIRA_STATUS_C: Record<string, string> = { 'To Do': '#555', 'In Progress': '#3b82f6', 'Done': '#22c55e', 'Blocked': '#ef4444', 'In Review': '#f59e0b' }
 const PROVIDER_LABELS: Record<string, string> = { anthropic: 'Anthropic', openai: 'OpenAI', google: 'Google', deepseek: 'DeepSeek', moonshot: 'Kimi / Moonshot', qwen: 'Qwen', minimax: 'MiniMax', ollama: 'Ollama (local)' }
 
-type Tab = 'overview' | 'agents' | 'tasks' | 'projects' | 'skills' | 'costs' | 'comms' | 'jira' | 'usage'
+type Tab = 'overview' | 'agents' | 'tasks' | 'projects' | 'skills' | 'costs' | 'comms' | 'jira' | 'usage' | 'settings'
 
 export default function DashboardPage() {
   const { getToken, isLoaded, isSignedIn } = useAuth()
@@ -54,6 +54,12 @@ export default function DashboardPage() {
   const [formErr, setFormErr] = useState<string | null>(null)
   const [form, setForm] = useState({ name: '', description: '', mission: '', culture: '', deployMode: '', cloudProvider: '', llmChoice: 'anthropic::claude-sonnet-4-20250514', llmApiKey: '', customBaseUrl: '', customModel: '' })
   const [catalogue, setCatalogue] = useState<Record<string, { id: string; label: string; tier: string }[]>>({})
+  // Org Settings (editable description/mission/culture + file ingestion)
+  const [settings, setSettings] = useState({ description: '', mission: '', culture: '' })
+  const [savingSettings, setSavingSettings] = useState(false)
+  const [settingsSaved, setSettingsSaved] = useState(false)
+  const [uploadingField, setUploadingField] = useState<string | null>(null)
+  const [settingsMsg, setSettingsMsg] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     const token = await getToken()
@@ -61,6 +67,7 @@ export default function DashboardPage() {
       const { orgs: ol } = await apiFetch<{ orgs: Org[] }>('/api/orgs', token)
       if (ol.length > 0) {
         const o = ol[0]; setOrg(o)
+        setSettings({ description: o.description ?? '', mission: o.mission ?? '', culture: o.culture ?? '' })
         const [ad, td, pd, nd] = await Promise.all([
           apiFetch<{ agents: Agent[] }>(`/api/orgs/${o.id}/agents`, token),
           apiFetch<{ tasks: Task[] }>(`/api/orgs/${o.id}/tasks`, token),
@@ -91,6 +98,49 @@ export default function DashboardPage() {
     apiFetch<{ models: Record<string, { id: string; label: string; tier: string }[]> }>('/api/models', null)
       .then(d => setCatalogue(d.models)).catch(() => {})
   }, [])
+
+  const saveSettings = async () => {
+    if (!org) return
+    setSavingSettings(true); setSettingsSaved(false); setSettingsMsg(null)
+    const token = await getToken()
+    try {
+      await apiFetch(`/api/orgs/${org.id}`, token, { method: 'PATCH', body: JSON.stringify(settings) })
+      setOrg({ ...org, ...settings })
+      setSettingsSaved(true)
+    } catch { setSettingsMsg('Could not save changes.') }
+    setSavingSettings(false)
+  }
+
+  // Upload a document under a field (mission/culture/knowledge): backend extracts +
+  // summarises to Markdown; for mission/culture we drop the summary into the field for review.
+  const uploadToField = async (field: 'mission' | 'culture' | 'knowledge', file: File) => {
+    if (!org) return
+    setUploadingField(field); setSettingsMsg(null); setSettingsSaved(false)
+    const token = await getToken()
+    const fd = new FormData()
+    fd.append('file', file)
+    try {
+      const res = await fetch(`${API}/api/orgs/${org.id}/knowledge/ingest-file?target=${field}`, {
+        method: 'POST',
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: fd,
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error ?? 'Upload failed')
+      }
+      const { summary } = await res.json() as { summary: string }
+      if (field === 'mission' || field === 'culture') {
+        setSettings(s => ({ ...s, [field]: s[field] ? `${s[field]}\n\n${summary}` : summary }))
+        setSettingsMsg(`Summarised "${file.name}" into ${field === 'mission' ? 'Mission & Vision' : 'Culture & Principles'} — review and Save.`)
+      } else {
+        setSettingsMsg(`Summarised "${file.name}" and saved to shared knowledge.`)
+      }
+    } catch (e: any) {
+      setSettingsMsg(e?.message ?? 'Upload failed.')
+    }
+    setUploadingField(null)
+  }
 
   const syncSkills = async () => {
     setSyncing(true)
@@ -237,6 +287,7 @@ export default function DashboardPage() {
     { id: 'comms', icon: '📬', label: 'Comms' },
     { id: 'jira', icon: '🔗', label: `Jira${jiraConnected ? ' ●' : ''}` },
     { id: 'usage', icon: '📊', label: 'Usage' },
+    { id: 'settings', icon: '⚙️', label: 'Settings' },
   ]
 
   return (
@@ -457,6 +508,54 @@ export default function DashboardPage() {
             )}
           </div>
         )}
+
+        {tab === 'settings' && (
+          <div style={s.page}>
+            <h1 style={s.h1}>Settings</h1>
+            <p style={{ color: '#888', fontSize: 14, marginTop: -8, maxWidth: 720 }}>
+              Edit your organisation’s description, mission, and culture — or upload a document
+              (PDF, Word, PowerPoint, Excel, .txt, .md) to summarise into a field. Mission &amp;
+              Culture are read by every agent; each upload is also saved to shared knowledge.
+            </p>
+
+            <div style={{ ...s.projCard, display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 720 }}>
+              <label style={s.formLabel}>Description
+                <input style={s.formInput} value={settings.description}
+                  onChange={e => setSettings({ ...settings, description: e.target.value })} />
+              </label>
+
+              {(['mission', 'culture'] as const).map(field => {
+                const label = field === 'mission' ? 'Mission & Vision' : 'Culture & Principles'
+                return (
+                  <div key={field} style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                      <span style={{ fontSize: 13, fontWeight: 600, color: '#aaa' }}>{label}</span>
+                      <label style={{ ...s.uploadChip, ...(uploadingField ? { opacity: 0.6, cursor: 'default' } : {}) }}>
+                        {uploadingField === field ? 'Summarising…' : '📎 Upload file'}
+                        <input type="file" style={{ display: 'none' }} disabled={uploadingField !== null}
+                          accept=".pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.txt,.md,.csv,.rtf,.html"
+                          onChange={e => { const f = e.target.files?.[0]; if (f) uploadToField(field, f); e.target.value = '' }} />
+                      </label>
+                    </div>
+                    <textarea style={{ ...s.formInput, minHeight: 110, resize: 'vertical' }} value={settings[field]}
+                      placeholder={field === 'mission' ? 'What you’re building and why.' : 'How your org works.'}
+                      onChange={e => setSettings({ ...settings, [field]: e.target.value })} />
+                  </div>
+                )
+              })}
+
+              {settingsMsg && <p style={{ fontSize: 13, margin: 0, color: /could not|fail/i.test(settingsMsg) ? '#ef4444' : '#22c55e' }}>{settingsMsg}</p>}
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <button onClick={saveSettings} disabled={savingSettings}
+                  style={{ ...s.primaryBtn, width: 'fit-content', opacity: savingSettings ? 0.6 : 1, cursor: savingSettings ? 'default' : 'pointer' }}>
+                  {savingSettings ? 'Saving…' : 'Save changes'}
+                </button>
+                {settingsSaved && <span style={{ color: '#22c55e', fontSize: 13 }}>✓ Saved</span>}
+              </div>
+            </div>
+          </div>
+        )}
       </main>
     </div>
   )
@@ -500,4 +599,5 @@ const s: Record<string, React.CSSProperties> = {
   formLabel: { display: 'flex', flexDirection: 'column', gap: 6, fontSize: 13, fontWeight: 600, color: '#aaa' },
   formInput: { background: '#0a0a0a', border: '1px solid #333', borderRadius: 8, padding: '10px 12px', color: '#fff', fontSize: 14, fontFamily: 'inherit', outline: 'none', width: '100%', boxSizing: 'border-box' as const },
   primaryBtn: { background: '#FFB800', color: '#000', border: 'none', borderRadius: 10, padding: '13px 20px', fontSize: 15, fontWeight: 700, marginTop: 4 },
+  uploadChip: { fontSize: 12, fontWeight: 600, color: '#FFB800', background: '#1a1a1a', border: '1px solid #333', padding: '5px 12px', borderRadius: 8, cursor: 'pointer' },
 }


### PR DESCRIPTION
## What

Implements Feature ①: an **Org Settings** screen where Mission & Vision and Culture & Principles can be edited as text **or** populated by uploading a document that gets summarised.

### Web (`web/app/dashboard/page.tsx`)
- New **Settings** tab: edit Description / Mission & Vision / Culture & Principles → **Save** (`PATCH /api/orgs/:orgId`).
- Each of Mission/Culture has an **📎 Upload file** button (PDF, Word, PowerPoint, Excel, .txt, .md, …). On upload the returned summary is dropped into the field for review before saving.

### Backend
- **`services/document-ingest.ts`** — `extractText()` (officeparser `convert` for binaries; direct decode for txt/md/csv) + `summariseToMarkdown()` (summarises via the org's configured LLM through `streamLLM`).
- **`POST /api/orgs/:orgId/knowledge/ingest-file`** (multipart) — extract → summarise → store as a `knowledgeItems` row (+ fire `upsertDocument` for RAG). `?target=mission|culture|knowledge`.
- Registered `@fastify/multipart` (25 MB limit).
- **New deps:** `officeparser` (one lib: PDF/DOCX/PPTX/XLSX), `@fastify/multipart`.
- Tests for the pure helpers.

## Design note
Mission/Culture summaries are written into the **org fields**, which are injected directly into every agent's system prompt (`agent-executor.ts`) — so uploaded knowledge reaches agents **immediately, without Pinecone**. The summary is *also* stored as a shared `.md` knowledge item and embedded (RAG lights up once `PINECONE_API_KEY` is set on the backend — currently off).

## Verification
- ✅ backend `tsc --noEmit` clean; `officeparser.convert(buffer,'text',{parseConfig:{fileType}})` validated locally (html/csv round-trip)
- ✅ web `tsc` + `next build` clean; middleware intact
- ⚠️ the new backend unit test fails *locally* only via the known Node-26 extensionless-import quirk (whole suite does); CI on Node 22 runs it
- Merging auto-deploys backend→Fly + web→Vercel (CI now fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)