### PR TITLE
External / BYO runtime agents + cockpit API (MCA-EXT Phase 1)

### DIFF
--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -1,0 +1,65 @@
+# OpenClaw / external runtime adapter (MCA-EXT, Phase 2)
+
+Bridges a **self-hosted runtime** (OpenClaw/MiniMax, Cursor, custom) to Mission
+Control. The app assigns tasks to an external agent; this adapter claims them,
+runs them with the host's own tools, and reports results + heartbeats back.
+
+```
+Mission Control  ──assign──▶  agent.task.assigned
+        ▲                            │
+        │ POST /result               ▼ GET /api/agent/tasks?state=assigned
+        │ POST /heartbeat   ┌──────────────────┐  POST /claim
+        └───────────────────┤  mc_adapter.py   ├── run with host tools (shell)
+                            └──────────────────┘
+```
+
+## 1. Onboard the agent (get a token)
+
+From the app (or curl with a Clerk session), create the external agent:
+
+```bash
+curl -sX POST "$MC_BASE_URL/api/orgs/$ORG_ID/agents/external" \
+  -H "Authorization: Bearer $CLERK_JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"Arturito · Open Claw","role":"Ops","runtime":"openclaw","llmProvider":"minimax"}'
+# → { "agent": {...}, "agentToken": "mca_..." }   ← token shown ONCE
+```
+
+## 2. Install on the Mac mini
+
+```bash
+mkdir -p ~/.openclaw/mc-adapter
+cp mc_adapter.py mc.env.example ~/.openclaw/mc-adapter/
+cp ~/.openclaw/mc-adapter/mc.env.example ~/.openclaw/mc-adapter/mc.env
+# edit mc.env → paste MC_AGENT_TOKEN, set MC_BASE_URL + MC_WORKDIR
+```
+
+## 3. Run
+
+```bash
+set -a; source ~/.openclaw/mc-adapter/mc.env; set +a
+python3 ~/.openclaw/mc-adapter/mc_adapter.py --once   # one pass
+python3 ~/.openclaw/mc-adapter/mc_adapter.py          # poll loop
+```
+
+Keep it alive with launchd: edit + install `com.7ei.mc-adapter.plist` to
+`~/Library/LaunchAgents/`, then `launchctl load -w ~/Library/LaunchAgents/com.7ei.mc-adapter.plist`.
+
+## Execution model
+
+The default executor runs `task.input` as a **shell command** in `MC_WORKDIR`
+(gated by `MC_ALLOW_SHELL=1`) — OpenClaw is a shell-capable runtime, so this is
+both the smoke-test path and genuinely useful (git ops, file work, scripts).
+To hand tasks to the full OpenClaw/MiniMax brain instead, replace `execute()`
+with a call into OpenClaw's gateway (Phase 2.1).
+
+## Security
+
+- Token is bearer-scoped to one agent+org; only its sha256 hash is stored server-side. Rotate via `POST /api/agents/:id/rotate-token`.
+- Shell execution is **off by default**. Only enable on a host the owner controls; scope `MC_WORKDIR`.
+- Store the token in 1Password (`op run --env-file mc.env -- python3 mc_adapter.py`), not in plaintext where avoidable.
+
+## Verify
+
+`backend/scripts/smoke-openclaw.ts` boots an in-process backend, onboards an
+external agent, assigns a task, runs this adapter `--once`, and asserts the task
+reaches **done** with a heartbeat. Run: `npm --prefix backend run smoke:openclaw`.

--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -44,13 +44,20 @@ python3 ~/.openclaw/mc-adapter/mc_adapter.py          # poll loop
 Keep it alive with launchd: edit + install `com.7ei.mc-adapter.plist` to
 `~/Library/LaunchAgents/`, then `launchctl load -w ~/Library/LaunchAgents/com.7ei.mc-adapter.plist`.
 
-## Execution model
+## Execution model (`MC_EXECUTOR`)
 
-The default executor runs `task.input` as a **shell command** in `MC_WORKDIR`
-(gated by `MC_ALLOW_SHELL=1`) — OpenClaw is a shell-capable runtime, so this is
-both the smoke-test path and genuinely useful (git ops, file work, scripts).
-To hand tasks to the full OpenClaw/MiniMax brain instead, replace `execute()`
-with a call into OpenClaw's gateway (Phase 2.1).
+- **`shell`** — runs `task.input` directly as a shell command in `MC_WORKDIR`
+  (gated by `MC_ALLOW_SHELL=1`). Deterministic; good for git ops / scripts.
+- **`llm`** (Phase 2.1) — hands the task to the agent's **MiniMax / OpenAI-compatible
+  brain**. The adapter fetches its identity from `GET /api/agent/me`, builds a
+  system prompt (name, role, terms of reference), and runs a **ReAct-style tool
+  loop**: the model may emit one ```` ```bash ```` block, the adapter executes it
+  (when `MC_ALLOW_SHELL=1`), feeds the `OBSERVATION:` back, and loops up to
+  `MC_MAX_STEPS` until the model returns a final answer. Configure with
+  `MC_LLM_BASE_URL`, `MC_LLM_API_KEY`, `MC_LLM_MODEL`.
+- **`auto`** (default) — `llm` when `MC_LLM_API_KEY` is set, else `shell`.
+
+So the agent gets real reasoning + the host's tools, not just raw shell.
 
 ## Security
 

--- a/adapters/openclaw/com.7ei.mc-adapter.plist
+++ b/adapters/openclaw/com.7ei.mc-adapter.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- launchd service: keep the MC adapter running + restart on crash.
+     Install: cp to ~/Library/LaunchAgents/ then `launchctl load -w ~/Library/LaunchAgents/com.7ei.mc-adapter.plist`
+     Edit paths/token first. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>            <string>com.7ei.mc-adapter</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/python3</string>
+    <string>/Users/artutito/.openclaw/mc-adapter/mc_adapter.py</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>MC_BASE_URL</key>     <string>https://7ei-backend.fly.dev</string>
+    <key>MC_AGENT_TOKEN</key>  <string>mca_REPLACE_ME</string>
+    <key>MC_WORKDIR</key>      <string>/Users/artutito/7Ei-MC_TARCO</string>
+    <key>MC_ALLOW_SHELL</key>  <string>1</string>
+    <key>MC_POLL_SECONDS</key> <string>20</string>
+  </dict>
+  <key>RunAtLoad</key>        <true/>
+  <key>KeepAlive</key>        <true/>
+  <key>StandardOutPath</key>  <string>/Users/artutito/.openclaw/mc-adapter/adapter.log</string>
+  <key>StandardErrorPath</key><string>/Users/artutito/.openclaw/mc-adapter/adapter.err</string>
+</dict>
+</plist>

--- a/adapters/openclaw/mc.env.example
+++ b/adapters/openclaw/mc.env.example
@@ -1,0 +1,13 @@
+# 7Ei Mission Control adapter config — copy to mc.env and fill in.
+# Keep mc.env out of git (already covered by .gitignore). Prefer 1Password:
+#   op run --env-file mc.env -- python3 mc_adapter.py
+
+MC_BASE_URL=https://7ei-backend.fly.dev
+MC_AGENT_TOKEN=mca_REPLACE_WITH_TOKEN_FROM_ONBOARDING
+MC_WORKDIR=/Users/artutito/7Ei-MC_TARCO        # canonical vault repo
+MC_ALLOW_SHELL=1
+MC_POLL_SECONDS=20
+
+# Optional Telegram completion pings (reuse OpenClaw's bot)
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_CHAT_ID=

--- a/adapters/openclaw/mc.env.example
+++ b/adapters/openclaw/mc.env.example
@@ -8,6 +8,14 @@ MC_WORKDIR=/Users/artutito/7Ei-MC_TARCO        # canonical vault repo
 MC_ALLOW_SHELL=1
 MC_POLL_SECONDS=20
 
+# Executor: auto (llm if MC_LLM_API_KEY set, else shell) | shell | llm
+MC_EXECUTOR=auto
+MC_MAX_STEPS=4
+# LLM brain (OpenAI-compatible). MiniMax shown; works with any compatible host.
+MC_LLM_BASE_URL=https://api.minimax.io/v1
+MC_LLM_API_KEY=
+MC_LLM_MODEL=MiniMax-Text-01
+
 # Optional Telegram completion pings (reuse OpenClaw's bot)
 # TELEGRAM_BOT_TOKEN=
 # TELEGRAM_CHAT_ID=

--- a/adapters/openclaw/mc_adapter.py
+++ b/adapters/openclaw/mc_adapter.py
@@ -1,40 +1,52 @@
 #!/usr/bin/env python3
 """
-7Ei Mission Control — external runtime adapter (MCA-EXT, Phase 2).
+7Ei Mission Control — external runtime adapter (MCA-EXT, Phase 2 / 2.1).
 
 A tiny poll loop that lets a self-hosted runtime (OpenClaw/MiniMax on the Mac
 mini, Cursor, or any custom agent) act as a Mission Control agent: it claims
-tasks the app assigned to it, executes them with the host's own tools, and
-posts results + heartbeats back over the agent-facing API.
+tasks the app assigned to it, executes them — either as a raw shell command or
+by handing them to the agent's LLM brain (MiniMax / any OpenAI-compatible model)
+with a shell tool loop — and posts results + heartbeats over the agent API.
 
-Stdlib only (urllib, json, subprocess) — no pip install. Configure via env or
-an env file (see mc.env.example). The agent token is issued once by
-`POST /api/orgs/:orgId/agents/external`.
+Stdlib only (urllib, json, subprocess) — no pip install.
 
-  MC_BASE_URL       e.g. https://7ei-backend.fly.dev   (or http://localhost:3001)
-  MC_AGENT_TOKEN    mca_...                             (shown once at onboarding)
-  MC_WORKDIR        working dir for shell tasks         (default: cwd)
-  MC_ALLOW_SHELL    "1" to let tasks run as shell       (default: off)
-  MC_POLL_SECONDS   loop interval                       (default: 20)
+  MC_BASE_URL       app backend, e.g. https://7ei-backend.fly.dev
+  MC_AGENT_TOKEN    mca_...  (shown once at onboarding)
+  MC_WORKDIR        working dir for shell tasks (default: cwd)
+  MC_ALLOW_SHELL    "1" to allow shell execution (default: off)
+  MC_EXECUTOR       auto | shell | llm   (default: auto → llm if MC_LLM_API_KEY set, else shell)
+  MC_POLL_SECONDS   loop interval (default: 20)
+  MC_MAX_STEPS      max brain↔tool steps (default: 4)
+  # LLM brain (OpenAI-compatible chat completions):
+  MC_LLM_BASE_URL   e.g. https://api.minimax.io/v1
+  MC_LLM_API_KEY    provider key
+  MC_LLM_MODEL      e.g. MiniMax-Text-01
   TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID   optional completion pings
 """
-import json, os, subprocess, sys, time, urllib.request, urllib.error
+import json, os, re, subprocess, sys, time, urllib.request, urllib.error
 
-BASE   = os.environ.get("MC_BASE_URL", "http://localhost:3001").rstrip("/")
-TOKEN  = os.environ.get("MC_AGENT_TOKEN", "")
+BASE    = os.environ.get("MC_BASE_URL", "http://localhost:3001").rstrip("/")
+TOKEN   = os.environ.get("MC_AGENT_TOKEN", "")
 WORKDIR = os.environ.get("MC_WORKDIR", os.getcwd())
 ALLOW_SHELL = os.environ.get("MC_ALLOW_SHELL", "") in ("1", "true", "yes")
 POLL = int(os.environ.get("MC_POLL_SECONDS", "20"))
+MAX_STEPS = int(os.environ.get("MC_MAX_STEPS", "4"))
+EXECUTOR = os.environ.get("MC_EXECUTOR", "auto")
+LLM_BASE  = os.environ.get("MC_LLM_BASE_URL", "").rstrip("/")
+LLM_KEY   = os.environ.get("MC_LLM_API_KEY", "")
+LLM_MODEL = os.environ.get("MC_LLM_MODEL", "MiniMax-Text-01")
 TG_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 TG_CHAT  = os.environ.get("TELEGRAM_CHAT_ID", "")
 
+_me = None  # cached agent identity
+
 
 def _req(method, path, body=None):
-    url = BASE + path
-    data = json.dumps(body).encode() if body is not None else None
-    req = urllib.request.Request(url, data=data, method=method)
+    req = urllib.request.Request(BASE + path,
+                                 data=json.dumps(body).encode() if body is not None else None,
+                                 method=method)
     req.add_header("Authorization", "Bearer " + TOKEN)
-    if data is not None:  # only when a JSON body is actually sent (Fastify 400s on empty json body)
+    if body is not None:  # Fastify 400s on empty json body
         req.add_header("Content-Type", "application/json")
     try:
         with urllib.request.urlopen(req, timeout=30) as r:
@@ -42,7 +54,7 @@ def _req(method, path, body=None):
             return r.status, (json.loads(raw) if raw else {})
     except urllib.error.HTTPError as e:
         return e.code, {"error": e.read().decode()[:300]}
-    except Exception as e:  # network / DNS / timeout
+    except Exception as e:
         return 0, {"error": str(e)}
 
 
@@ -53,39 +65,124 @@ def heartbeat(status="green", note=None):
     return _req("POST", "/api/agent/heartbeat", body)
 
 
+def whoami():
+    global _me
+    if _me is None:
+        _, data = _req("GET", "/api/agent/me")
+        _me = data.get("agent", {}) if isinstance(data, dict) else {}
+    return _me
+
+
 def telegram(text):
     if not (TG_TOKEN and TG_CHAT):
         return
     try:
-        body = json.dumps({"chat_id": TG_CHAT, "text": text}).encode()
         req = urllib.request.Request(
             f"https://api.telegram.org/bot{TG_TOKEN}/sendMessage",
-            data=body, headers={"Content-Type": "application/json"}, method="POST")
+            data=json.dumps({"chat_id": TG_CHAT, "text": text}).encode(),
+            headers={"Content-Type": "application/json"}, method="POST")
         urllib.request.urlopen(req, timeout=15)
     except Exception as e:
         print("  telegram ping failed:", e, file=sys.stderr)
 
 
-def execute(task):
-    """Run a task with the host's tools. Default executor = shell (gated).
-    Replace/extend this to hand off to the full OpenClaw/MiniMax brain."""
+# ─── executors ──────────────────────────────────────────────────────────────
+
+def shell_run(cmd):
+    """Run a shell command in MC_WORKDIR; return (rc, combined_output)."""
+    os.makedirs(WORKDIR, exist_ok=True)
+    p = subprocess.run(cmd, shell=True, cwd=WORKDIR, capture_output=True, text=True, timeout=600)
+    return p.returncode, (p.stdout + p.stderr).strip()
+
+
+def shell_execute(task):
     cmd = (task.get("input") or task.get("title") or "").strip()
     if not cmd:
         return "failed", "empty task input"
     if not ALLOW_SHELL:
-        return "failed", "shell execution disabled (set MC_ALLOW_SHELL=1 to enable)"
+        return "failed", "shell execution disabled (set MC_ALLOW_SHELL=1)"
     try:
-        os.makedirs(WORKDIR, exist_ok=True)
-        proc = subprocess.run(cmd, shell=True, cwd=WORKDIR, capture_output=True,
-                              text=True, timeout=600)
-        out = (proc.stdout + proc.stderr).strip()
-        return ("done" if proc.returncode == 0 else "failed",
-                out or f"(exit {proc.returncode}, no output)")
+        rc, out = shell_run(cmd)
+        return ("done" if rc == 0 else "failed", out or f"(exit {rc}, no output)")
     except subprocess.TimeoutExpired:
         return "failed", "task timed out after 600s"
     except Exception as e:
         return "failed", f"executor error: {e}"
 
+
+_BASH_RE = re.compile(r"```(?:bash|sh)\s*\n(.*?)```", re.DOTALL)
+
+
+def _extract_bash(text):
+    m = _BASH_RE.search(text or "")
+    return m.group(1).strip() if m else None
+
+
+def llm_chat(messages):
+    """OpenAI-compatible chat completion → assistant content string."""
+    if not (LLM_BASE and LLM_KEY):
+        raise RuntimeError("MC_LLM_BASE_URL / MC_LLM_API_KEY not configured")
+    req = urllib.request.Request(
+        LLM_BASE + "/chat/completions",
+        data=json.dumps({"model": LLM_MODEL, "messages": messages, "temperature": 0.2}).encode(),
+        headers={"Authorization": "Bearer " + LLM_KEY, "Content-Type": "application/json"},
+        method="POST")
+    with urllib.request.urlopen(req, timeout=120) as r:
+        data = json.loads(r.read().decode())
+    return data["choices"][0]["message"]["content"]
+
+
+def llm_execute(task):
+    """Hand the task to the agent's LLM brain with a gated shell tool loop."""
+    me = whoami()
+    name = me.get("name", "Agent")
+    role = me.get("role", "agent")
+    runtime = me.get("runtime", "custom")
+    tor = me.get("termsOfReference") or ""
+    system = (
+        f"You are {name}, {role} at 7Ei, operating as an autonomous Mission Control "
+        f"agent on a {runtime} runtime. {tor}\n"
+        "Complete the user's task. To run a shell command in your working directory, "
+        "reply with EXACTLY ONE fenced ```bash code block and nothing else; the runtime "
+        "executes it and replies with 'OBSERVATION:' + output. When finished, reply with a "
+        "concise final answer and NO bash block."
+    )
+    messages = [{"role": "system", "content": system},
+                {"role": "user", "content": task.get("input") or task.get("title") or ""}]
+    last = ""
+    try:
+        for _ in range(MAX_STEPS):
+            content = llm_chat(messages)
+            last = content
+            bash = _extract_bash(content)
+            if not bash:
+                return "done", content.strip()
+            if not ALLOW_SHELL:
+                messages.append({"role": "assistant", "content": content})
+                messages.append({"role": "user", "content": "OBSERVATION: shell disabled; answer without it."})
+                continue
+            rc, out = shell_run(bash)
+            messages.append({"role": "assistant", "content": content})
+            messages.append({"role": "user", "content": f"OBSERVATION: (exit {rc})\n{out[:4000]}"})
+        return "done", (last.strip() or "(max steps reached)")
+    except Exception as e:
+        return "failed", f"llm executor error: {e}"
+
+
+def choose_executor():
+    if EXECUTOR == "shell":
+        return shell_execute
+    if EXECUTOR == "llm":
+        return llm_execute
+    # auto
+    return llm_execute if LLM_KEY else shell_execute
+
+
+def execute(task):
+    return choose_executor()(task)
+
+
+# ─── poll loop ──────────────────────────────────────────────────────────────
 
 def process_one(task):
     tid = task["id"]
@@ -95,8 +192,7 @@ def process_one(task):
     if code not in (200, 201):
         print(f"    claim failed ({code})"); return
     status, output = execute(task)
-    code, _ = _req("POST", f"/api/agent/tasks/{tid}/result",
-                   {"output": output[:8000], "status": status})
+    code, _ = _req("POST", f"/api/agent/tasks/{tid}/result", {"output": output[:8000], "status": status})
     mark = "✓" if status == "done" else "✗"
     print(f"    {mark} {status}  ({code})")
     telegram(f"{mark} MC task {status}: {title}\n{output[:300]}")
@@ -116,10 +212,10 @@ def poll_once():
 def main():
     if not TOKEN:
         print("MC_AGENT_TOKEN is required", file=sys.stderr); sys.exit(2)
-    once = "--once" in sys.argv
-    print(f"7Ei MC adapter → {BASE}  (shell={'on' if ALLOW_SHELL else 'off'}, workdir={WORKDIR})")
+    mode = "llm" if choose_executor() is llm_execute else "shell"
+    print(f"7Ei MC adapter → {BASE}  (executor={mode}, shell={'on' if ALLOW_SHELL else 'off'}, workdir={WORKDIR})")
     heartbeat("green")
-    if once:
+    if "--once" in sys.argv:
         n = poll_once(); print(f"processed {n} task(s)"); return
     while True:
         try:

--- a/adapters/openclaw/mc_adapter.py
+++ b/adapters/openclaw/mc_adapter.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+7Ei Mission Control — external runtime adapter (MCA-EXT, Phase 2).
+
+A tiny poll loop that lets a self-hosted runtime (OpenClaw/MiniMax on the Mac
+mini, Cursor, or any custom agent) act as a Mission Control agent: it claims
+tasks the app assigned to it, executes them with the host's own tools, and
+posts results + heartbeats back over the agent-facing API.
+
+Stdlib only (urllib, json, subprocess) — no pip install. Configure via env or
+an env file (see mc.env.example). The agent token is issued once by
+`POST /api/orgs/:orgId/agents/external`.
+
+  MC_BASE_URL       e.g. https://7ei-backend.fly.dev   (or http://localhost:3001)
+  MC_AGENT_TOKEN    mca_...                             (shown once at onboarding)
+  MC_WORKDIR        working dir for shell tasks         (default: cwd)
+  MC_ALLOW_SHELL    "1" to let tasks run as shell       (default: off)
+  MC_POLL_SECONDS   loop interval                       (default: 20)
+  TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID   optional completion pings
+"""
+import json, os, subprocess, sys, time, urllib.request, urllib.error
+
+BASE   = os.environ.get("MC_BASE_URL", "http://localhost:3001").rstrip("/")
+TOKEN  = os.environ.get("MC_AGENT_TOKEN", "")
+WORKDIR = os.environ.get("MC_WORKDIR", os.getcwd())
+ALLOW_SHELL = os.environ.get("MC_ALLOW_SHELL", "") in ("1", "true", "yes")
+POLL = int(os.environ.get("MC_POLL_SECONDS", "20"))
+TG_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+TG_CHAT  = os.environ.get("TELEGRAM_CHAT_ID", "")
+
+
+def _req(method, path, body=None):
+    url = BASE + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", "Bearer " + TOKEN)
+    if data is not None:  # only when a JSON body is actually sent (Fastify 400s on empty json body)
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            raw = r.read().decode()
+            return r.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as e:
+        return e.code, {"error": e.read().decode()[:300]}
+    except Exception as e:  # network / DNS / timeout
+        return 0, {"error": str(e)}
+
+
+def heartbeat(status="green", note=None):
+    body = {"status": status}
+    if note:
+        body["note"] = note
+    return _req("POST", "/api/agent/heartbeat", body)
+
+
+def telegram(text):
+    if not (TG_TOKEN and TG_CHAT):
+        return
+    try:
+        body = json.dumps({"chat_id": TG_CHAT, "text": text}).encode()
+        req = urllib.request.Request(
+            f"https://api.telegram.org/bot{TG_TOKEN}/sendMessage",
+            data=body, headers={"Content-Type": "application/json"}, method="POST")
+        urllib.request.urlopen(req, timeout=15)
+    except Exception as e:
+        print("  telegram ping failed:", e, file=sys.stderr)
+
+
+def execute(task):
+    """Run a task with the host's tools. Default executor = shell (gated).
+    Replace/extend this to hand off to the full OpenClaw/MiniMax brain."""
+    cmd = (task.get("input") or task.get("title") or "").strip()
+    if not cmd:
+        return "failed", "empty task input"
+    if not ALLOW_SHELL:
+        return "failed", "shell execution disabled (set MC_ALLOW_SHELL=1 to enable)"
+    try:
+        os.makedirs(WORKDIR, exist_ok=True)
+        proc = subprocess.run(cmd, shell=True, cwd=WORKDIR, capture_output=True,
+                              text=True, timeout=600)
+        out = (proc.stdout + proc.stderr).strip()
+        return ("done" if proc.returncode == 0 else "failed",
+                out or f"(exit {proc.returncode}, no output)")
+    except subprocess.TimeoutExpired:
+        return "failed", "task timed out after 600s"
+    except Exception as e:
+        return "failed", f"executor error: {e}"
+
+
+def process_one(task):
+    tid = task["id"]
+    title = task.get("title", "")[:60]
+    print(f"  ▶ claim {tid}  {title}")
+    code, _ = _req("POST", f"/api/agent/tasks/{tid}/claim")
+    if code not in (200, 201):
+        print(f"    claim failed ({code})"); return
+    status, output = execute(task)
+    code, _ = _req("POST", f"/api/agent/tasks/{tid}/result",
+                   {"output": output[:8000], "status": status})
+    mark = "✓" if status == "done" else "✗"
+    print(f"    {mark} {status}  ({code})")
+    telegram(f"{mark} MC task {status}: {title}\n{output[:300]}")
+
+
+def poll_once():
+    code, data = _req("GET", "/api/agent/tasks?state=assigned")
+    if code != 200:
+        print(f"poll failed ({code}): {data.get('error','')}"); heartbeat("amber"); return 0
+    tasks = data.get("tasks", [])
+    for t in tasks:
+        process_one(t)
+    heartbeat("green")
+    return len(tasks)
+
+
+def main():
+    if not TOKEN:
+        print("MC_AGENT_TOKEN is required", file=sys.stderr); sys.exit(2)
+    once = "--once" in sys.argv
+    print(f"7Ei MC adapter → {BASE}  (shell={'on' if ALLOW_SHELL else 'off'}, workdir={WORKDIR})")
+    heartbeat("green")
+    if once:
+        n = poll_once(); print(f"processed {n} task(s)"); return
+    while True:
+        try:
+            poll_once()
+        except KeyboardInterrupt:
+            print("bye"); return
+        except Exception as e:
+            print("loop error:", e, file=sys.stderr); heartbeat("amber")
+        time.sleep(POLL)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3166,6 +3166,16 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "start": "node dist/index.js",
     "test": "node --test --import=tsx src/tests/*.test.ts",
     "test:watch": "node --test --watch --import=tsx src/tests/*.test.ts",
+    "smoke:openclaw": "node --import=tsx scripts/smoke-openclaw.ts",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
     "db:push": "drizzle-kit push",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "test": "node --test --import=tsx src/tests/*.test.ts",
     "test:watch": "node --test --watch --import=tsx src/tests/*.test.ts",
     "smoke:openclaw": "node --import=tsx scripts/smoke-openclaw.ts",
+    "smoke:openclaw:llm": "node --import=tsx scripts/smoke-openclaw-llm.ts",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
     "db:push": "drizzle-kit push",

--- a/backend/scripts/smoke-openclaw-llm.ts
+++ b/backend/scripts/smoke-openclaw-llm.ts
@@ -1,0 +1,98 @@
+/**
+ * Phase 2.1 smoke — the LLM brain + shell tool loop.
+ *
+ * Boots the agent API + a fake OpenAI-compatible /v1/chat/completions on a real
+ * port, assigns a natural-language task, runs the real adapter with
+ * MC_EXECUTOR=llm, and asserts the adapter ran a brain→bash→brain loop:
+ * the model emits a ```bash block, the adapter executes it (writes the file),
+ * feeds the OBSERVATION back, and the model returns a final answer → task done.
+ *
+ *   npm run smoke:openclaw:llm
+ */
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+
+const work = mkdtempSync(join(tmpdir(), 'mc-smoke-llm-'))
+process.env.DATABASE_URL = `file:${join(work, 'smoke.db')}`
+
+const fail = (m: string) => { console.error('✗ SMOKE FAIL:', m); cleanup(); process.exit(1) }
+function cleanup() { try { rmSync(work, { recursive: true, force: true }) } catch {} }
+
+const main = async () => {
+  const Fastify = (await import('fastify')).default
+  const { setupDatabase } = await import('../src/db/setup.ts')
+  const { db, schema } = await import('../src/db/client.ts')
+  const { agentApiRoutes } = await import('../src/routes/agent-api.ts')
+  const { generateAgentToken, hashToken } = await import('../src/middleware/agent-token.ts')
+  const { eq } = await import('drizzle-orm')
+
+  await setupDatabase()
+
+  const orgId = randomUUID(), agentId = randomUUID(), taskId = randomUUID()
+  const { token } = generateAgentToken()
+  const marker = `brain-${taskId.slice(0, 8)}`
+  await db.insert(schema.organisations).values({ id: orgId, name: 'SmokeCo', ownerId: 'u1', createdAt: new Date() })
+  await db.insert(schema.agents).values({
+    id: agentId, orgId, name: 'Arturito · Open Claw', role: 'Ops',
+    termsOfReference: 'Operate sovereignly; verify before done.',
+    llmProvider: 'minimax', llmModel: 'MiniMax-Text-01', agentType: 'external',
+    runtime: 'openclaw', apiTokenHash: hashToken(token), status: 'idle', createdAt: new Date(),
+  } as any)
+  await db.insert(schema.tasks).values({
+    id: taskId, orgId, agentId, assignedTo: agentId, title: 'write marker',
+    input: `The marker is ${marker}. Write it into ping.txt in your working directory, then confirm.`,
+    status: 'assigned', priority: 'medium', kanbanColumn: 'in_progress', createdAt: new Date(),
+  } as any)
+
+  // Agent API + a fake OpenAI-compatible model on one app.
+  const app = Fastify({ logger: false })
+  let llmCalls = 0
+  app.post('/v1/chat/completions', async (req) => {
+    llmCalls++
+    const msgs = ((req.body as any)?.messages ?? []) as Array<{ role: string; content: string }>
+    const lastUser = [...msgs].reverse().find(m => m.role === 'user')?.content ?? ''
+    // Step 1: emit a bash block. Step 2 (after OBSERVATION): final answer w/ marker.
+    const content = lastUser.includes('OBSERVATION:')
+      ? `Done — wrote ${marker} to ping.txt and verified it.`
+      : '```bash\n' + `echo "${marker}" > ping.txt && cat ping.txt\n` + '```'
+    return { choices: [{ message: { role: 'assistant', content } }] }
+  })
+  await app.register(agentApiRoutes)
+  await app.listen({ port: 0, host: '127.0.0.1' })
+  const port = (app.server.address() as any).port
+  const base = `http://127.0.0.1:${port}`
+
+  const adapter = join(import.meta.dirname, '..', '..', 'adapters', 'openclaw', 'mc_adapter.py')
+  await new Promise<void>((resolve) => {
+    const child = spawn('python3', [adapter, '--once'], {
+      env: {
+        ...process.env, MC_BASE_URL: base, MC_AGENT_TOKEN: token,
+        MC_EXECUTOR: 'llm', MC_ALLOW_SHELL: '1', MC_WORKDIR: work,
+        MC_LLM_BASE_URL: `${base}/v1`, MC_LLM_API_KEY: 'fake', MC_LLM_MODEL: 'MiniMax-Text-01',
+      },
+    })
+    child.stdout.on('data', d => process.stdout.write(d))
+    child.stderr.on('data', d => process.stderr.write(d))
+    child.on('close', () => resolve())
+  })
+
+  const task = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+  const agent = await db.query.agents.findFirst({ where: eq(schema.agents.id, agentId) })
+  await app.close()
+
+  if (llmCalls < 2) fail(`expected a brain→tool→brain loop (>=2 LLM calls), got ${llmCalls}`)
+  if (!task || task.status !== 'done') fail(`task status = ${task?.status} (expected done)`)
+  if (!task!.output?.includes(marker)) fail(`final answer missing marker: ${task!.output}`)
+  if (!existsSync(join(work, 'ping.txt')) || !readFileSync(join(work, 'ping.txt'), 'utf8').includes(marker))
+    fail('tool step did not write ping.txt')
+  if (!agent?.lastHeartbeatAt) fail('agent heartbeat not recorded')
+
+  console.log(`✓ SMOKE PASS — ${llmCalls} LLM calls (brain→bash→brain), task done, marker written + echoed in final answer`)
+  cleanup()
+  process.exit(0)
+}
+
+main().catch(e => fail(e?.message ?? String(e)))

--- a/backend/scripts/smoke-openclaw.ts
+++ b/backend/scripts/smoke-openclaw.ts
@@ -1,0 +1,87 @@
+/**
+ * End-to-end smoke test for the external-agent loop (MCA-EXT Phase 2).
+ *
+ * Boots an in-process backend on a real port with a throwaway sqlite DB,
+ * onboards an external agent, assigns it a shell task, runs the actual
+ * adapters/openclaw/mc_adapter.py with --once, and asserts the task reaches
+ * `done` with a fresh heartbeat. No Clerk, no network, no external services.
+ *
+ *   npm run smoke:openclaw
+ */
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+
+const work = mkdtempSync(join(tmpdir(), 'mc-smoke-'))
+process.env.DATABASE_URL = `file:${join(work, 'smoke.db')}`
+
+const fail = (m: string) => { console.error('✗ SMOKE FAIL:', m); cleanup(); process.exit(1) }
+function cleanup() { try { rmSync(work, { recursive: true, force: true }) } catch {} }
+
+const main = async () => {
+  // Import AFTER DATABASE_URL is set so the singleton client uses the temp DB.
+  const Fastify = (await import('fastify')).default
+  const { setupDatabase } = await import('../src/db/setup.ts')
+  const { db, schema } = await import('../src/db/client.ts')
+  const { agentApiRoutes } = await import('../src/routes/agent-api.ts')
+  const { generateAgentToken, hashToken } = await import('../src/middleware/agent-token.ts')
+  const { eq } = await import('drizzle-orm')
+
+  await setupDatabase()
+
+  // ── seed: org, external agent (known token), assigned shell task ──
+  const orgId = randomUUID(), agentId = randomUUID(), taskId = randomUUID()
+  const { token } = generateAgentToken()
+  await db.insert(schema.organisations).values({ id: orgId, name: 'SmokeCo', ownerId: 'u1', createdAt: new Date() })
+  await db.insert(schema.agents).values({
+    id: agentId, orgId, name: 'Arturito · Open Claw', role: 'Ops',
+    llmProvider: 'minimax', llmModel: 'minimax', agentType: 'external',
+    runtime: 'openclaw', apiTokenHash: hashToken(token), status: 'idle', createdAt: new Date(),
+  } as any)
+  const marker = `pong-${taskId.slice(0, 8)}`
+  await db.insert(schema.tasks).values({
+    id: taskId, orgId, agentId, assignedTo: agentId,
+    title: 'smoke ping', input: `echo "${marker}" > ping.txt && echo "${marker}"`,
+    status: 'assigned', priority: 'medium', kanbanColumn: 'in_progress', createdAt: new Date(),
+  } as any)
+
+  // ── boot the agent API on a real port ──
+  const app = Fastify({ logger: false })
+  await app.register(agentApiRoutes)
+  await app.listen({ port: 0, host: '127.0.0.1' })
+  const addr = app.server.address()
+  const port = typeof addr === 'object' && addr ? addr.port : 0
+  const base = `http://127.0.0.1:${port}`
+
+  // ── run the real Python adapter once ──
+  const adapter = join(import.meta.dirname, '..', '..', 'adapters', 'openclaw', 'mc_adapter.py')
+  if (!existsSync(adapter)) { await app.close(); fail(`adapter not found at ${adapter}`) }
+  // async spawn so this process's event loop keeps serving the Fastify server
+  await new Promise<void>((resolve) => {
+    const child = spawn('python3', [adapter, '--once'], {
+      env: { ...process.env, MC_BASE_URL: base, MC_AGENT_TOKEN: token, MC_ALLOW_SHELL: '1', MC_WORKDIR: work },
+    })
+    child.stdout.on('data', d => process.stdout.write(d))
+    child.stderr.on('data', d => process.stderr.write(d))
+    child.on('close', () => resolve())
+  })
+
+  // ── assert ──
+  const task = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+  const agent = await db.query.agents.findFirst({ where: eq(schema.agents.id, agentId) })
+  await app.close()
+
+  if (!task || task.status !== 'done') fail(`task status = ${task?.status} (expected done)`)
+  if (!task!.output?.includes(marker)) fail(`task output missing marker: ${task!.output}`)
+  if (!existsSync(join(work, 'ping.txt')) || !readFileSync(join(work, 'ping.txt'), 'utf8').includes(marker))
+    fail('adapter did not write ping.txt in workdir')
+  if (!agent?.lastHeartbeatAt) fail('agent heartbeat not recorded')
+
+  console.log(`✓ SMOKE PASS — task ${task!.status}, marker echoed, ping.txt written, heartbeat ${agent!.heartbeatStatus}`)
+  cleanup()
+  process.exit(0)
+}
+
+main().catch(e => fail(e?.message ?? String(e)))

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -53,6 +53,15 @@ export const agents = sqliteTable('agents', {
   persona: text('persona'),
   expertise: text('expertise'),
   advisorIds: text('advisor_ids'),
+  // External / bring-your-own runtime (MCA-EXT). runtime='internal' → driven by
+  // agent-executor + llm-router; anything else (openclaw, cursor, claude_code,
+  // custom) is a self-hosted runtime that polls the agent API.
+  runtime: text('runtime').notNull().default('internal'),
+  externalEndpoint: text('external_endpoint'),       // optional push callback URL
+  apiTokenHash: text('api_token_hash'),              // sha256 of the agent token
+  lastHeartbeatAt: integer('last_heartbeat_at', { mode: 'timestamp' }),
+  heartbeatStatus: text('heartbeat_status').default('unknown'), // green|amber|stale|unknown
+  contactChannel: text('contact_channel'),           // telegram chat id / email for pings
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -6,7 +6,7 @@ export async function setupDatabase() {
     `CREATE TABLE IF NOT EXISTS organisations (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, logo_url TEXT, owner_id TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS departments (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, name TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS projects (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, description TEXT, created_at INTEGER NOT NULL)`,
-    `CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, role TEXT NOT NULL, personality TEXT, cv TEXT, terms_of_reference TEXT, llm_provider TEXT NOT NULL DEFAULT 'anthropic', llm_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514', skills TEXT DEFAULT '[]', status TEXT NOT NULL DEFAULT 'idle', avatar_emoji TEXT DEFAULT '🤖', agent_type TEXT NOT NULL DEFAULT 'standard', advisor_persona TEXT, memory_long_term TEXT, persona TEXT, expertise TEXT, advisor_ids TEXT, created_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, role TEXT NOT NULL, personality TEXT, cv TEXT, terms_of_reference TEXT, llm_provider TEXT NOT NULL DEFAULT 'anthropic', llm_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514', skills TEXT DEFAULT '[]', status TEXT NOT NULL DEFAULT 'idle', avatar_emoji TEXT DEFAULT '🤖', agent_type TEXT NOT NULL DEFAULT 'standard', advisor_persona TEXT, memory_long_term TEXT, persona TEXT, expertise TEXT, advisor_ids TEXT, runtime TEXT NOT NULL DEFAULT 'internal', external_endpoint TEXT, api_token_hash TEXT, last_heartbeat_at INTEGER, heartbeat_status TEXT DEFAULT 'unknown', contact_channel TEXT, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS messages (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, task_id TEXT, role TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, org_id TEXT NOT NULL, project_id TEXT, title TEXT NOT NULL, input TEXT, output TEXT, status TEXT NOT NULL DEFAULT 'pending', priority TEXT NOT NULL DEFAULT 'medium', kanban_column TEXT DEFAULT 'todo', llm_model TEXT, tokens_used INTEGER, cost_usd REAL, duration_ms INTEGER, assigned_to TEXT, due_at INTEGER, parent_task_id TEXT, created_at INTEGER NOT NULL, completed_at INTEGER)`,
     `CREATE TABLE IF NOT EXISTS skills (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, domain TEXT NOT NULL, content TEXT NOT NULL, source TEXT NOT NULL DEFAULT 'github', github_path TEXT, org_id TEXT, last_synced_at INTEGER, created_at INTEGER NOT NULL)`,
@@ -44,6 +44,14 @@ export async function setupDatabase() {
     // Telegram integration
     `ALTER TABLE org_members ADD COLUMN telegram_chat_id TEXT`,
     `ALTER TABLE organisations ADD COLUMN telegram_bot_token TEXT`,
+    // MCA-EXT: external / bring-your-own-runtime agents
+    `ALTER TABLE agents ADD COLUMN runtime TEXT NOT NULL DEFAULT 'internal'`,
+    `ALTER TABLE agents ADD COLUMN external_endpoint TEXT`,
+    `ALTER TABLE agents ADD COLUMN api_token_hash TEXT`,
+    `ALTER TABLE agents ADD COLUMN last_heartbeat_at INTEGER`,
+    `ALTER TABLE agents ADD COLUMN heartbeat_status TEXT DEFAULT 'unknown'`,
+    `ALTER TABLE agents ADD COLUMN contact_channel TEXT`,
+    `CREATE INDEX IF NOT EXISTS idx_agents_token ON agents(api_token_hash)`,
   ]
   for (const sql of alterStatements) {
     try { await dbClient.execute(sql) } catch { /* column already exists */ }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import { modelRoutes } from './routes/models'
 import { scheduledRoutes } from './routes/scheduled'
 import { webhookRoutes } from './routes/webhooks'
 import { telegramWebhookRoutes } from './routes/telegram-webhook'
+import { agentApiRoutes } from './routes/agent-api'
 import { ensureIndex } from './services/vector-search'
 import { auditLogPlugin } from './middleware/audit-log'
 import { clerkAuth } from './middleware/clerk-auth'
@@ -84,6 +85,9 @@ async function start() {
   await app.register(modelRoutes)
   await app.register(webhookRoutes)
   await app.register(telegramWebhookRoutes)
+  // Agent-facing API (MCA-EXT): external runtimes authenticate with an agent
+  // token via this plugin's own onRequest hook, not Clerk.
+  await app.register(agentApiRoutes)
   await app.register(authRoutes)
   await app.register(telemetryPlugin)
   await app.register(auditLogPlugin)

--- a/backend/src/middleware/agent-token.ts
+++ b/backend/src/middleware/agent-token.ts
@@ -1,0 +1,63 @@
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { createHash, randomBytes } from 'crypto'
+import { db, schema } from '../db/client'
+import { eq } from 'drizzle-orm'
+
+// ─── AGENT TOKEN AUTH (MCA-EXT) ────────────────────────────────────────────
+//
+// External / bring-your-own runtimes (OpenClaw, Cursor, custom) authenticate to
+// the agent-facing API with a long-lived agent token instead of a Clerk JWT.
+// The token is shown once at onboarding; only its sha256 hash is stored on the
+// agent row (agents.api_token_hash). This hook resolves the agent from the
+// Bearer token and attaches it to the request, or replies 401.
+
+const TOKEN_PREFIX = 'mca_'
+
+/** Generate a new agent token + its storable hash. Token is returned ONCE. */
+export function generateAgentToken(): { token: string; hash: string } {
+  const token = TOKEN_PREFIX + randomBytes(32).toString('hex')
+  return { token, hash: hashToken(token) }
+}
+
+/** Deterministic sha256 of a token, hex-encoded. */
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+/** Pull the bearer token out of the Authorization header, or null if absent. */
+export function extractBearerToken(req: FastifyRequest): string | null {
+  const header = req.headers.authorization
+  if (!header || typeof header !== 'string') return null
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim())
+  if (!match) return null
+  const token = match[1].trim()
+  return token.length > 0 ? token : null
+}
+
+export type AgentResolver = (hash: string) => Promise<typeof schema.agents.$inferSelect | null>
+
+const defaultResolver: AgentResolver = async (hash) =>
+  (await db.query.agents.findFirst({ where: eq(schema.agents.apiTokenHash, hash) })) ?? null
+
+/**
+ * Build the agent-token onRequest hook. The resolver is injectable so tests can
+ * exercise the hook without a live DB.
+ */
+export function createAgentAuth(resolve: AgentResolver = defaultResolver) {
+  return async function agentAuth(req: FastifyRequest, reply: FastifyReply) {
+    if (req.method === 'OPTIONS') return
+    const token = extractBearerToken(req)
+    if (!token) return reply.code(401).send({ error: 'Unauthorized' })
+    try {
+      const agent = await resolve(hashToken(token))
+      if (!agent) return reply.code(401).send({ error: 'Unauthorized' })
+      ;(req as any).agent = agent
+      ;(req as any).orgId = agent.orgId
+    } catch {
+      return reply.code(401).send({ error: 'Unauthorized' })
+    }
+  }
+}
+
+/** The production hook, using the real DB resolver. */
+export const agentAuth = createAgentAuth()

--- a/backend/src/routes/agent-api.ts
+++ b/backend/src/routes/agent-api.ts
@@ -1,0 +1,97 @@
+import { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { db, schema } from '../db/client'
+import { eq, and, inArray, desc } from 'drizzle-orm'
+import { randomUUID } from 'crypto'
+import { agentAuth } from '../middleware/agent-token'
+
+// ─── AGENT-FACING API (MCA-EXT) ────────────────────────────────────────────
+//
+// Called by external / self-hosted runtimes (OpenClaw, Cursor, custom) using
+// their agent token (Authorization: Bearer mca_...). Every route is scoped to
+// the single agent resolved from the token (req.agent). NOT Clerk-protected —
+// registered in the public scope with its own onRequest hook.
+
+const HeartbeatSchema = z.object({
+  status: z.enum(['green', 'amber', 'stale']).default('green'),
+  note: z.string().max(500).optional(),
+})
+
+const ResultSchema = z.object({
+  output: z.string(),
+  status: z.enum(['done', 'failed']).default('done'),
+})
+
+export async function agentApiRoutes(app: FastifyInstance) {
+  app.addHook('onRequest', agentAuth)
+
+  // Liveness/heartbeat — also returns who the runtime is authenticated as.
+  app.post('/api/agent/heartbeat', async (req) => {
+    const agent = (req as any).agent
+    const { status } = HeartbeatSchema.parse(req.body ?? {})
+    await db.update(schema.agents)
+      .set({ lastHeartbeatAt: new Date(), heartbeatStatus: status, status: 'idle' })
+      .where(eq(schema.agents.id, agent.id))
+    return { ok: true, agentId: agent.id, name: agent.name, runtime: agent.runtime }
+  })
+
+  // The agent's claimable / active queue. ?state=assigned (default) | in_progress | all
+  app.get('/api/agent/tasks', async (req) => {
+    const agent = (req as any).agent
+    const state = ((req.query as any)?.state ?? 'assigned') as string
+    const statusFilter: Record<string, string[]> = {
+      assigned: ['assigned'],
+      in_progress: ['in_progress'],
+      open: ['assigned', 'in_progress'],
+      all: ['assigned', 'in_progress', 'pending', 'blocked', 'done', 'failed'],
+    }
+    const states = statusFilter[state] ?? statusFilter.assigned
+    const tasks = await db.select().from(schema.tasks)
+      .where(and(eq(schema.tasks.agentId, agent.id), inArray(schema.tasks.status, states)))
+      .orderBy(desc(schema.tasks.createdAt)).limit(50)
+    return { tasks }
+  })
+
+  // Claim a task: assigned → in_progress (only this agent's tasks).
+  app.post('/api/agent/tasks/:taskId/claim', async (req, reply) => {
+    const agent = (req as any).agent
+    const { taskId } = req.params as any
+    const task = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+    if (!task || task.agentId !== agent.id) return reply.code(404).send({ error: 'Task not found' })
+    if (task.status === 'done') return reply.code(409).send({ error: 'Task already completed' })
+    await db.update(schema.tasks).set({ status: 'in_progress', kanbanColumn: 'in_progress' })
+      .where(eq(schema.tasks.id, taskId))
+    await db.update(schema.agents).set({ status: 'active' }).where(eq(schema.agents.id, agent.id))
+    return { ok: true, task: { ...task, status: 'in_progress' } }
+  })
+
+  // Post the result of a task: done | failed.
+  app.post('/api/agent/tasks/:taskId/result', async (req, reply) => {
+    const agent = (req as any).agent
+    const { taskId } = req.params as any
+    const { output, status } = ResultSchema.parse(req.body ?? {})
+    const task = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+    if (!task || task.agentId !== agent.id) return reply.code(404).send({ error: 'Task not found' })
+    await db.update(schema.tasks)
+      .set({ output, status, kanbanColumn: status === 'done' ? 'done' : 'blocked', completedAt: new Date() })
+      .where(eq(schema.tasks.id, taskId))
+    await db.insert(schema.messages).values({
+      id: randomUUID(), agentId: agent.id, taskId, role: 'assistant', content: output, createdAt: new Date(),
+    })
+    await db.update(schema.agents)
+      .set({ status: 'idle', lastHeartbeatAt: new Date(), heartbeatStatus: 'green' })
+      .where(eq(schema.agents.id, agent.id))
+    return { ok: true }
+  })
+
+  // Free-form progress / chatter message from the runtime.
+  app.post('/api/agent/messages', async (req) => {
+    const agent = (req as any).agent
+    const { taskId, content } = (req.body as any) ?? {}
+    await db.insert(schema.messages).values({
+      id: randomUUID(), agentId: agent.id, taskId: taskId ?? null, role: 'assistant',
+      content: String(content ?? ''), createdAt: new Date(),
+    })
+    return { ok: true }
+  })
+}

--- a/backend/src/routes/agent-api.ts
+++ b/backend/src/routes/agent-api.ts
@@ -25,6 +25,19 @@ const ResultSchema = z.object({
 export async function agentApiRoutes(app: FastifyInstance) {
   app.addHook('onRequest', agentAuth)
 
+  // Identity of the authenticated agent — lets a runtime build its system prompt.
+  app.get('/api/agent/me', async (req) => {
+    const a = (req as any).agent
+    return {
+      agent: {
+        id: a.id, orgId: a.orgId, name: a.name, role: a.role,
+        runtime: a.runtime, llmProvider: a.llmProvider, llmModel: a.llmModel,
+        termsOfReference: a.termsOfReference ?? null, persona: a.persona ?? null,
+        skills: a.skills ?? [],
+      },
+    }
+  })
+
   // Liveness/heartbeat — also returns who the runtime is authenticated as.
   app.post('/api/agent/heartbeat', async (req) => {
     const agent = (req as any).agent

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -8,6 +8,8 @@ import { executeAgentTask } from '../services/agent-executor'
 import { upsertDocument } from '../services/vector-search'
 import { streamLLM } from '../services/llm-router'
 import { buildAuthUrl, exchangeCode } from '../services/google-auth'
+import { generateAgentToken } from '../middleware/agent-token'
+import { isExternalAgent, heartbeatFreshness } from '../services/agent-runtime'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -335,6 +337,79 @@ export async function agentRoutes(app: FastifyInstance) {
       return { proposal: json }
     } catch {
       return reply.code(500).send({ error: 'LLM returned invalid JSON', raw: fullOutput })
+    }
+  })
+
+  // ─── EXTERNAL / BRING-YOUR-OWN RUNTIME AGENTS (MCA-EXT) ──────────────────
+  const ExternalAgentSchema = z.object({
+    name: z.string().min(1).max(100),
+    role: z.string().min(1).max(200),
+    runtime: z.enum(['openclaw', 'cursor', 'claude_code', 'custom']),
+    llmProvider: z.string().default('minimax'),
+    llmModel: z.string().default('minimax'),
+    termsOfReference: z.string().optional(),
+    avatarEmoji: z.string().default('🤖'),
+    externalEndpoint: z.string().url().optional(),
+    contactChannel: z.string().optional(),  // telegram chat id / email for pings
+  })
+
+  // Onboard an external agent. Returns the agent token ONCE — only its hash is stored.
+  app.post('/api/orgs/:orgId/agents/external', async (req, reply) => {
+    const { orgId } = req.params as any
+    const body = ExternalAgentSchema.parse(req.body)
+    const { token, hash } = generateAgentToken()
+    const agent = {
+      id: randomUUID(), orgId, departmentId: null, name: body.name, role: body.role,
+      personality: null, cv: null, termsOfReference: body.termsOfReference ?? null,
+      llmProvider: body.llmProvider, llmModel: body.llmModel, skills: [] as string[],
+      status: 'idle', avatarEmoji: body.avatarEmoji, agentType: 'external',
+      advisorPersona: null, memoryLongTerm: null, runtime: body.runtime,
+      externalEndpoint: body.externalEndpoint ?? null, apiTokenHash: hash,
+      heartbeatStatus: 'unknown', contactChannel: body.contactChannel ?? null,
+      createdAt: new Date(),
+    }
+    await db.insert(schema.agents).values(agent)
+    reply.code(201)
+    // Never echo the hash; the raw token is shown exactly once here.
+    return { agent: { ...agent, apiTokenHash: undefined }, agentToken: token }
+  })
+
+  // Rotate an external agent's token (revokes the previous one).
+  app.post('/api/agents/:agentId/rotate-token', async (req, reply) => {
+    const { agentId } = req.params as any
+    const agent = await db.query.agents.findFirst({ where: eq(schema.agents.id, agentId) })
+    if (!agent) return reply.code(404).send({ error: 'Agent not found' })
+    if (!isExternalAgent(agent)) return reply.code(400).send({ error: 'Not an external agent' })
+    const { token, hash } = generateAgentToken()
+    await db.update(schema.agents).set({ apiTokenHash: hash }).where(eq(schema.agents.id, agentId))
+    return { agentToken: token }
+  })
+
+  // Cockpit payload: roster (with heartbeat freshness) + tasks + summary.
+  // Shape matches the dashboard's STATE object (offline fallback ⇄ live mode).
+  app.get('/api/orgs/:orgId/cockpit', async (req) => {
+    const { orgId } = req.params as any
+    const now = Date.now()
+    const agents = await db.select().from(schema.agents).where(eq(schema.agents.orgId, orgId))
+    const tasks = await db.select().from(schema.tasks)
+      .where(eq(schema.tasks.orgId, orgId)).orderBy(desc(schema.tasks.createdAt)).limit(200)
+    const roster = agents.map(a => ({
+      id: a.id, name: a.name, role: a.role, runtime: a.runtime,
+      llmProvider: a.llmProvider, llmModel: a.llmModel, status: a.status,
+      agentType: a.agentType, avatarEmoji: a.avatarEmoji,
+      heartbeat: isExternalAgent(a) ? heartbeatFreshness(a.lastHeartbeatAt as any, now) : 'green',
+      lastHeartbeatAt: a.lastHeartbeatAt,
+    }))
+    const inCol = (c: string) => tasks.filter(t => (t.kanbanColumn ?? 'todo') === c).length
+    return {
+      orgId, generatedAt: new Date().toISOString(), agents: roster, tasks,
+      summary: {
+        agents: roster.length,
+        external: roster.filter(r => r.agentType === 'external').length,
+        tasks: tasks.length,
+        todo: inCol('todo'), in_progress: inCol('in_progress'),
+        blocked: inCol('blocked'), done: inCol('done'),
+      },
     }
   })
 }

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -9,6 +9,7 @@ import { parseAgentWebhooks, stripAgentWebhooks, executeAgentWebhooks } from './
 import { sendPushNotification } from '../routes/notifications'
 import { fireWebhook } from './outbound-webhooks'
 import { ensureFreshToken, searchDriveFiles } from './google-auth'
+import { isExternalAgent, notifyExternalAgent } from './agent-runtime'
 
 export interface ExecuteResult {
   output: string; tokensUsed: number; costUsd: number; durationMs: number
@@ -26,6 +27,22 @@ export async function executeAgentTask(opts: {
 
   const agent = await db.query.agents.findFirst({ where: eq(schema.agents.id, agentId) })
   if (!agent) throw new Error('Agent not found')
+
+  // MCA-EXT: external / bring-your-own runtimes are not driven by the LLM here.
+  // Assign the task and notify the runtime; it claims + posts results via the
+  // agent API. The internal executor path below is skipped entirely.
+  if (isExternalAgent(agent)) {
+    await db.update(schema.tasks)
+      .set({ status: 'assigned', assignedTo: agent.id })
+      .where(eq(schema.tasks.id, taskId))
+    await notifyExternalAgent(agent, { taskId, input })
+    const r: ExecuteResult = {
+      output: `Task assigned to external runtime "${agent.name}" (${agent.runtime}). Awaiting result.`,
+      tokensUsed: 0, costUsd: 0, durationMs: 0, provider: 'external',
+    }
+    onDone?.(r)
+    return r
+  }
 
   const budget = checkDailyBudget(agent.orgId, 2000)
   if (!budget.allowed) throw new Error(`Daily budget exceeded. Remaining: $${budget.remaining.cost.toFixed(4)}`)

--- a/backend/src/services/agent-runtime.ts
+++ b/backend/src/services/agent-runtime.ts
@@ -1,0 +1,48 @@
+import { schema } from '../db/client'
+import { fireWebhook } from './outbound-webhooks'
+
+// ─── EXTERNAL AGENT RUNTIME HELPERS (MCA-EXT) ──────────────────────────────
+
+type Agent = typeof schema.agents.$inferSelect
+
+/** True when the agent is a self-hosted / bring-your-own runtime, not the
+ *  internal LLM executor. Driven by agentType==='external' OR runtime!=='internal'. */
+export function isExternalAgent(agent: Pick<Agent, 'agentType' | 'runtime'>): boolean {
+  return agent.agentType === 'external' || (!!agent.runtime && agent.runtime !== 'internal')
+}
+
+export type Heartbeat = 'green' | 'amber' | 'stale' | 'unknown'
+
+const GREEN_MS = 2 * 60 * 1000    // < 2 min  → green
+const AMBER_MS = 10 * 60 * 1000   // < 10 min → amber, else stale
+
+/** Derive heartbeat freshness from the last heartbeat timestamp. */
+export function heartbeatFreshness(last: Date | number | null | undefined, now: number = Date.now()): Heartbeat {
+  if (last == null) return 'unknown'
+  const ts = last instanceof Date ? last.getTime() : Number(last)
+  if (!Number.isFinite(ts)) return 'unknown'
+  const age = now - ts
+  if (age < GREEN_MS) return 'green'
+  if (age < AMBER_MS) return 'amber'
+  return 'stale'
+}
+
+/** Notify an external runtime that a task is waiting. Best-effort, never throws:
+ *  fires an outbound webhook the runtime (or a relay) can listen on. Telegram
+ *  ping is handled separately by the comms layer when contactChannel is set. */
+export async function notifyExternalAgent(
+  agent: Pick<Agent, 'id' | 'orgId' | 'name' | 'runtime' | 'externalEndpoint'>,
+  task: { taskId: string; input: string },
+): Promise<void> {
+  try {
+    await fireWebhook('agent.task.assigned', agent.orgId, {
+      agentId: agent.id,
+      agentName: agent.name,
+      runtime: agent.runtime,
+      taskId: task.taskId,
+      inputPreview: task.input.slice(0, 200),
+    })
+  } catch (err) {
+    console.warn('notifyExternalAgent failed (non-critical):', err)
+  }
+}

--- a/backend/src/services/outbound-webhooks.ts
+++ b/backend/src/services/outbound-webhooks.ts
@@ -15,6 +15,7 @@ export type WebhookEvent =
   | 'message.created'
   | 'org.created'
   | 'delegation.complete'
+  | 'agent.task.assigned'
 
 export interface WebhookPayload {
   event: WebhookEvent

--- a/backend/src/tests/external-agents.test.ts
+++ b/backend/src/tests/external-agents.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { z } from 'zod'
+import { createHash } from 'crypto'
+import { generateAgentToken, hashToken, createAgentAuth } from '../middleware/agent-token.ts'
+import { isExternalAgent, heartbeatFreshness } from '../services/agent-runtime.ts'
+
+// Replicates ExternalAgentSchema from routes/all.ts for validation testing.
+const ExternalAgentSchema = z.object({
+  name: z.string().min(1).max(100),
+  role: z.string().min(1).max(200),
+  runtime: z.enum(['openclaw', 'cursor', 'claude_code', 'custom']),
+  llmProvider: z.string().default('minimax'),
+  llmModel: z.string().default('minimax'),
+  termsOfReference: z.string().optional(),
+  avatarEmoji: z.string().default('🤖'),
+  externalEndpoint: z.string().url().optional(),
+  contactChannel: z.string().optional(),
+})
+
+describe('[MCA-EXT] agent tokens', () => {
+  it('generateAgentToken returns mca_-prefixed token with matching hash', () => {
+    const { token, hash } = generateAgentToken()
+    assert.ok(token.startsWith('mca_'))
+    assert.equal(hash, createHash('sha256').update(token).digest('hex'))
+    assert.equal(hash, hashToken(token))
+  })
+
+  it('tokens are unique', () => {
+    const a = generateAgentToken(), b = generateAgentToken()
+    assert.notEqual(a.token, b.token)
+    assert.notEqual(a.hash, b.hash)
+  })
+
+  it('hashToken is deterministic', () => {
+    assert.equal(hashToken('mca_test'), hashToken('mca_test'))
+  })
+})
+
+describe('[MCA-EXT] isExternalAgent', () => {
+  it('true for agentType external', () => {
+    assert.equal(isExternalAgent({ agentType: 'external', runtime: 'internal' }), true)
+  })
+  it('true for non-internal runtime', () => {
+    assert.equal(isExternalAgent({ agentType: 'standard', runtime: 'openclaw' }), true)
+  })
+  it('false for internal standard agent', () => {
+    assert.equal(isExternalAgent({ agentType: 'standard', runtime: 'internal' }), false)
+  })
+})
+
+describe('[MCA-EXT] heartbeatFreshness', () => {
+  const now = 1_000_000_000_000
+  it('unknown when never seen', () => assert.equal(heartbeatFreshness(null, now), 'unknown'))
+  it('green within 2 min', () => assert.equal(heartbeatFreshness(now - 60_000, now), 'green'))
+  it('amber within 10 min', () => assert.equal(heartbeatFreshness(now - 5 * 60_000, now), 'amber'))
+  it('stale beyond 10 min', () => assert.equal(heartbeatFreshness(now - 30 * 60_000, now), 'stale'))
+  it('accepts Date input', () => assert.equal(heartbeatFreshness(new Date(now - 60_000), now), 'green'))
+})
+
+describe('[MCA-EXT] ExternalAgentSchema', () => {
+  it('accepts a valid openclaw agent and defaults provider to minimax', () => {
+    const p = ExternalAgentSchema.parse({ name: 'Arturito Open Claw', role: 'Ops', runtime: 'openclaw' })
+    assert.equal(p.runtime, 'openclaw')
+    assert.equal(p.llmProvider, 'minimax')
+  })
+  it('rejects an unknown runtime', () => {
+    assert.throws(() => ExternalAgentSchema.parse({ name: 'X', role: 'Y', runtime: 'k8s' }))
+  })
+})
+
+describe('[MCA-EXT] agentAuth hook', () => {
+  function fakeReply() {
+    const r: any = { _code: 200, _body: null }
+    r.code = (c: number) => { r._code = c; return r }
+    r.send = (b: any) => { r._body = b; return r }
+    return r
+  }
+  const agent = { id: 'a1', orgId: 'o1', name: 'Claw', runtime: 'openclaw' } as any
+
+  it('401 when no Authorization header', async () => {
+    const auth = createAgentAuth(async () => agent)
+    const reply = fakeReply()
+    await auth({ method: 'POST', headers: {} } as any, reply)
+    assert.equal(reply._code, 401)
+  })
+
+  it('401 when token resolves to no agent', async () => {
+    const auth = createAgentAuth(async () => null)
+    const reply = fakeReply()
+    await auth({ method: 'POST', headers: { authorization: 'Bearer mca_bad' } } as any, reply)
+    assert.equal(reply._code, 401)
+  })
+
+  it('attaches req.agent on a valid token', async () => {
+    const auth = createAgentAuth(async () => agent)
+    const reply = fakeReply()
+    const req: any = { method: 'POST', headers: { authorization: 'Bearer mca_good' } }
+    await auth(req, reply)
+    assert.equal(reply._code, 200)
+    assert.equal(req.agent.id, 'a1')
+    assert.equal(req.orgId, 'o1')
+  })
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -1,0 +1,248 @@
+'use client'
+import { useCallback, useEffect, useState } from 'react'
+
+// Mission Control cockpit (MCA-EXT Phase 3): live roster + task board + health,
+// plus onboarding for external / bring-your-own runtimes (OpenClaw, Cursor, …).
+// Reads GET /api/orgs/:id/cockpit and POSTs /api/orgs/:id/agents/external.
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'
+
+type Getter = () => Promise<string | null>
+async function call<T>(path: string, token: string | null, opts?: RequestInit): Promise<T> {
+  const res = await fetch(`${API}${path}`, {
+    ...opts,
+    headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}), 'Content-Type': 'application/json', ...(opts?.headers ?? {}) },
+  })
+  if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error ?? 'Request failed')
+  return res.json()
+}
+
+type CAgent = {
+  id: string; name: string; role: string; runtime: string; llmProvider: string; llmModel: string
+  status: string; agentType: string; avatarEmoji: string; heartbeat: string; lastHeartbeatAt: number | null
+}
+type CTask = { id: string; title: string; status: string; kanbanColumn: string; priority: string; agentId: string }
+type Cockpit = { agents: CAgent[]; tasks: CTask[]; summary: Record<string, number>; generatedAt: string }
+
+const HB: Record<string, string> = { green: '#22c55e', amber: '#f59e0b', stale: '#ef4444', unknown: '#555' }
+const STATUS_C: Record<string, string> = { idle: '#888', active: '#22c55e', external: '#a96bff' }
+const RUNTIME_BADGE: Record<string, string> = { internal: '🧠', openclaw: '📎', cursor: '⌨️', claude_code: '🤖', custom: '⚙️' }
+const PRI_C: Record<string, string> = { high: '#ef4444', medium: '#f59e0b', low: '#555' }
+const COLS: { key: string; label: string }[] = [
+  { key: 'todo', label: 'To do' }, { key: 'in_progress', label: 'In progress' },
+  { key: 'blocked', label: 'Blocked' }, { key: 'done', label: 'Done' },
+]
+
+export default function CockpitPanel({ orgId, getToken }: { orgId: string; getToken: Getter }) {
+  const [data, setData] = useState<Cockpit | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+  const [wizard, setWizard] = useState(false)
+
+  const load = useCallback(async () => {
+    try { setData(await call<Cockpit>(`/api/orgs/${orgId}/cockpit`, await getToken())); setErr(null) }
+    catch (e: any) { setErr(e?.message ?? 'Failed to load') }
+  }, [orgId, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  const agentName = (id: string) => data?.agents.find(a => a.id === id)?.name ?? '—'
+  const sum = data?.summary ?? {}
+
+  return (
+    <div style={s.page}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h1 style={s.h1}>Mission Control</h1>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button onClick={load} style={s.ghostBtn}>↻ Refresh</button>
+          <button onClick={() => setWizard(true)} style={s.primaryBtn}>＋ Add agent</button>
+        </div>
+      </div>
+
+      {err && <div style={s.errBox}>⚠ {err}</div>}
+
+      <div style={s.grid4}>
+        {[
+          { l: 'Agents', v: sum.agents ?? 0, c: '#fff' },
+          { l: 'External', v: sum.external ?? 0, c: '#a96bff' },
+          { l: 'In progress', v: sum.in_progress ?? 0, c: '#3b82f6' },
+          { l: 'Done', v: sum.done ?? 0, c: '#22c55e' },
+        ].map(k => <div key={k.l} style={s.statCard}><span style={{ ...s.statVal, color: k.c }}>{k.v}</span><span style={s.statLabel}>{k.l}</span></div>)}
+      </div>
+
+      <h2 style={s.h2}>Agent fleet</h2>
+      <div style={s.agentGrid}>
+        {(data?.agents ?? []).map(a => (
+          <div key={a.id} style={s.agentCard}>
+            <span style={{ fontSize: 26 }}>{a.avatarEmoji || '🤖'}</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 700, fontSize: 14, display: 'flex', alignItems: 'center', gap: 6 }}>
+                {a.name}
+                <span title={a.runtime} style={s.badge}>{RUNTIME_BADGE[a.runtime] ?? '⚙️'} {a.runtime}</span>
+              </div>
+              <div style={{ fontSize: 12, color: '#888', marginTop: 2 }}>{a.role}</div>
+              <div style={{ fontSize: 11, color: '#555', marginTop: 4 }}>{a.llmProvider} · {a.llmModel}</div>
+            </div>
+            <span title={`heartbeat: ${a.heartbeat}`} style={{ width: 10, height: 10, borderRadius: 5, background: HB[a.heartbeat] ?? '#555', flexShrink: 0 }} />
+          </div>
+        ))}
+        {data && data.agents.length === 0 && <p style={{ color: '#888' }}>No agents yet — add one.</p>}
+      </div>
+
+      <h2 style={s.h2}>Task board</h2>
+      <div style={s.board}>
+        {COLS.map(col => {
+          const items = (data?.tasks ?? []).filter(t => (t.kanbanColumn ?? 'todo') === col.key)
+          return (
+            <div key={col.key} style={s.col}>
+              <div style={s.colHead}>{col.label}<span style={s.colCount}>{items.length}</span></div>
+              {items.map(t => (
+                <div key={t.id} style={{ ...s.task, borderLeftColor: PRI_C[t.priority] ?? '#555' }}>
+                  <div style={{ fontSize: 12.5 }}>{t.title}</div>
+                  <div style={{ fontSize: 10.5, color: '#888', marginTop: 6 }}>{agentName(t.agentId)}</div>
+                </div>
+              ))}
+              {items.length === 0 && <div style={{ color: '#444', fontSize: 12, padding: 4 }}>—</div>}
+            </div>
+          )
+        })}
+      </div>
+
+      {wizard && <AddAgentWizard orgId={orgId} getToken={getToken} onClose={() => setWizard(false)} onDone={() => { setWizard(false); load() }} />}
+    </div>
+  )
+}
+
+// ─── Add-agent wizard (external runtime onboarding) ──────────────────────────
+
+const RUNTIMES = [
+  { id: 'openclaw', label: 'OpenClaw', emoji: '📎', defModel: 'MiniMax-Text-01', defProvider: 'minimax' },
+  { id: 'cursor', label: 'Cursor', emoji: '⌨️', defModel: 'claude-sonnet-4-20250514', defProvider: 'anthropic' },
+  { id: 'claude_code', label: 'Claude Code', emoji: '🤖', defModel: 'claude-sonnet-4-20250514', defProvider: 'anthropic' },
+  { id: 'custom', label: 'Custom', emoji: '⚙️', defModel: 'minimax', defProvider: 'custom' },
+]
+
+function AddAgentWizard({ orgId, getToken, onClose, onDone }: { orgId: string; getToken: Getter; onClose: () => void; onDone: () => void }) {
+  const [step, setStep] = useState(0)
+  const [f, setF] = useState({ name: 'Arturito · Open Claw', role: 'Ops', runtime: 'openclaw', llmProvider: 'minimax', llmModel: 'MiniMax-Text-01', termsOfReference: '', avatarEmoji: '📎' })
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const pickRuntime = (r: typeof RUNTIMES[number]) =>
+    setF({ ...f, runtime: r.id, llmProvider: r.defProvider, llmModel: r.defModel, avatarEmoji: r.emoji })
+
+  const submit = async () => {
+    setBusy(true); setErr(null)
+    try {
+      const res = await call<{ agentToken: string }>(`/api/orgs/${orgId}/agents/external`, await getToken(),
+        { method: 'POST', body: JSON.stringify(f) })
+      setToken(res.agentToken)
+    } catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setBusy(false)
+  }
+
+  const envSnippet = token ? `MC_BASE_URL=${API}\nMC_AGENT_TOKEN=${token}\nMC_EXECUTOR=auto\nMC_ALLOW_SHELL=1\nMC_WORKDIR=/Users/artutito/7Ei-MC_TARCO` : ''
+
+  return (
+    <div style={s.modalWrap} onClick={onClose}>
+      <div style={s.modal} onClick={e => e.stopPropagation()}>
+        {token ? (
+          <>
+            <h2 style={s.h2}>✓ {f.name} onboarded</h2>
+            <p style={{ color: '#888', fontSize: 13, margin: '6px 0 0' }}>Copy this agent token now — it is shown only once. Paste it into the runtime's <code style={s.code}>mc.env</code>.</p>
+            <div style={s.tokenBox}>{token}</div>
+            <button style={s.ghostBtn} onClick={() => { navigator.clipboard?.writeText(envSnippet); setCopied(true); setTimeout(() => setCopied(false), 1500) }}>
+              {copied ? '✓ Copied env' : '📋 Copy mc.env block'}
+            </button>
+            <pre style={s.pre}>{envSnippet}</pre>
+            <button style={{ ...s.primaryBtn, marginTop: 8 }} onClick={onDone}>Done</button>
+          </>
+        ) : (
+          <>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <h2 style={s.h2}>Add an agent</h2>
+              <button onClick={onClose} style={s.x}>✕</button>
+            </div>
+            <div style={s.stepRow}>{['Identity', 'Runtime', 'Model', 'Review'].map((label, i) => (
+              <span key={label} style={{ ...s.stepChip, ...(i === step ? s.stepOn : {}) }}>{i + 1}. {label}</span>
+            ))}</div>
+
+            {step === 0 && (
+              <div style={s.form}>
+                <label style={s.lab}>Name<input style={s.inp} value={f.name} onChange={e => setF({ ...f, name: e.target.value })} /></label>
+                <label style={s.lab}>Role<input style={s.inp} value={f.role} onChange={e => setF({ ...f, role: e.target.value })} /></label>
+                <label style={s.lab}>Terms of reference (optional)<textarea style={{ ...s.inp, minHeight: 60 }} value={f.termsOfReference} onChange={e => setF({ ...f, termsOfReference: e.target.value })} /></label>
+              </div>
+            )}
+            {step === 1 && (
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 12 }}>
+                {RUNTIMES.map(r => (
+                  <button key={r.id} onClick={() => pickRuntime(r)} style={{ ...s.opt, ...(f.runtime === r.id ? s.optOn : {}) }}>{r.emoji} {r.label}</button>
+                ))}
+              </div>
+            )}
+            {step === 2 && (
+              <div style={s.form}>
+                <label style={s.lab}>LLM provider<input style={s.inp} value={f.llmProvider} onChange={e => setF({ ...f, llmProvider: e.target.value })} /></label>
+                <label style={s.lab}>Model<input style={s.inp} value={f.llmModel} onChange={e => setF({ ...f, llmModel: e.target.value })} /></label>
+                <p style={{ fontSize: 11.5, color: '#555', margin: 0 }}>External runtimes run their own brain; this is metadata + the model the adapter calls.</p>
+              </div>
+            )}
+            {step === 3 && (
+              <div style={{ ...s.form, fontSize: 13, color: '#aaa' }}>
+                <div>Name: <b style={{ color: '#fff' }}>{f.name}</b></div>
+                <div>Role: <b style={{ color: '#fff' }}>{f.role}</b></div>
+                <div>Runtime: <b style={{ color: '#fff' }}>{RUNTIME_BADGE[f.runtime]} {f.runtime}</b></div>
+                <div>Model: <b style={{ color: '#fff' }}>{f.llmProvider} · {f.llmModel}</b></div>
+                <p style={{ fontSize: 11.5, color: '#555', margin: '6px 0 0' }}>On create you'll get a one-time agent token for the adapter.</p>
+              </div>
+            )}
+            {err && <div style={s.errBox}>⚠ {err}</div>}
+
+            <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
+              {step > 0 && <button style={s.ghostBtn} onClick={() => setStep(step - 1)}>← Back</button>}
+              {step < 3
+                ? <button style={s.primaryBtn} onClick={() => setStep(step + 1)}>Next →</button>
+                : <button style={{ ...s.primaryBtn, opacity: busy ? 0.6 : 1 }} disabled={busy} onClick={submit}>{busy ? 'Creating…' : 'Create agent'}</button>}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const s: Record<string, React.CSSProperties> = {
+  page: { padding: 28, maxWidth: 1200, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 18 },
+  h1: { fontSize: 28, fontWeight: 800, margin: 0, letterSpacing: -0.5 },
+  h2: { fontSize: 18, fontWeight: 700, margin: 0 },
+  grid4: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 12 },
+  statCard: { background: '#111', border: '1px solid #222', borderRadius: 10, padding: 16, display: 'flex', flexDirection: 'column', gap: 4 },
+  statVal: { fontSize: 28, fontWeight: 800, lineHeight: 1 }, statLabel: { fontSize: 12, color: '#888' },
+  agentGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 12 },
+  agentCard: { background: '#111', border: '1px solid #222', borderRadius: 10, padding: 16, display: 'flex', alignItems: 'center', gap: 12 },
+  badge: { fontSize: 10, color: '#aaa', background: '#1a1a1a', border: '1px solid #333', borderRadius: 6, padding: '1px 6px', fontWeight: 600 },
+  board: { display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 },
+  col: { background: '#0d0d0d', border: '1px solid #222', borderRadius: 10, padding: 10, minHeight: 80 },
+  colHead: { display: 'flex', justifyContent: 'space-between', fontSize: 12, textTransform: 'uppercase', letterSpacing: 0.5, color: '#888', fontWeight: 700, marginBottom: 8 },
+  colCount: { background: '#1a1a1a', border: '1px solid #333', borderRadius: 10, padding: '0 7px', fontSize: 11 },
+  task: { background: '#111', border: '1px solid #222', borderLeft: '3px solid #555', borderRadius: 8, padding: '8px 10px', marginBottom: 8 },
+  primaryBtn: { background: '#FFB800', color: '#000', border: 'none', borderRadius: 9, padding: '9px 16px', fontSize: 14, fontWeight: 700, cursor: 'pointer' },
+  ghostBtn: { background: '#1a1a1a', border: '1px solid #333', color: '#FFB800', padding: '9px 14px', borderRadius: 9, cursor: 'pointer', fontSize: 13, fontWeight: 600 },
+  errBox: { background: '#2a1414', border: '1px solid #5a2a2a', color: '#ff8080', borderRadius: 8, padding: '10px 12px', fontSize: 13 },
+  modalWrap: { position: 'fixed', inset: 0, background: 'rgba(0,0,0,.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50, padding: 20 },
+  modal: { background: '#111', border: '1px solid #2a2a2a', borderRadius: 16, padding: 24, width: '100%', maxWidth: 480, display: 'flex', flexDirection: 'column', gap: 8 },
+  x: { background: 'transparent', border: 'none', color: '#888', fontSize: 16, cursor: 'pointer' },
+  stepRow: { display: 'flex', flexWrap: 'wrap', gap: 6, margin: '12px 0 4px' },
+  stepChip: { fontSize: 11, color: '#888', background: '#1a1a1a', border: '1px solid #2a2a2a', borderRadius: 999, padding: '3px 9px' },
+  stepOn: { color: '#000', background: '#FFB800', borderColor: '#FFB800', fontWeight: 700 },
+  form: { display: 'flex', flexDirection: 'column', gap: 12, marginTop: 12 },
+  lab: { display: 'flex', flexDirection: 'column', gap: 5, fontSize: 12, fontWeight: 600, color: '#aaa' },
+  inp: { background: '#0a0a0a', border: '1px solid #333', borderRadius: 8, padding: '9px 11px', color: '#fff', fontSize: 13, fontFamily: 'inherit', outline: 'none', width: '100%', boxSizing: 'border-box' },
+  opt: { fontSize: 13, border: '1px solid #333', background: '#0a0a0a', color: '#aaa', borderRadius: 8, padding: '9px 13px', cursor: 'pointer' },
+  optOn: { borderColor: '#FFB800', background: '#211c08', color: '#fff' },
+  tokenBox: { background: '#0a0a0a', border: '1px solid #333', borderRadius: 8, padding: 10, fontFamily: 'monospace', fontSize: 12, color: '#FFB800', wordBreak: 'break-all', margin: '10px 0' },
+  pre: { background: '#000', border: '1px solid #222', borderRadius: 8, padding: 12, fontSize: 11.5, color: '#cdd3de', whiteSpace: 'pre-wrap', margin: '8px 0 0' },
+  code: { background: '#000', border: '1px solid #222', borderRadius: 4, padding: '1px 5px', fontSize: 11, color: '#FFB800' },
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import CockpitPanel from './CockpitPanel'
 let useAuth: () => { getToken: () => Promise<string | null>; isLoaded: boolean; isSignedIn: boolean }
 try {
   useAuth = require('@clerk/nextjs').useAuth
@@ -32,7 +33,7 @@ const STATUS_C: Record<string, string> = { idle: '#555', active: '#22c55e', paus
 const JIRA_STATUS_C: Record<string, string> = { 'To Do': '#555', 'In Progress': '#3b82f6', 'Done': '#22c55e', 'Blocked': '#ef4444', 'In Review': '#f59e0b' }
 const PROVIDER_LABELS: Record<string, string> = { anthropic: 'Anthropic', openai: 'OpenAI', google: 'Google', deepseek: 'DeepSeek', moonshot: 'Kimi / Moonshot', qwen: 'Qwen', minimax: 'MiniMax', ollama: 'Ollama (local)' }
 
-type Tab = 'overview' | 'agents' | 'tasks' | 'projects' | 'skills' | 'costs' | 'comms' | 'jira' | 'usage' | 'settings'
+type Tab = 'overview' | 'cockpit' | 'agents' | 'tasks' | 'projects' | 'skills' | 'costs' | 'comms' | 'jira' | 'usage' | 'settings'
 
 export default function DashboardPage() {
   const { getToken, isLoaded, isSignedIn } = useAuth()
@@ -279,6 +280,7 @@ export default function DashboardPage() {
 
   const NAV: { id: Tab; icon: string; label: string }[] = [
     { id: 'overview', icon: '🏠', label: 'Overview' },
+    { id: 'cockpit', icon: '🛰️', label: 'Cockpit' },
     { id: 'agents', icon: '🤖', label: 'Agents' },
     { id: 'tasks', icon: '📋', label: 'Tasks' },
     { id: 'projects', icon: '📁', label: 'Projects' },
@@ -306,6 +308,8 @@ export default function DashboardPage() {
       </aside>
 
       <main style={s.main}>
+
+        {tab === 'cockpit' && <CockpitPanel orgId={org.id} getToken={getToken} />}
 
         {tab === 'overview' && (
           <div style={s.page}>

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What
Phase 1 of the paperclip-like control plane: the app can now onboard and coordinate **external, self-hosted runtimes** (OpenClaw/MiniMax first, then Cursor/custom) — not just internal LLM-executor agents.

## Changes
- Schema/migration (idempotent): agents += runtime, external_endpoint, api_token_hash, last_heartbeat_at, heartbeat_status, contact_channel; new agentType external.
- Agent token auth (middleware/agent-token.ts): one-time mca_ token, sha256 hash stored, injectable agentAuth hook.
- Runtime helpers (services/agent-runtime.ts): isExternalAgent, heartbeatFreshness, notifyExternalAgent.
- Executor branch: external agents set assigned + notified; LLM path skipped. Delegation inherits this.
- Agent-facing API (routes/agent-api.ts): heartbeat, tasks?state, claim, result, messages.
- Control plane (routes/all.ts): POST /agents/external (token once), rotate-token, GET /cockpit.

## Tests
16 new; 303/303 pass; tsc --noEmit clean.

## Next (Phase 2)
OpenClaw poll-loop adapter + Telegram ping, then cockpit UI.