### PR TITLE
Cursor runtime adapter + smoke (MCA-EXT Phase 4)

### DIFF
--- a/adapters/cursor/README.md
+++ b/adapters/cursor/README.md
@@ -1,0 +1,32 @@
+# Cursor runtime adapter (MCA-EXT, Phase 4)
+
+Bridges Mission Control's task queue to a filesystem **inbox** that Cursor works in.
+Unlike the OpenClaw adapter (which executes autonomously), Cursor is human-in-the-IDE,
+so this adapter hands work orders in and watches for results.
+
+```
+MC assigns task ─▶ cursor_adapter.py ─claim─▶ coordination/inbox/TASK-<id>.md
+                                                      │ Cursor (agent/human) does the work
+                                                      ▼ writes TASK-<id>.result.md
+MC task = done ◀─ POST /result ◀── cursor_adapter.py detects result ── archives to inbox/done/
+```
+
+## Onboard
+Create the agent with `runtime: "cursor"` (cockpit → Add agent → Cursor, or
+`POST /api/orgs/:id/agents/external`). Copy the one-time token.
+
+## Install & run (in the Cursor repo)
+```bash
+export MC_BASE_URL=https://7ei-backend.fly.dev
+export MC_AGENT_TOKEN=mca_...        # from onboarding
+export MC_INBOX="$PWD/coordination/inbox"
+python3 path/to/cursor_adapter.py --once   # one pass
+python3 path/to/cursor_adapter.py          # poll loop
+```
+Drop `cursor-rules-7ei-mc.md` into the repo's `.cursor/rules/7ei-mc.md` so Cursor's agent
+knows to watch `coordination/inbox/` and write `TASK-<id>.result.md` when done.
+
+## Verify
+`backend/scripts/smoke-cursor.ts` (`npm run smoke:cursor`) seeds an assigned task, runs the
+adapter (pass 1 → work order), simulates Cursor writing a result, runs the adapter again
+(pass 2 → posts done), and asserts the task reaches **done** with the result text.

--- a/adapters/cursor/cursor-rules-7ei-mc.md
+++ b/adapters/cursor/cursor-rules-7ei-mc.md
@@ -1,0 +1,15 @@
+# 7Ei Mission Control — Cursor agent rule
+# Copy this file into your repo's `.cursor/rules/7ei-mc.md` so Cursor's agent
+# picks up Mission Control work orders.
+
+You are a 7Ei Mission Control agent operating inside Cursor.
+
+- Mission Control assigns you tasks as Markdown **work orders** in `coordination/inbox/TASK-*.md`.
+- At the start of a session, check `coordination/inbox/` for any `TASK-*.md` that has no
+  matching `TASK-*.result.md`. Those are your open work orders.
+- Do the work described in the work order, in this repo, following 7Ei_OS protocols.
+- When finished, write a short result (what you did + any output) to
+  `coordination/inbox/TASK-<id>.result.md`.
+- The MC adapter watches the inbox: it reports the task **done** to the app and archives
+  the order to `coordination/inbox/done/`. Do not edit files under `done/`.
+- One owner per task; commit your code changes on the `cursor/` branch prefix.

--- a/adapters/cursor/cursor_adapter.py
+++ b/adapters/cursor/cursor_adapter.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+7Ei Mission Control — Cursor runtime adapter (MCA-EXT, Phase 4).
+
+Cursor is a human-in-the-IDE runtime, so this adapter does NOT execute tasks
+itself. It bridges the app's task queue to a filesystem **inbox** that Cursor
+(its agent or the human) works in:
+
+  1. assigned task → claim → write a Markdown work order to MC_INBOX/TASK-<id>.md
+  2. Cursor does the work in the repo, then writes MC_INBOX/TASK-<id>.result.md
+  3. next poll → adapter detects the result → POST /result done → archive both
+
+Stdlib only. Pair with the `.cursor/rules` snippet in this folder so Cursor's
+agent knows to watch the inbox.
+
+  MC_BASE_URL     app backend
+  MC_AGENT_TOKEN  mca_...  (external agent, runtime=cursor)
+  MC_INBOX        work-order dir (default: ./coordination/inbox)
+  MC_POLL_SECONDS loop interval (default: 20)
+"""
+import json, os, re, sys, time, glob, shutil, urllib.request, urllib.error
+
+BASE  = os.environ.get("MC_BASE_URL", "http://localhost:3001").rstrip("/")
+TOKEN = os.environ.get("MC_AGENT_TOKEN", "")
+INBOX = os.environ.get("MC_INBOX", os.path.join(os.getcwd(), "coordination", "inbox"))
+POLL  = int(os.environ.get("MC_POLL_SECONDS", "20"))
+DONE_DIR = os.path.join(INBOX, "done")
+
+
+def _req(method, path, body=None):
+    req = urllib.request.Request(BASE + path,
+                                 data=json.dumps(body).encode() if body is not None else None,
+                                 method=method)
+    req.add_header("Authorization", "Bearer " + TOKEN)
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            raw = r.read().decode()
+            return r.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as e:
+        return e.code, {"error": e.read().decode()[:300]}
+    except Exception as e:
+        return 0, {"error": str(e)}
+
+
+def heartbeat(status="green"):
+    return _req("POST", "/api/agent/heartbeat", {"status": status})
+
+
+def work_order(task):
+    tid = task["id"]
+    return (f"# MC Work Order — {tid}\n\n"
+            f"- task: {task.get('title','')}\n"
+            f"- status: in_progress\n"
+            f"- priority: {task.get('priority','medium')}\n\n"
+            f"## Input\n\n{task.get('input') or task.get('title') or ''}\n\n"
+            f"## How to complete\n\n"
+            f"Do the work in this repo. When finished, write your result (a short summary "
+            f"of what you did + any output) to:\n\n"
+            f"    {os.path.join(INBOX, 'TASK-' + tid + '.result.md')}\n\n"
+            f"The MC adapter will detect it on its next poll and report the task done.\n")
+
+
+def emit_orders():
+    """Claim newly-assigned tasks and drop a work order for each."""
+    code, data = _req("GET", "/api/agent/tasks?state=assigned")
+    if code != 200:
+        print(f"poll failed ({code}): {data.get('error','')}"); return
+    for t in data.get("tasks", []):
+        tid = t["id"]
+        path = os.path.join(INBOX, f"TASK-{tid}.md")
+        if os.path.exists(path):
+            continue
+        c, _ = _req("POST", f"/api/agent/tasks/{tid}/claim")
+        if c not in (200, 201):
+            print(f"  claim {tid} failed ({c})"); continue
+        os.makedirs(INBOX, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(work_order(t))
+        print(f"  ⮕ work order written: TASK-{tid}.md  ({t.get('title','')[:40]})")
+
+
+_RES_RE = re.compile(r"TASK-(.+)\.result\.md$")
+
+
+def collect_results():
+    """Detect result files Cursor wrote and report them done."""
+    n = 0
+    for rp in glob.glob(os.path.join(INBOX, "TASK-*.result.md")):
+        m = _RES_RE.search(os.path.basename(rp))
+        if not m:
+            continue
+        tid = m.group(1)
+        output = open(rp, encoding="utf-8").read().strip() or "(done by Cursor)"
+        c, _ = _req("POST", f"/api/agent/tasks/{tid}/result", {"output": output[:8000], "status": "done"})
+        print(f"  ✓ result posted for {tid} ({c})")
+        if c in (200, 201):
+            os.makedirs(DONE_DIR, exist_ok=True)
+            for suffix in (".md", ".result.md"):
+                src = os.path.join(INBOX, f"TASK-{tid}{suffix}")
+                if os.path.exists(src):
+                    shutil.move(src, os.path.join(DONE_DIR, f"TASK-{tid}{suffix}"))
+            n += 1
+    return n
+
+
+def poll_once():
+    emit_orders()
+    collect_results()
+    heartbeat("green")
+
+
+def main():
+    if not TOKEN:
+        print("MC_AGENT_TOKEN is required", file=sys.stderr); sys.exit(2)
+    print(f"7Ei MC cursor adapter → {BASE}  (inbox={INBOX})")
+    os.makedirs(INBOX, exist_ok=True)
+    heartbeat("green")
+    if "--once" in sys.argv:
+        poll_once(); return
+    while True:
+        try:
+            poll_once()
+        except KeyboardInterrupt:
+            print("bye"); return
+        except Exception as e:
+            print("loop error:", e, file=sys.stderr); heartbeat("amber")
+        time.sleep(POLL)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "test:watch": "node --test --watch --import=tsx src/tests/*.test.ts",
     "smoke:openclaw": "node --import=tsx scripts/smoke-openclaw.ts",
     "smoke:openclaw:llm": "node --import=tsx scripts/smoke-openclaw-llm.ts",
+    "smoke:cursor": "node --import=tsx scripts/smoke-cursor.ts",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
     "db:push": "drizzle-kit push",

--- a/backend/scripts/smoke-cursor.ts
+++ b/backend/scripts/smoke-cursor.ts
@@ -1,0 +1,91 @@
+/**
+ * Phase 4 smoke — the Cursor file/rules-based adapter.
+ *
+ * Boots the agent API on a real port, seeds an external agent (runtime=cursor)
+ * with an assigned task, then drives the real cursor_adapter.py twice:
+ *   pass 1 → claims + writes a work order to the inbox (task → in_progress)
+ *   (test simulates Cursor writing TASK-<id>.result.md)
+ *   pass 2 → detects the result and posts /result (task → done)
+ * Asserts the task reaches done with the result text and the order is archived.
+ *
+ *   npm run smoke:cursor
+ */
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+
+const work = mkdtempSync(join(tmpdir(), 'mc-smoke-cursor-'))
+const inbox = join(work, 'coordination', 'inbox')
+process.env.DATABASE_URL = `file:${join(work, 'smoke.db')}`
+
+const fail = (m: string) => { console.error('✗ SMOKE FAIL:', m); cleanup(); process.exit(1) }
+function cleanup() { try { rmSync(work, { recursive: true, force: true }) } catch {} }
+
+const main = async () => {
+  const Fastify = (await import('fastify')).default
+  const { setupDatabase } = await import('../src/db/setup.ts')
+  const { db, schema } = await import('../src/db/client.ts')
+  const { agentApiRoutes } = await import('../src/routes/agent-api.ts')
+  const { generateAgentToken, hashToken } = await import('../src/middleware/agent-token.ts')
+  const { eq } = await import('drizzle-orm')
+
+  await setupDatabase()
+  const orgId = randomUUID(), agentId = randomUUID(), taskId = randomUUID()
+  const { token } = generateAgentToken()
+  await db.insert(schema.organisations).values({ id: orgId, name: 'SmokeCo', ownerId: 'u1', createdAt: new Date() })
+  await db.insert(schema.agents).values({
+    id: agentId, orgId, name: 'Arturito · Cursor', role: 'Eng',
+    llmProvider: 'anthropic', llmModel: 'claude-sonnet-4-20250514', agentType: 'external',
+    runtime: 'cursor', apiTokenHash: hashToken(token), status: 'idle', createdAt: new Date(),
+  } as any)
+  await db.insert(schema.tasks).values({
+    id: taskId, orgId, agentId, assignedTo: agentId, title: 'add a helper',
+    input: 'Add a formatDate() helper and a test.', status: 'assigned',
+    priority: 'medium', kanbanColumn: 'in_progress', createdAt: new Date(),
+  } as any)
+
+  const app = Fastify({ logger: false })
+  await app.register(agentApiRoutes)
+  await app.listen({ port: 0, host: '127.0.0.1' })
+  const base = `http://127.0.0.1:${(app.server.address() as any).port}`
+  const adapter = join(import.meta.dirname, '..', '..', 'adapters', 'cursor', 'cursor_adapter.py')
+  const env = { ...process.env, MC_BASE_URL: base, MC_AGENT_TOKEN: token, MC_INBOX: inbox }
+  const runAdapter = () => new Promise<void>((resolve) => {
+    const c = spawn('python3', [adapter, '--once'], { env })
+    c.stdout.on('data', d => process.stdout.write(d))
+    c.stderr.on('data', d => process.stderr.write(d))
+    c.on('close', () => resolve())
+  })
+
+  // pass 1 → work order
+  await runAdapter()
+  const orderPath = join(inbox, `TASK-${taskId}.md`)
+  if (!existsSync(orderPath)) { await app.close(); fail('pass 1 did not write a work order') }
+  let t1 = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+  if (t1?.status !== 'in_progress') { await app.close(); fail(`after pass 1 status=${t1?.status} (expected in_progress)`) }
+
+  // simulate Cursor completing the work
+  const marker = `cursor-${taskId.slice(0, 8)}`
+  writeFileSync(join(inbox, `TASK-${taskId}.result.md`), `Added formatDate() + test. ${marker}`)
+
+  // pass 2 → detect result, post done
+  await runAdapter()
+  const task = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+  const agent = await db.query.agents.findFirst({ where: eq(schema.agents.id, agentId) })
+  await app.close()
+
+  if (task?.status !== 'done') fail(`task status = ${task?.status} (expected done)`)
+  if (!task!.output?.includes(marker)) fail(`task output missing result marker: ${task!.output}`)
+  if (existsSync(orderPath)) fail('work order was not archived after completion')
+  const archived = existsSync(join(inbox, 'done')) ? readdirSync(join(inbox, 'done')) : []
+  if (!archived.some(f => f.includes(taskId))) fail('order/result not moved to inbox/done/')
+  if (!agent?.lastHeartbeatAt) fail('agent heartbeat not recorded')
+
+  console.log(`✓ SMOKE PASS — work order → result → done; archived ${archived.length} file(s); heartbeat ${agent!.heartbeatStatus}`)
+  cleanup()
+  process.exit(0)
+}
+
+main().catch(e => fail(e?.message ?? String(e)))


### PR DESCRIPTION
Phase 4 / MCA-31. File-and-rules-based adapter bridging Mission Control tasks to a Cursor inbox: claim → write work order → watch for result file → POST done → archive. Includes .cursor rules snippet, README, and a two-pass smoke (npm run smoke:cursor) that passes. 303/303 tests, tsc clean. Closes MCA-31.