### PR TITLE
Org chart & hierarchy (MCA-PC A1)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -62,6 +62,10 @@ export const agents = sqliteTable('agents', {
   lastHeartbeatAt: integer('last_heartbeat_at', { mode: 'timestamp' }),
   heartbeatStatus: text('heartbeat_status').default('unknown'), // green|amber|stale|unknown
   contactChannel: text('contact_channel'),           // telegram chat id / email for pings
+  // Org chart & hierarchy (MCA-PC A1)
+  reportsTo: text('reports_to'),                      // manager agent id
+  title: text('title'),                              // job title (e.g. "Head of Engineering")
+  jobDescription: text('job_description'),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -6,7 +6,7 @@ export async function setupDatabase() {
     `CREATE TABLE IF NOT EXISTS organisations (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, logo_url TEXT, owner_id TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS departments (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, name TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS projects (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, description TEXT, created_at INTEGER NOT NULL)`,
-    `CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, role TEXT NOT NULL, personality TEXT, cv TEXT, terms_of_reference TEXT, llm_provider TEXT NOT NULL DEFAULT 'anthropic', llm_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514', skills TEXT DEFAULT '[]', status TEXT NOT NULL DEFAULT 'idle', avatar_emoji TEXT DEFAULT '🤖', agent_type TEXT NOT NULL DEFAULT 'standard', advisor_persona TEXT, memory_long_term TEXT, persona TEXT, expertise TEXT, advisor_ids TEXT, runtime TEXT NOT NULL DEFAULT 'internal', external_endpoint TEXT, api_token_hash TEXT, last_heartbeat_at INTEGER, heartbeat_status TEXT DEFAULT 'unknown', contact_channel TEXT, created_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, role TEXT NOT NULL, personality TEXT, cv TEXT, terms_of_reference TEXT, llm_provider TEXT NOT NULL DEFAULT 'anthropic', llm_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514', skills TEXT DEFAULT '[]', status TEXT NOT NULL DEFAULT 'idle', avatar_emoji TEXT DEFAULT '🤖', agent_type TEXT NOT NULL DEFAULT 'standard', advisor_persona TEXT, memory_long_term TEXT, persona TEXT, expertise TEXT, advisor_ids TEXT, runtime TEXT NOT NULL DEFAULT 'internal', external_endpoint TEXT, api_token_hash TEXT, last_heartbeat_at INTEGER, heartbeat_status TEXT DEFAULT 'unknown', contact_channel TEXT, reports_to TEXT, title TEXT, job_description TEXT, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS messages (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, task_id TEXT, role TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, org_id TEXT NOT NULL, project_id TEXT, title TEXT NOT NULL, input TEXT, output TEXT, status TEXT NOT NULL DEFAULT 'pending', priority TEXT NOT NULL DEFAULT 'medium', kanban_column TEXT DEFAULT 'todo', llm_model TEXT, tokens_used INTEGER, cost_usd REAL, duration_ms INTEGER, assigned_to TEXT, due_at INTEGER, parent_task_id TEXT, created_at INTEGER NOT NULL, completed_at INTEGER)`,
     `CREATE TABLE IF NOT EXISTS skills (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, domain TEXT NOT NULL, content TEXT NOT NULL, source TEXT NOT NULL DEFAULT 'github', github_path TEXT, org_id TEXT, last_synced_at INTEGER, created_at INTEGER NOT NULL)`,
@@ -52,6 +52,10 @@ export async function setupDatabase() {
     `ALTER TABLE agents ADD COLUMN heartbeat_status TEXT DEFAULT 'unknown'`,
     `ALTER TABLE agents ADD COLUMN contact_channel TEXT`,
     `CREATE INDEX IF NOT EXISTS idx_agents_token ON agents(api_token_hash)`,
+    // MCA-PC A1: org chart & hierarchy
+    `ALTER TABLE agents ADD COLUMN reports_to TEXT`,
+    `ALTER TABLE agents ADD COLUMN title TEXT`,
+    `ALTER TABLE agents ADD COLUMN job_description TEXT`,
   ]
   for (const sql of alterStatements) {
     try { await dbClient.execute(sql) } catch { /* column already exists */ }

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -10,6 +10,7 @@ import { streamLLM } from '../services/llm-router'
 import { buildAuthUrl, exchangeCode } from '../services/google-auth'
 import { generateAgentToken } from '../middleware/agent-token'
 import { isExternalAgent, heartbeatFreshness } from '../services/agent-runtime'
+import { buildOrgChart } from '../services/orgchart'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -411,6 +412,18 @@ export async function agentRoutes(app: FastifyInstance) {
         blocked: inCol('blocked'), done: inCol('done'),
       },
     }
+  })
+
+  // Org chart & hierarchy (MCA-PC A1): reporting tree built from agents.reportsTo.
+  app.get('/api/orgs/:orgId/orgchart', async (req) => {
+    const { orgId } = req.params as any
+    const rows = await db.select({
+      id: schema.agents.id, name: schema.agents.name, role: schema.agents.role,
+      title: schema.agents.title, reportsTo: schema.agents.reportsTo,
+      avatarEmoji: schema.agents.avatarEmoji, status: schema.agents.status,
+      runtime: schema.agents.runtime,
+    }).from(schema.agents).where(eq(schema.agents.orgId, orgId))
+    return { tree: buildOrgChart(rows), count: rows.length }
   })
 }
 

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -110,7 +110,16 @@ export async function executeAgentTask(opts: {
       console.warn('Drive context fetch failed (non-critical):', err)
     }
 
-    const systemPrompt = buildSystemPrompt(agent, memoryBlock, isOrchestrator, org, ragContext, driveContext, availableAgents)
+    // Org chart context (MCA-PC A1): manager + direct reports for the reporting line.
+    const hierAgents = await db.select({ id: schema.agents.id, name: schema.agents.name, reportsTo: schema.agents.reportsTo })
+      .from(schema.agents).where(eq(schema.agents.orgId, agent.orgId))
+    const hierarchy = {
+      title: agent.title,
+      manager: agent.reportsTo ? (hierAgents.find(a => a.id === agent.reportsTo)?.name ?? null) : null,
+      reports: hierAgents.filter(a => a.reportsTo === agent.id).map(a => a.name),
+    }
+
+    const systemPrompt = buildSystemPrompt(agent, memoryBlock, isOrchestrator, org, ragContext, driveContext, availableAgents, hierarchy)
     const model    = agent.llmModel    ?? 'claude-sonnet-4-20250514'
     const provider = agent.llmProvider ?? 'anthropic'
     const orgApiKey = org?.deployConfig?.[`${provider}_api_key`] as string | undefined
@@ -210,6 +219,7 @@ export function buildSystemPrompt(
   ragContext?: string,
   driveContext?: string,
   availableAgents?: Array<{ name: string; role: string }>,
+  hierarchy?: { title?: string | null; manager?: string | null; reports?: string[] },
 ): string {
   const lines: string[] = []
 
@@ -231,6 +241,13 @@ export function buildSystemPrompt(
     lines.push(`You are ${agent.name}, a Silver Board Advisor.`, `Persona: ${agent.advisorPersona}`, '', 'Embody this persona fully. Speak with their voice, wisdom, and philosophy.', '')
   } else {
     lines.push(`You are ${agent.name}, ${agent.role} at 7Ei.`, '')
+  }
+  if (hierarchy && (hierarchy.title || hierarchy.manager || (hierarchy.reports && hierarchy.reports.length))) {
+    lines.push('=== YOUR PLACE IN THE ORG ===')
+    if (hierarchy.title)   lines.push(`Title: ${hierarchy.title}`)
+    if (hierarchy.manager) lines.push(`Reports to: ${hierarchy.manager}`)
+    if (hierarchy.reports && hierarchy.reports.length) lines.push(`Direct reports: ${hierarchy.reports.join(', ')}`)
+    lines.push('Escalate to your manager; delegate to your reports.', '=== END ORG ===', '')
   }
   if (agent.personality)      lines.push(`Communication style: ${agent.personality}`, '')
   if (agent.persona)          lines.push('\nYOUR PERSONALITY AND STYLE:\n' + agent.persona, '')

--- a/backend/src/services/orgchart.ts
+++ b/backend/src/services/orgchart.ts
@@ -1,0 +1,63 @@
+// Org chart & hierarchy (MCA-PC A1).
+// Pure helpers to assemble a reporting tree from a flat agent list.
+
+export interface OrgAgent {
+  id: string
+  name: string
+  role: string
+  title?: string | null
+  reportsTo?: string | null
+  avatarEmoji?: string | null
+  status?: string | null
+  runtime?: string | null
+}
+
+export interface OrgNode extends OrgAgent {
+  children: OrgNode[]
+}
+
+/**
+ * Build a reporting tree. Roots are agents whose reportsTo is null/empty or
+ * points outside the set (orphans are promoted to roots so none are lost).
+ * Cycles are broken: an agent already placed never becomes its own descendant.
+ */
+export function buildOrgChart<T extends OrgAgent>(agents: T[]): (T & { children: any[] })[] {
+  const byId = new Map<string, T & { children: any[] }>()
+  for (const a of agents) byId.set(a.id, { ...a, children: [] })
+
+  const roots: (T & { children: any[] })[] = []
+  const placed = new Set<string>()
+
+  for (const a of agents) {
+    const node = byId.get(a.id)!
+    const parentId = a.reportsTo ?? null
+    const parent = parentId ? byId.get(parentId) : undefined
+    // Root when: no manager, manager missing from set, or self-reference.
+    if (!parent || parentId === a.id) {
+      roots.push(node); placed.add(a.id); continue
+    }
+    // Cycle guard: walk up from parent; if we reach this agent, treat as root.
+    let cursor: string | null | undefined = parentId
+    let cyclic = false
+    const seen = new Set<string>()
+    while (cursor) {
+      if (cursor === a.id) { cyclic = true; break }
+      if (seen.has(cursor)) break
+      seen.add(cursor)
+      cursor = byId.get(cursor)?.reportsTo ?? null
+    }
+    if (cyclic) { roots.push(node); placed.add(a.id); continue }
+    parent.children.push(node); placed.add(a.id)
+  }
+  return roots
+}
+
+/** Direct reports of an agent. */
+export function directReports<T extends OrgAgent>(agents: T[], managerId: string): T[] {
+  return agents.filter(a => a.reportsTo === managerId)
+}
+
+/** Total agents in a (sub)tree, including roots. */
+export function countTree(nodes: { children: any[] }[]): number {
+  return nodes.reduce((n, node) => n + 1 + countTree(node.children), 0)
+}

--- a/backend/src/tests/orgchart.test.ts
+++ b/backend/src/tests/orgchart.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildOrgChart, directReports, countTree } from '../services/orgchart.ts'
+
+const A = (id: string, reportsTo: string | null = null) =>
+  ({ id, name: id.toUpperCase(), role: 'role', reportsTo })
+
+describe('[MCA-PC A1] buildOrgChart', () => {
+  it('roots agents with no manager', () => {
+    const tree = buildOrgChart([A('ceo')])
+    assert.equal(tree.length, 1)
+    assert.equal(tree[0].id, 'ceo')
+    assert.deepEqual(tree[0].children, [])
+  })
+
+  it('nests reports under their manager', () => {
+    const tree = buildOrgChart([A('ceo'), A('cto', 'ceo'), A('eng', 'cto')])
+    assert.equal(tree.length, 1)
+    assert.equal(tree[0].children[0].id, 'cto')
+    assert.equal(tree[0].children[0].children[0].id, 'eng')
+    assert.equal(countTree(tree), 3)
+  })
+
+  it('promotes orphans (manager not in set) to roots', () => {
+    const tree = buildOrgChart([A('eng', 'ghost')])
+    assert.equal(tree.length, 1)
+    assert.equal(tree[0].id, 'eng')
+  })
+
+  it('breaks cycles without losing agents', () => {
+    const tree = buildOrgChart([A('a', 'b'), A('b', 'a')])
+    assert.equal(countTree(tree), 2)  // both present, no infinite loop
+  })
+
+  it('handles multiple roots', () => {
+    const tree = buildOrgChart([A('ceo'), A('advisor'), A('cto', 'ceo')])
+    assert.equal(tree.length, 2)
+    assert.equal(countTree(tree), 3)
+  })
+
+  it('directReports returns immediate children only', () => {
+    const agents = [A('ceo'), A('cto', 'ceo'), A('eng', 'cto')]
+    assert.deepEqual(directReports(agents, 'ceo').map(a => a.id), ['cto'])
+  })
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -23,6 +23,7 @@ type CAgent = {
 }
 type CTask = { id: string; title: string; status: string; kanbanColumn: string; priority: string; agentId: string }
 type Cockpit = { agents: CAgent[]; tasks: CTask[]; summary: Record<string, number>; generatedAt: string }
+type OrgNode = { id: string; name: string; role: string; title?: string | null; runtime?: string; avatarEmoji?: string | null; status?: string; children: OrgNode[] }
 
 const HB: Record<string, string> = { green: '#22c55e', amber: '#f59e0b', stale: '#ef4444', unknown: '#555' }
 const STATUS_C: Record<string, string> = { idle: '#888', active: '#22c55e', external: '#a96bff' }
@@ -35,12 +36,19 @@ const COLS: { key: string; label: string }[] = [
 
 export default function CockpitPanel({ orgId, getToken }: { orgId: string; getToken: Getter }) {
   const [data, setData] = useState<Cockpit | null>(null)
+  const [chart, setChart] = useState<OrgNode[] | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [wizard, setWizard] = useState(false)
 
   const load = useCallback(async () => {
-    try { setData(await call<Cockpit>(`/api/orgs/${orgId}/cockpit`, await getToken())); setErr(null) }
-    catch (e: any) { setErr(e?.message ?? 'Failed to load') }
+    try {
+      const tok = await getToken()
+      const [c, oc] = await Promise.all([
+        call<Cockpit>(`/api/orgs/${orgId}/cockpit`, tok),
+        call<{ tree: OrgNode[] }>(`/api/orgs/${orgId}/orgchart`, tok),
+      ])
+      setData(c); setChart(oc.tree); setErr(null)
+    } catch (e: any) { setErr(e?.message ?? 'Failed to load') }
   }, [orgId, getToken])
 
   useEffect(() => { load() }, [load])
@@ -88,6 +96,13 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         {data && data.agents.length === 0 && <p style={{ color: '#888' }}>No agents yet — add one.</p>}
       </div>
 
+      <h2 style={s.h2}>Org chart</h2>
+      <div style={s.panel}>
+        {(chart ?? []).map(n => <OrgNodeRow key={n.id} node={n} depth={0} />)}
+        {chart && chart.length === 0 && <p style={{ color: '#888' }}>No agents yet.</p>}
+        {!chart && <p style={{ color: '#555', fontSize: 12 }}>Loading…</p>}
+      </div>
+
       <h2 style={s.h2}>Task board</h2>
       <div style={s.board}>
         {COLS.map(col => {
@@ -109,6 +124,23 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
 
       {wizard && <AddAgentWizard orgId={orgId} getToken={getToken} onClose={() => setWizard(false)} onDone={() => { setWizard(false); load() }} />}
     </div>
+  )
+}
+
+// ─── Org chart (recursive reporting tree) ────────────────────────────────────
+
+function OrgNodeRow({ node, depth }: { node: OrgNode; depth: number }) {
+  return (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0', paddingLeft: depth * 22 }}>
+        {depth > 0 && <span style={{ color: '#444' }}>└─</span>}
+        <span style={{ fontSize: 18 }}>{node.avatarEmoji || '🤖'}</span>
+        <span style={{ fontWeight: 600, fontSize: 13 }}>{node.name}</span>
+        <span style={{ fontSize: 11.5, color: '#888' }}>{node.title || node.role}</span>
+        {node.runtime && <span style={s.badge}>{RUNTIME_BADGE[node.runtime] ?? '⚙️'} {node.runtime}</span>}
+      </div>
+      {node.children.map(c => <OrgNodeRow key={c.id} node={c} depth={depth + 1} />)}
+    </>
   )
 }
 
@@ -221,6 +253,7 @@ const s: Record<string, React.CSSProperties> = {
   statCard: { background: '#111', border: '1px solid #222', borderRadius: 10, padding: 16, display: 'flex', flexDirection: 'column', gap: 4 },
   statVal: { fontSize: 28, fontWeight: 800, lineHeight: 1 }, statLabel: { fontSize: 12, color: '#888' },
   agentGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 12 },
+  panel: { background: '#111', border: '1px solid #222', borderRadius: 12, padding: 16 },
   agentCard: { background: '#111', border: '1px solid #222', borderRadius: 10, padding: 16, display: 'flex', alignItems: 'center', gap: 12 },
   badge: { fontSize: 10, color: '#aaa', background: '#1a1a1a', border: '1px solid #333', borderRadius: 6, padding: '1px 6px', fontWeight: 600 },
   board: { display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 },


### PR DESCRIPTION
First story of the Paperclip-parity epic (MCA-34). Adds reporting hierarchy.

- **Schema**: agents += reports_to, title, job_description (idempotent ALTERs).
- **services/orgchart.ts**: pure buildOrgChart — roots, orphan promotion, cycle-safe; 6 unit tests.
- **API**: GET /api/orgs/:id/orgchart → nested reporting tree.
- **Prompt**: executor injects manager + direct reports so agents respect the reporting line.
- **UI**: Org chart view in the cockpit (recursive tree, runtime badges).

309/309 backend tests, tsc clean, next build ok. Closes MCA-35.