### PR TITLE
Add an agent via a prompt — goal-driven hiring (MCA-PC A2)

### DIFF
--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -11,6 +11,7 @@ import { buildAuthUrl, exchangeCode } from '../services/google-auth'
 import { generateAgentToken } from '../middleware/agent-token'
 import { isExternalAgent, heartbeatFreshness } from '../services/agent-runtime'
 import { buildOrgChart } from '../services/orgchart'
+import { buildHirePrompt, parseHireProposal, isExternalRuntime } from '../services/hiring'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -384,6 +385,50 @@ export async function agentRoutes(app: FastifyInstance) {
     const { token, hash } = generateAgentToken()
     await db.update(schema.agents).set({ apiTokenHash: hash }).where(eq(schema.agents.id, agentId))
     return { agentToken: token }
+  })
+
+  // Goal-driven hiring (MCA-PC A2): prompt → proposed profile; confirm → create + place.
+  app.post('/api/orgs/:orgId/agents/hire', async (req, reply) => {
+    const { orgId } = req.params as any
+    const body = (req.body ?? {}) as any
+    const org = await db.query.organisations.findFirst({ where: eq(schema.organisations.id, orgId) })
+    if (!org) return reply.code(404).send({ error: 'Org not found' })
+
+    // Confirm path → create the (possibly edited) proposed agent and place it.
+    if (body.confirm && body.profile) {
+      const p = parseHireProposal(JSON.stringify(body.profile))
+      let reportsTo: string | null = null
+      if (p.reportsTo) {
+        const mgr = await db.query.agents.findFirst({ where: and(eq(schema.agents.id, p.reportsTo), eq(schema.agents.orgId, orgId)) })
+        reportsTo = mgr ? mgr.id : null
+      }
+      const external = isExternalRuntime(p.runtime)
+      const tok = external ? generateAgentToken() : null
+      const agent = {
+        id: randomUUID(), orgId, departmentId: null, name: p.name, role: p.role,
+        personality: null, cv: null, termsOfReference: p.termsOfReference || null,
+        llmProvider: p.llmProvider, llmModel: p.llmModel, skills: p.skills,
+        status: 'idle', avatarEmoji: p.avatarEmoji, agentType: external ? 'external' : 'standard',
+        advisorPersona: null, memoryLongTerm: null, runtime: p.runtime,
+        externalEndpoint: null, apiTokenHash: tok ? tok.hash : null,
+        heartbeatStatus: external ? 'unknown' : null, contactChannel: null,
+        reportsTo, title: p.title, jobDescription: p.jobDescription, createdAt: new Date(),
+      }
+      await db.insert(schema.agents).values(agent as any)
+      reply.code(201)
+      return { agent: { ...agent, apiTokenHash: undefined }, agentToken: tok ? tok.token : undefined }
+    }
+
+    // Propose path → ask the LLM to design an agent from the prompt + org chart.
+    if (!body.prompt) return reply.code(400).send({ error: 'prompt is required' })
+    const agents = await db.select({ id: schema.agents.id, name: schema.agents.name, role: schema.agents.role, title: schema.agents.title })
+      .from(schema.agents).where(eq(schema.agents.orgId, orgId))
+    const { system, user } = buildHirePrompt(body.prompt, org, agents)
+    let out = ''
+    await streamLLM({ provider: 'anthropic', model: 'claude-sonnet-4-20250514', system, messages: [{ role: 'user', content: user }], maxTokens: 1024, onToken: (t) => { out += t } })
+    const proposal = parseHireProposal(out)
+    if (proposal.reportsTo && !agents.find(a => a.id === proposal.reportsTo)) proposal.reportsTo = null
+    return { proposal }
   })
 
   // Cockpit payload: roster (with heartbeat freshness) + tasks + summary.

--- a/backend/src/services/hiring.ts
+++ b/backend/src/services/hiring.ts
@@ -1,0 +1,76 @@
+// Goal-driven hiring (MCA-PC A2). Pure helpers: build the proposal prompt from
+// org context + the existing org chart, and parse/normalise the LLM's JSON.
+
+export const HIRE_RUNTIMES = ['internal', 'openclaw', 'cursor', 'claude_code', 'custom'] as const
+export type HireRuntime = (typeof HIRE_RUNTIMES)[number]
+
+export interface HireProposal {
+  name: string
+  title: string
+  role: string
+  jobDescription: string
+  avatarEmoji: string
+  llmProvider: string
+  llmModel: string
+  skills: string[]
+  runtime: HireRuntime
+  reportsTo: string | null   // existing agent id, or null
+  termsOfReference: string
+}
+
+export interface ExistingAgent { id: string; name: string; role: string; title?: string | null }
+
+/** System + user prompt that asks the model to design one agent for the org. */
+export function buildHirePrompt(
+  prompt: string,
+  org: { mission?: string | null; culture?: string | null } | null,
+  agents: ExistingAgent[],
+): { system: string; user: string } {
+  const roster = agents.length
+    ? agents.map(a => `- id=${a.id} · ${a.name} · ${a.title || a.role}`).join('\n')
+    : '(no agents yet — this may be the first hire)'
+  const system = [
+    'You are 7Ei’s head of org design. Design ONE agent for the company from the request.',
+    'Pick a fitting title, a concise role, a one-paragraph job description, an emoji, and 2–5 skills.',
+    'Choose a runtime: "internal" (the app runs it via its LLM) unless the request clearly implies a',
+    'self-hosted coding/ops agent — then use "openclaw" | "cursor" | "claude_code" | "custom".',
+    'Choose a sensible manager from the existing roster and return their EXACT id in reportsTo, or null',
+    'if it should report to no one. Return ONLY a JSON object, no markdown, with keys:',
+    '{ "name", "title", "role", "jobDescription", "avatarEmoji", "llmProvider", "llmModel",',
+    '  "skills": string[], "runtime", "reportsTo": string|null, "termsOfReference" }',
+  ].join('\n')
+  const user = [
+    org?.mission ? `Org mission: ${org.mission}` : '',
+    org?.culture ? `Org culture: ${org.culture}` : '',
+    `Existing org chart:\n${roster}`,
+    '',
+    `Request: ${prompt}`,
+  ].filter(Boolean).join('\n')
+  return { system, user }
+}
+
+const DEFAULTS = { provider: 'anthropic', model: 'claude-sonnet-4-20250514' }
+
+/** Parse the model output into a normalised proposal with safe defaults. */
+export function parseHireProposal(raw: string): HireProposal {
+  let obj: any = {}
+  try { obj = JSON.parse(String(raw).replace(/```json|```/g, '').trim()) } catch { obj = {} }
+  const runtime: HireRuntime = HIRE_RUNTIMES.includes(obj.runtime) ? obj.runtime : 'internal'
+  const skills = Array.isArray(obj.skills) ? obj.skills.filter((s: any) => typeof s === 'string').slice(0, 8) : []
+  const name = (obj.name && String(obj.name).trim()) || 'New Agent'
+  return {
+    name,
+    title: (obj.title && String(obj.title).trim()) || (obj.role && String(obj.role).trim()) || 'Team Member',
+    role: (obj.role && String(obj.role).trim()) || obj.title || 'Team Member',
+    jobDescription: typeof obj.jobDescription === 'string' ? obj.jobDescription : '',
+    avatarEmoji: (typeof obj.avatarEmoji === 'string' && obj.avatarEmoji.trim()) || '🤖',
+    llmProvider: (typeof obj.llmProvider === 'string' && obj.llmProvider.trim()) || (runtime === 'openclaw' ? 'minimax' : DEFAULTS.provider),
+    llmModel: (typeof obj.llmModel === 'string' && obj.llmModel.trim()) || (runtime === 'openclaw' ? 'MiniMax-Text-01' : DEFAULTS.model),
+    skills,
+    runtime,
+    reportsTo: typeof obj.reportsTo === 'string' && obj.reportsTo.trim() ? obj.reportsTo.trim() : null,
+    termsOfReference: typeof obj.termsOfReference === 'string' ? obj.termsOfReference : '',
+  }
+}
+
+export const isExternalRuntime = (r: string | null | undefined) => !!r && r !== 'internal'

--- a/backend/src/tests/hiring.test.ts
+++ b/backend/src/tests/hiring.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildHirePrompt, parseHireProposal } from '../services/hiring.ts'
+
+describe('[MCA-PC A2] buildHirePrompt', () => {
+  it('includes mission, roster ids, and the request', () => {
+    const { system, user } = buildHirePrompt(
+      'a growth marketer',
+      { mission: 'Win the market', culture: 'sovereign' },
+      [{ id: 'ceo1', name: 'Arturito', role: 'CEO', title: 'CEO' }],
+    )
+    assert.match(system, /JSON object/)
+    assert.match(user, /Win the market/)
+    assert.match(user, /id=ceo1/)
+    assert.match(user, /a growth marketer/)
+  })
+  it('handles an empty roster', () => {
+    const { user } = buildHirePrompt('first hire', null, [])
+    assert.match(user, /no agents yet/)
+  })
+})
+
+describe('[MCA-PC A2] parseHireProposal', () => {
+  it('parses fenced JSON and keeps fields', () => {
+    const raw = '```json\n' + JSON.stringify({
+      name: 'Maya', title: 'Head of Marketing', role: 'Marketing', jobDescription: 'Grow.',
+      avatarEmoji: '📣', llmProvider: 'anthropic', llmModel: 'claude-sonnet-4-20250514',
+      skills: ['seo', 'content'], runtime: 'internal', reportsTo: 'ceo1', termsOfReference: 'ToR',
+    }) + '\n```'
+    const p = parseHireProposal(raw)
+    assert.equal(p.name, 'Maya')
+    assert.equal(p.runtime, 'internal')
+    assert.deepEqual(p.skills, ['seo', 'content'])
+    assert.equal(p.reportsTo, 'ceo1')
+  })
+  it('applies safe defaults on junk', () => {
+    const p = parseHireProposal('not json at all')
+    assert.equal(p.name, 'New Agent')
+    assert.equal(p.runtime, 'internal')
+    assert.equal(p.avatarEmoji, '🤖')
+    assert.equal(p.llmProvider, 'anthropic')
+    assert.deepEqual(p.skills, [])
+    assert.equal(p.reportsTo, null)
+  })
+  it('coerces an invalid runtime to internal', () => {
+    assert.equal(parseHireProposal('{"runtime":"k8s"}').runtime, 'internal')
+  })
+  it('defaults openclaw runtime to minimax model', () => {
+    const p = parseHireProposal('{"runtime":"openclaw","name":"Claw"}')
+    assert.equal(p.runtime, 'openclaw')
+    assert.equal(p.llmProvider, 'minimax')
+    assert.equal(p.llmModel, 'MiniMax-Text-01')
+  })
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -39,6 +39,7 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const [chart, setChart] = useState<OrgNode[] | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [wizard, setWizard] = useState(false)
+  const [hire, setHire] = useState(false)
 
   const load = useCallback(async () => {
     try {
@@ -62,6 +63,7 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         <h1 style={s.h1}>Mission Control</h1>
         <div style={{ display: 'flex', gap: 8 }}>
           <button onClick={load} style={s.ghostBtn}>↻ Refresh</button>
+          <button onClick={() => setHire(true)} style={s.ghostBtn}>✨ Hire with a prompt</button>
           <button onClick={() => setWizard(true)} style={s.primaryBtn}>＋ Add agent</button>
         </div>
       </div>
@@ -123,6 +125,88 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
       </div>
 
       {wizard && <AddAgentWizard orgId={orgId} getToken={getToken} onClose={() => setWizard(false)} onDone={() => { setWizard(false); load() }} />}
+      {hire && <HireDialog orgId={orgId} getToken={getToken} onClose={() => setHire(false)} onDone={() => { setHire(false); load() }} />}
+    </div>
+  )
+}
+
+// ─── Hire with a prompt (goal-driven hiring) ─────────────────────────────────
+
+function HireDialog({ orgId, getToken, onClose, onDone }: { orgId: string; getToken: Getter; onClose: () => void; onDone: () => void }) {
+  const [prompt, setPrompt] = useState('')
+  const [proposal, setProposal] = useState<any>(null)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+
+  const propose = async () => {
+    if (!prompt.trim()) return
+    setBusy(true); setErr(null)
+    try {
+      const r = await call<{ proposal: any }>(`/api/orgs/${orgId}/agents/hire`, await getToken(), { method: 'POST', body: JSON.stringify({ prompt }) })
+      setProposal(r.proposal)
+    } catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setBusy(false)
+  }
+  const confirmHire = async () => {
+    setBusy(true); setErr(null)
+    try {
+      const r = await call<{ agentToken?: string }>(`/api/orgs/${orgId}/agents/hire`, await getToken(), { method: 'POST', body: JSON.stringify({ confirm: true, profile: proposal }) })
+      if (r.agentToken) setToken(r.agentToken); else onDone()
+    } catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setBusy(false)
+  }
+  const set = (k: string, v: string) => setProposal((p: any) => ({ ...p, [k]: v }))
+
+  return (
+    <div style={s.modalWrap} onClick={onClose}>
+      <div style={s.modal} onClick={e => e.stopPropagation()}>
+        {token ? (
+          <>
+            <h2 style={s.h2}>✓ Hired {proposal?.name}</h2>
+            <p style={{ color: '#888', fontSize: 13, margin: '6px 0 0' }}>External runtime — copy this one-time token into the adapter's <code style={s.code}>mc.env</code>.</p>
+            <div style={s.tokenBox}>{token}</div>
+            <button style={{ ...s.primaryBtn, marginTop: 8 }} onClick={onDone}>Done</button>
+          </>
+        ) : !proposal ? (
+          <>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <h2 style={s.h2}>Hire with a prompt</h2><button onClick={onClose} style={s.x}>✕</button>
+            </div>
+            <p style={{ color: '#888', fontSize: 12.5, margin: '4px 0 0' }}>Describe the agent you need — Arturito proposes a profile, title, and manager from your org chart.</p>
+            <textarea style={{ ...s.inp, minHeight: 90, marginTop: 12 }} autoFocus value={prompt}
+              placeholder="e.g. A growth marketer who owns SEO and the weekly newsletter, reporting to the CMO."
+              onChange={e => setPrompt(e.target.value)} />
+            {err && <div style={s.errBox}>⚠ {err}</div>}
+            <button style={{ ...s.primaryBtn, marginTop: 14, opacity: busy ? 0.6 : 1 }} disabled={busy} onClick={propose}>{busy ? 'Designing…' : '✨ Propose'}</button>
+          </>
+        ) : (
+          <>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <h2 style={s.h2}>Review &amp; hire</h2><button onClick={onClose} style={s.x}>✕</button>
+            </div>
+            <div style={s.form}>
+              <div style={{ display: 'flex', gap: 10 }}>
+                <label style={{ ...s.lab, flex: 1 }}>Name<input style={s.inp} value={proposal.name} onChange={e => set('name', e.target.value)} /></label>
+                <label style={{ ...s.lab, width: 80 }}>Emoji<input style={s.inp} value={proposal.avatarEmoji} onChange={e => set('avatarEmoji', e.target.value)} /></label>
+              </div>
+              <label style={s.lab}>Title<input style={s.inp} value={proposal.title} onChange={e => set('title', e.target.value)} /></label>
+              <label style={s.lab}>Role<input style={s.inp} value={proposal.role} onChange={e => set('role', e.target.value)} /></label>
+              <div style={{ fontSize: 12, color: '#aaa', lineHeight: 1.7 }}>
+                <div>Runtime: <b style={{ color: '#fff' }}>{RUNTIME_BADGE[proposal.runtime] ?? '⚙️'} {proposal.runtime}</b> · Model: <b style={{ color: '#fff' }}>{proposal.llmProvider}·{proposal.llmModel}</b></div>
+                <div>Reports to: <b style={{ color: '#fff' }}>{proposal.reportsTo ?? '— (top level)'}</b></div>
+                {proposal.skills?.length ? <div>Skills: {proposal.skills.join(', ')}</div> : null}
+                {proposal.jobDescription ? <div style={{ color: '#888', marginTop: 4 }}>{proposal.jobDescription}</div> : null}
+              </div>
+            </div>
+            {err && <div style={s.errBox}>⚠ {err}</div>}
+            <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
+              <button style={s.ghostBtn} onClick={() => setProposal(null)}>← Re-prompt</button>
+              <button style={{ ...s.primaryBtn, opacity: busy ? 0.6 : 1 }} disabled={busy} onClick={confirmHire}>{busy ? 'Hiring…' : 'Hire'}</button>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Second story of the Paperclip-parity epic (MCA-34).

- **services/hiring.ts** (pure): buildHirePrompt (org mission/culture + current org chart) + parseHireProposal (fenced-JSON extraction, safe defaults, runtime coercion). 6 unit tests.
- **POST /api/orgs/:id/agents/hire** — propose: prompt -> full profile incl title, suggested manager (reportsTo matched to a real agent), runtime, model, skills. confirm: create + place; external runtimes get a one-time token.
- **Cockpit**: Hire-with-a-prompt dialog (describe -> review/edit -> Hire), reusing the token reveal for external runtimes.

315/315 backend tests, tsc clean, next build ok. Closes MCA-36.