### PR TITLE
Unified inbox (MCA-PC A3)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -96,8 +96,17 @@ export const tasks = sqliteTable('tasks', {
   assignedTo: text('assigned_to'),
   dueAt: integer('due_at', { mode: 'timestamp' }),
   parentTaskId: text('parent_task_id'),
+  inboxState: text('inbox_state').default('none'),   // none|needs_attention|blocked|awaiting_review|done (MCA-PC A3)
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   completedAt: integer('completed_at', { mode: 'timestamp' }),
+})
+
+export const inboxDismissals = sqliteTable('inbox_dismissals', {
+  id: text('id').primaryKey(),
+  orgId: text('org_id').notNull(),
+  userId: text('user_id').notNull(),
+  taskId: text('task_id').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 
 export const skills = sqliteTable('skills', {

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -56,6 +56,10 @@ export async function setupDatabase() {
     `ALTER TABLE agents ADD COLUMN reports_to TEXT`,
     `ALTER TABLE agents ADD COLUMN title TEXT`,
     `ALTER TABLE agents ADD COLUMN job_description TEXT`,
+    // MCA-PC A3: unified inbox
+    `ALTER TABLE tasks ADD COLUMN inbox_state TEXT DEFAULT 'none'`,
+    `CREATE TABLE IF NOT EXISTS inbox_dismissals (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, user_id TEXT NOT NULL, task_id TEXT NOT NULL, created_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS idx_inbox_dismissals ON inbox_dismissals(org_id, user_id)`,
   ]
   for (const sql of alterStatements) {
     try { await dbClient.execute(sql) } catch { /* column already exists */ }

--- a/backend/src/routes/agent-api.ts
+++ b/backend/src/routes/agent-api.ts
@@ -86,7 +86,11 @@ export async function agentApiRoutes(app: FastifyInstance) {
     const task = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
     if (!task || task.agentId !== agent.id) return reply.code(404).send({ error: 'Task not found' })
     await db.update(schema.tasks)
-      .set({ output, status, kanbanColumn: status === 'done' ? 'done' : 'blocked', completedAt: new Date() })
+      .set({
+        output, status, kanbanColumn: status === 'done' ? 'done' : 'blocked',
+        inboxState: status === 'done' ? 'awaiting_review' : 'needs_attention',  // MCA-PC A3
+        completedAt: new Date(),
+      })
       .where(eq(schema.tasks.id, taskId))
     await db.insert(schema.messages).values({
       id: randomUUID(), agentId: agent.id, taskId, role: 'assistant', content: output, createdAt: new Date(),

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -12,6 +12,7 @@ import { generateAgentToken } from '../middleware/agent-token'
 import { isExternalAgent, heartbeatFreshness } from '../services/agent-runtime'
 import { buildOrgChart } from '../services/orgchart'
 import { buildHirePrompt, parseHireProposal, isExternalRuntime } from '../services/hiring'
+import { buildInbox } from '../services/inbox'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -475,6 +476,48 @@ export async function agentRoutes(app: FastifyInstance) {
 // ─── TASKS ───────────────────────────────────────────────────────────────────
 
 export async function taskRoutes(app: FastifyInstance) {
+  // ─── Unified inbox (MCA-PC A3) ──────────────────────────────────────────
+  const inboxCols = {
+    id: schema.tasks.id, title: schema.tasks.title, status: schema.tasks.status,
+    inboxState: schema.tasks.inboxState, priority: schema.tasks.priority,
+    agentId: schema.tasks.agentId, createdAt: schema.tasks.createdAt,
+  }
+  const dismissedSet = async (orgId: string, userId: string) => new Set(
+    (await db.select({ taskId: schema.inboxDismissals.taskId }).from(schema.inboxDismissals)
+      .where(and(eq(schema.inboxDismissals.orgId, orgId), eq(schema.inboxDismissals.userId, userId)))).map(d => d.taskId))
+
+  app.get('/api/orgs/:orgId/inbox', async (req) => {
+    const { orgId } = req.params as any
+    const userId = (req as any).userId ?? 'anon'
+    const [tasks, dismissed, agents] = await Promise.all([
+      db.select(inboxCols).from(schema.tasks).where(eq(schema.tasks.orgId, orgId)).orderBy(desc(schema.tasks.createdAt)).limit(300),
+      dismissedSet(orgId, userId),
+      db.select({ id: schema.agents.id, name: schema.agents.name, avatarEmoji: schema.agents.avatarEmoji }).from(schema.agents).where(eq(schema.agents.orgId, orgId)),
+    ])
+    const amap = new Map(agents.map(a => [a.id, a]))
+    const items = buildInbox(tasks as any, dismissed).map(i => ({
+      ...i, agentName: amap.get(i.agentId)?.name ?? '—', agentEmoji: amap.get(i.agentId)?.avatarEmoji ?? '🤖',
+    }))
+    return { items, count: items.length }
+  })
+  app.get('/api/orgs/:orgId/inbox/count', async (req) => {
+    const { orgId } = req.params as any
+    const userId = (req as any).userId ?? 'anon'
+    const [tasks, dismissed] = await Promise.all([
+      db.select(inboxCols).from(schema.tasks).where(eq(schema.tasks.orgId, orgId)).limit(300),
+      dismissedSet(orgId, userId),
+    ])
+    return { count: buildInbox(tasks as any, dismissed).length }
+  })
+  app.post('/api/orgs/:orgId/inbox/dismiss', async (req, reply) => {
+    const { orgId } = req.params as any
+    const userId = (req as any).userId ?? 'anon'
+    const { taskId } = (req.body ?? {}) as any
+    if (!taskId) return reply.code(400).send({ error: 'taskId is required' })
+    await db.insert(schema.inboxDismissals).values({ id: randomUUID(), orgId, userId, taskId, createdAt: new Date() })
+    return { ok: true }
+  })
+
   app.get('/api/orgs/:orgId/tasks', async (req) => {
     const { orgId } = req.params as any
     const q = req.query as any

--- a/backend/src/services/inbox.ts
+++ b/backend/src/services/inbox.ts
@@ -1,0 +1,48 @@
+// Unified inbox (MCA-PC A3). Pure aggregation of tasks that need a human's
+// attention, minus per-user dismissals.
+
+export interface InboxTask {
+  id: string
+  title: string
+  status: string
+  inboxState?: string | null
+  priority?: string | null
+  agentId: string
+  createdAt: Date | number | null
+}
+
+export type InboxKind = 'blocked' | 'failed' | 'review' | 'attention'
+
+export interface InboxItem {
+  taskId: string
+  title: string
+  kind: InboxKind
+  priority: string
+  agentId: string
+  createdAt: number
+}
+
+/** Classify a task into an inbox kind, or null if it doesn't need attention. */
+export function inboxKind(t: InboxTask): InboxKind | null {
+  if (t.status === 'blocked') return 'blocked'
+  if (t.status === 'failed') return 'failed'
+  if (t.inboxState === 'awaiting_review') return 'review'
+  if (t.inboxState === 'needs_attention') return 'attention'
+  return null
+}
+
+const KIND_RANK: Record<InboxKind, number> = { blocked: 0, failed: 1, review: 2, attention: 3 }
+
+/** Build the inbox: attention-worthy tasks minus dismissals, ranked by kind then recency. */
+export function buildInbox(tasks: InboxTask[], dismissed: Set<string> = new Set()): InboxItem[] {
+  const items: InboxItem[] = []
+  for (const t of tasks) {
+    if (dismissed.has(t.id)) continue
+    const kind = inboxKind(t)
+    if (!kind) continue
+    const ts = t.createdAt instanceof Date ? t.createdAt.getTime() : Number(t.createdAt ?? 0)
+    items.push({ taskId: t.id, title: t.title, kind, priority: t.priority ?? 'medium', agentId: t.agentId, createdAt: ts })
+  }
+  items.sort((a, b) => KIND_RANK[a.kind] - KIND_RANK[b.kind] || b.createdAt - a.createdAt)
+  return items
+}

--- a/backend/src/tests/inbox.test.ts
+++ b/backend/src/tests/inbox.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildInbox, inboxKind } from '../services/inbox.ts'
+
+const T = (id: string, status: string, inboxState: string | null = null, createdAt = 0) =>
+  ({ id, title: id, status, inboxState, agentId: 'a1', priority: 'medium', createdAt })
+
+describe('[MCA-PC A3] inboxKind', () => {
+  it('blocked status → blocked', () => assert.equal(inboxKind(T('x', 'blocked')), 'blocked'))
+  it('failed status → failed', () => assert.equal(inboxKind(T('x', 'failed')), 'failed'))
+  it('awaiting_review inboxState → review', () => assert.equal(inboxKind(T('x', 'done', 'awaiting_review')), 'review'))
+  it('needs_attention inboxState → attention', () => assert.equal(inboxKind(T('x', 'in_progress', 'needs_attention')), 'attention'))
+  it('normal task → null', () => assert.equal(inboxKind(T('x', 'in_progress')), null))
+})
+
+describe('[MCA-PC A3] buildInbox', () => {
+  it('includes only attention-worthy tasks', () => {
+    const items = buildInbox([T('a', 'done'), T('b', 'blocked'), T('c', 'failed')])
+    assert.deepEqual(items.map(i => i.taskId).sort(), ['b', 'c'])
+  })
+  it('ranks blocked before review, then by recency', () => {
+    const items = buildInbox([
+      T('rev1', 'done', 'awaiting_review', 100),
+      T('blk', 'blocked', null, 50),
+      T('rev2', 'done', 'awaiting_review', 200),
+    ])
+    assert.deepEqual(items.map(i => i.taskId), ['blk', 'rev2', 'rev1'])
+  })
+  it('excludes dismissed tasks', () => {
+    const items = buildInbox([T('a', 'blocked'), T('b', 'failed')], new Set(['a']))
+    assert.deepEqual(items.map(i => i.taskId), ['b'])
+  })
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -24,11 +24,17 @@ type CAgent = {
 type CTask = { id: string; title: string; status: string; kanbanColumn: string; priority: string; agentId: string }
 type Cockpit = { agents: CAgent[]; tasks: CTask[]; summary: Record<string, number>; generatedAt: string }
 type OrgNode = { id: string; name: string; role: string; title?: string | null; runtime?: string; avatarEmoji?: string | null; status?: string; children: OrgNode[] }
+type InboxItem = { taskId: string; title: string; kind: string; priority: string; agentName: string; agentEmoji: string }
 
 const HB: Record<string, string> = { green: '#22c55e', amber: '#f59e0b', stale: '#ef4444', unknown: '#555' }
 const STATUS_C: Record<string, string> = { idle: '#888', active: '#22c55e', external: '#a96bff' }
 const RUNTIME_BADGE: Record<string, string> = { internal: '🧠', openclaw: '📎', cursor: '⌨️', claude_code: '🤖', custom: '⚙️' }
 const PRI_C: Record<string, string> = { high: '#ef4444', medium: '#f59e0b', low: '#555' }
+const KIND_LABEL: Record<string, string> = { blocked: 'Blocked', failed: 'Failed', review: 'Review', attention: 'Attention' }
+const KIND_C: Record<string, { bg: string; fg: string }> = {
+  blocked: { bg: '#2a1414', fg: '#ff6b6b' }, failed: { bg: '#2a1414', fg: '#ff8080' },
+  review: { bg: '#211c08', fg: '#FFB800' }, attention: { bg: '#0d1a2a', fg: '#4aa8ff' },
+}
 const COLS: { key: string; label: string }[] = [
   { key: 'todo', label: 'To do' }, { key: 'in_progress', label: 'In progress' },
   { key: 'blocked', label: 'Blocked' }, { key: 'done', label: 'Done' },
@@ -37,6 +43,7 @@ const COLS: { key: string; label: string }[] = [
 export default function CockpitPanel({ orgId, getToken }: { orgId: string; getToken: Getter }) {
   const [data, setData] = useState<Cockpit | null>(null)
   const [chart, setChart] = useState<OrgNode[] | null>(null)
+  const [inbox, setInbox] = useState<InboxItem[]>([])
   const [err, setErr] = useState<string | null>(null)
   const [wizard, setWizard] = useState(false)
   const [hire, setHire] = useState(false)
@@ -44,13 +51,19 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const load = useCallback(async () => {
     try {
       const tok = await getToken()
-      const [c, oc] = await Promise.all([
+      const [c, oc, ib] = await Promise.all([
         call<Cockpit>(`/api/orgs/${orgId}/cockpit`, tok),
         call<{ tree: OrgNode[] }>(`/api/orgs/${orgId}/orgchart`, tok),
+        call<{ items: InboxItem[] }>(`/api/orgs/${orgId}/inbox`, tok),
       ])
-      setData(c); setChart(oc.tree); setErr(null)
+      setData(c); setChart(oc.tree); setInbox(ib.items); setErr(null)
     } catch (e: any) { setErr(e?.message ?? 'Failed to load') }
   }, [orgId, getToken])
+
+  const dismiss = async (taskId: string) => {
+    setInbox(x => x.filter(i => i.taskId !== taskId))
+    try { await call(`/api/orgs/${orgId}/inbox/dismiss`, await getToken(), { method: 'POST', body: JSON.stringify({ taskId }) }) } catch {}
+  }
 
   useEffect(() => { load() }, [load])
 
@@ -60,7 +73,10 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   return (
     <div style={s.page}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <h1 style={s.h1}>Mission Control</h1>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <h1 style={s.h1}>Mission Control</h1>
+          {inbox.length > 0 && <span style={{ ...s.tag, background: '#211c08', color: '#FFB800' }}>📥 {inbox.length}</span>}
+        </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <button onClick={load} style={s.ghostBtn}>↻ Refresh</button>
           <button onClick={() => setHire(true)} style={s.ghostBtn}>✨ Hire with a prompt</button>
@@ -78,6 +94,22 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
           { l: 'Done', v: sum.done ?? 0, c: '#22c55e' },
         ].map(k => <div key={k.l} style={s.statCard}><span style={{ ...s.statVal, color: k.c }}>{k.v}</span><span style={s.statLabel}>{k.l}</span></div>)}
       </div>
+
+      {inbox.length > 0 && (<>
+        <h2 style={s.h2}>Inbox <span style={s.colCount}>{inbox.length}</span></h2>
+        <div style={s.panel}>
+          {inbox.map(i => (
+            <div key={i.taskId} style={s.inboxRow}>
+              <span style={{ ...s.tag, background: (KIND_C[i.kind] ?? KIND_C.attention).bg, color: (KIND_C[i.kind] ?? KIND_C.attention).fg }}>{KIND_LABEL[i.kind] ?? i.kind}</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 560 }}>{i.title}</div>
+                <div style={{ fontSize: 11, color: '#888' }}>{i.agentEmoji} {i.agentName}</div>
+              </div>
+              <button style={s.ghostBtn} onClick={() => dismiss(i.taskId)}>Dismiss</button>
+            </div>
+          ))}
+        </div>
+      </>)}
 
       <h2 style={s.h2}>Agent fleet</h2>
       <div style={s.agentGrid}>
@@ -338,6 +370,7 @@ const s: Record<string, React.CSSProperties> = {
   statVal: { fontSize: 28, fontWeight: 800, lineHeight: 1 }, statLabel: { fontSize: 12, color: '#888' },
   agentGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 12 },
   panel: { background: '#111', border: '1px solid #222', borderRadius: 12, padding: 16 },
+  inboxRow: { display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: '1px solid #1a1a1a' },
   agentCard: { background: '#111', border: '1px solid #222', borderRadius: 10, padding: 16, display: 'flex', alignItems: 'center', gap: 12 },
   badge: { fontSize: 10, color: '#aaa', background: '#1a1a1a', border: '1px solid #333', borderRadius: 6, padding: '1px 6px', fontWeight: 600 },
   board: { display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 },


### PR DESCRIPTION
Third story of the Paperclip-parity epic (MCA-34); completes the first-sprint set (A1+A2+A3).

- **Schema**: tasks += inbox_state; inbox_dismissals (per-user).
- **services/inbox.ts** (pure): buildInbox — classifies blocked/failed/awaiting_review/needs_attention, ranks, excludes dismissals. 8 unit tests.
- **API**: GET /inbox + /inbox/count + POST /inbox/dismiss.
- **Flow**: external agent results set tasks to awaiting_review (done) / needs_attention (failed), so the OpenClaw/Cursor loop feeds a review queue.
- **Cockpit**: Inbox panel (kind tags + dismiss) + header badge.

323/323 backend tests, tsc clean, next build ok. Closes MCA-37.