### PR TITLE
Goals & goal alignment (MCA-PC B1)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -97,8 +97,21 @@ export const tasks = sqliteTable('tasks', {
   dueAt: integer('due_at', { mode: 'timestamp' }),
   parentTaskId: text('parent_task_id'),
   inboxState: text('inbox_state').default('none'),   // none|needs_attention|blocked|awaiting_review|done (MCA-PC A3)
+  goalId: text('goal_id'),                            // links task to a goal (MCA-PC B1)
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   completedAt: integer('completed_at', { mode: 'timestamp' }),
+})
+
+export const goals = sqliteTable('goals', {
+  id: text('id').primaryKey(),
+  orgId: text('org_id').notNull(),
+  parentGoalId: text('parent_goal_id'),
+  title: text('title').notNull(),
+  description: text('description'),
+  metric: text('metric'),                             // success metric, e.g. "$1M MRR"
+  status: text('status').notNull().default('active'), // active|done|paused|dropped
+  ownerAgentId: text('owner_agent_id'),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 
 export const inboxDismissals = sqliteTable('inbox_dismissals', {

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -60,6 +60,10 @@ export async function setupDatabase() {
     `ALTER TABLE tasks ADD COLUMN inbox_state TEXT DEFAULT 'none'`,
     `CREATE TABLE IF NOT EXISTS inbox_dismissals (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, user_id TEXT NOT NULL, task_id TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_inbox_dismissals ON inbox_dismissals(org_id, user_id)`,
+    // MCA-PC B1: goals & goal alignment
+    `ALTER TABLE tasks ADD COLUMN goal_id TEXT`,
+    `CREATE TABLE IF NOT EXISTS goals (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, parent_goal_id TEXT, title TEXT NOT NULL, description TEXT, metric TEXT, status TEXT NOT NULL DEFAULT 'active', owner_agent_id TEXT, created_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS idx_goals_org ON goals(org_id)`,
   ]
   for (const sql of alterStatements) {
     try { await dbClient.execute(sql) } catch { /* column already exists */ }

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -13,6 +13,7 @@ import { isExternalAgent, heartbeatFreshness } from '../services/agent-runtime'
 import { buildOrgChart } from '../services/orgchart'
 import { buildHirePrompt, parseHireProposal, isExternalRuntime } from '../services/hiring'
 import { buildInbox } from '../services/inbox'
+import { buildGoalTree } from '../services/goals'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -516,6 +517,34 @@ export async function taskRoutes(app: FastifyInstance) {
     if (!taskId) return reply.code(400).send({ error: 'taskId is required' })
     await db.insert(schema.inboxDismissals).values({ id: randomUUID(), orgId, userId, taskId, createdAt: new Date() })
     return { ok: true }
+  })
+
+  // ─── Goals & goal alignment (MCA-PC B1) ─────────────────────────────────
+  app.get('/api/orgs/:orgId/goals', async (req) => {
+    const { orgId } = req.params as any
+    const rows = await db.select().from(schema.goals).where(eq(schema.goals.orgId, orgId))
+    return { tree: buildGoalTree(rows as any), goals: rows }
+  })
+  app.post('/api/orgs/:orgId/goals', async (req, reply) => {
+    const { orgId } = req.params as any
+    const b = (req.body ?? {}) as any
+    if (!b.title) return reply.code(400).send({ error: 'title is required' })
+    const goal = {
+      id: randomUUID(), orgId, parentGoalId: b.parentGoalId ?? null, title: b.title,
+      description: b.description ?? null, metric: b.metric ?? null,
+      status: b.status ?? 'active', ownerAgentId: b.ownerAgentId ?? null, createdAt: new Date(),
+    }
+    await db.insert(schema.goals).values(goal)
+    reply.code(201); return { goal }
+  })
+  app.patch('/api/goals/:goalId', async (req) => {
+    const { goalId } = req.params as any
+    await db.update(schema.goals).set(req.body as any).where(eq(schema.goals.id, goalId))
+    return { goal: await db.query.goals.findFirst({ where: eq(schema.goals.id, goalId) }) }
+  })
+  app.delete('/api/goals/:goalId', async (req, reply) => {
+    await db.delete(schema.goals).where(eq(schema.goals.id, (req.params as any).goalId))
+    reply.code(204)
   })
 
   app.get('/api/orgs/:orgId/tasks', async (req) => {

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -10,6 +10,7 @@ import { sendPushNotification } from '../routes/notifications'
 import { fireWebhook } from './outbound-webhooks'
 import { ensureFreshToken, searchDriveFiles } from './google-auth'
 import { isExternalAgent, notifyExternalAgent } from './agent-runtime'
+import { goalAncestry, formatGoalContext } from './goals'
 
 export interface ExecuteResult {
   output: string; tokensUsed: number; costUsd: number; durationMs: number
@@ -119,7 +120,17 @@ export async function executeAgentTask(opts: {
       reports: hierAgents.filter(a => a.reportsTo === agent.id).map(a => a.name),
     }
 
-    const systemPrompt = buildSystemPrompt(agent, memoryBlock, isOrchestrator, org, ragContext, driveContext, availableAgents, hierarchy)
+    // Goal alignment (MCA-PC B1): inject the task's goal ancestry as the "why".
+    let goalContext = ''
+    try {
+      const taskRow = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+      if (taskRow?.goalId) {
+        const goalRows = await db.select().from(schema.goals).where(eq(schema.goals.orgId, agent.orgId))
+        goalContext = formatGoalContext(goalAncestry(goalRows as any, taskRow.goalId), org?.mission)
+      }
+    } catch { /* non-critical */ }
+
+    const systemPrompt = buildSystemPrompt(agent, memoryBlock, isOrchestrator, org, ragContext, driveContext, availableAgents, hierarchy, goalContext)
     const model    = agent.llmModel    ?? 'claude-sonnet-4-20250514'
     const provider = agent.llmProvider ?? 'anthropic'
     const orgApiKey = org?.deployConfig?.[`${provider}_api_key`] as string | undefined
@@ -220,6 +231,7 @@ export function buildSystemPrompt(
   driveContext?: string,
   availableAgents?: Array<{ name: string; role: string }>,
   hierarchy?: { title?: string | null; manager?: string | null; reports?: string[] },
+  goalContext?: string,
 ): string {
   const lines: string[] = []
 
@@ -235,6 +247,9 @@ export function buildSystemPrompt(
   }
   if (driveContext) {
     lines.push(driveContext, '')
+  }
+  if (goalContext) {
+    lines.push(goalContext, '')
   }
 
   if (agent.agentType === 'advisor' && agent.advisorPersona) {

--- a/backend/src/services/goals.ts
+++ b/backend/src/services/goals.ts
@@ -1,0 +1,64 @@
+// Goals & goal alignment (MCA-PC B1). Pure helpers: build the goal tree, walk a
+// goal's ancestry, and format the "why" for an agent's system prompt.
+
+export interface Goal {
+  id: string
+  title: string
+  parentGoalId?: string | null
+  description?: string | null
+  metric?: string | null
+  status?: string | null
+}
+
+export interface GoalNode extends Goal { children: GoalNode[] }
+
+/** Build a goal tree from parentGoalId. Orphans become roots; cycles are broken. */
+export function buildGoalTree<T extends Goal>(goals: T[]): (T & { children: any[] })[] {
+  const byId = new Map<string, T & { children: any[] }>()
+  for (const g of goals) byId.set(g.id, { ...g, children: [] })
+  const roots: (T & { children: any[] })[] = []
+  for (const g of goals) {
+    const node = byId.get(g.id)!
+    const pid = g.parentGoalId ?? null
+    const parent = pid ? byId.get(pid) : undefined
+    if (!parent || pid === g.id) { roots.push(node); continue }
+    // cycle guard
+    let cur: string | null | undefined = pid, cyclic = false
+    const seen = new Set<string>()
+    while (cur) {
+      if (cur === g.id) { cyclic = true; break }
+      if (seen.has(cur)) break
+      seen.add(cur); cur = byId.get(cur)?.parentGoalId ?? null
+    }
+    if (cyclic) { roots.push(node); continue }
+    parent.children.push(node)
+  }
+  return roots
+}
+
+/** Ordered ancestry root→leaf for a goal id (inclusive). */
+export function goalAncestry<T extends Goal>(goals: T[], goalId: string): T[] {
+  const byId = new Map(goals.map(g => [g.id, g]))
+  const chain: T[] = []
+  let cur: string | null | undefined = goalId
+  const seen = new Set<string>()
+  while (cur && byId.has(cur) && !seen.has(cur)) {
+    seen.add(cur)
+    chain.push(byId.get(cur)!)
+    cur = byId.get(cur)!.parentGoalId ?? null
+  }
+  return chain.reverse()
+}
+
+/** Format goal ancestry (+ optional mission) for the agent prompt. */
+export function formatGoalContext(ancestry: Goal[], mission?: string | null): string {
+  if (!ancestry.length && !mission) return ''
+  const lines = ['=== GOAL ALIGNMENT (why this task matters) ===']
+  if (mission) lines.push(`Company mission: ${mission}`)
+  ancestry.forEach((g, i) => {
+    const m = g.metric ? ` [metric: ${g.metric}]` : ''
+    lines.push(`${'  '.repeat(i)}↳ ${g.title}${m}`)
+  })
+  lines.push('Keep your work traceable to this goal.', '=== END GOAL ALIGNMENT ===')
+  return lines.join('\n')
+}

--- a/backend/src/tests/goals.test.ts
+++ b/backend/src/tests/goals.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildGoalTree, goalAncestry, formatGoalContext } from '../services/goals.ts'
+
+const G = (id: string, parentGoalId: string | null = null, extra: any = {}) =>
+  ({ id, title: id.toUpperCase(), parentGoalId, ...extra })
+
+describe('[MCA-PC B1] buildGoalTree', () => {
+  it('nests subgoals under parents', () => {
+    const tree = buildGoalTree([G('root'), G('a', 'root'), G('b', 'a')])
+    assert.equal(tree.length, 1)
+    assert.equal(tree[0].children[0].id, 'a')
+    assert.equal(tree[0].children[0].children[0].id, 'b')
+  })
+  it('promotes orphans to roots and breaks cycles', () => {
+    assert.equal(buildGoalTree([G('x', 'ghost')]).length, 1)
+    const cyc = buildGoalTree([G('a', 'b'), G('b', 'a')])
+    assert.equal(cyc.length + cyc[0].children.length, 2)  // no infinite loop, both present
+  })
+})
+
+describe('[MCA-PC B1] goalAncestry', () => {
+  it('returns ordered root→leaf inclusive', () => {
+    const goals = [G('root'), G('mid', 'root'), G('leaf', 'mid')]
+    assert.deepEqual(goalAncestry(goals, 'leaf').map(g => g.id), ['root', 'mid', 'leaf'])
+  })
+  it('handles missing id', () => assert.deepEqual(goalAncestry([G('a')], 'nope'), []))
+})
+
+describe('[MCA-PC B1] formatGoalContext', () => {
+  it('includes mission, titles, and metrics', () => {
+    const out = formatGoalContext([G('root', null, { metric: '$1M MRR' }), G('leaf', 'root')], 'Win')
+    assert.match(out, /Company mission: Win/)
+    assert.match(out, /ROOT \[metric: \$1M MRR\]/)
+    assert.match(out, /LEAF/)
+  })
+  it('empty when nothing to say', () => assert.equal(formatGoalContext([], null), ''))
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -25,6 +25,7 @@ type CTask = { id: string; title: string; status: string; kanbanColumn: string; 
 type Cockpit = { agents: CAgent[]; tasks: CTask[]; summary: Record<string, number>; generatedAt: string }
 type OrgNode = { id: string; name: string; role: string; title?: string | null; runtime?: string; avatarEmoji?: string | null; status?: string; children: OrgNode[] }
 type InboxItem = { taskId: string; title: string; kind: string; priority: string; agentName: string; agentEmoji: string }
+type GoalNode = { id: string; title: string; metric?: string | null; status?: string; children: GoalNode[] }
 
 const HB: Record<string, string> = { green: '#22c55e', amber: '#f59e0b', stale: '#ef4444', unknown: '#555' }
 const STATUS_C: Record<string, string> = { idle: '#888', active: '#22c55e', external: '#a96bff' }
@@ -44,19 +45,22 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const [data, setData] = useState<Cockpit | null>(null)
   const [chart, setChart] = useState<OrgNode[] | null>(null)
   const [inbox, setInbox] = useState<InboxItem[]>([])
+  const [goals, setGoals] = useState<GoalNode[] | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [wizard, setWizard] = useState(false)
   const [hire, setHire] = useState(false)
+  const [goalDlg, setGoalDlg] = useState(false)
 
   const load = useCallback(async () => {
     try {
       const tok = await getToken()
-      const [c, oc, ib] = await Promise.all([
+      const [c, oc, ib, gl] = await Promise.all([
         call<Cockpit>(`/api/orgs/${orgId}/cockpit`, tok),
         call<{ tree: OrgNode[] }>(`/api/orgs/${orgId}/orgchart`, tok),
         call<{ items: InboxItem[] }>(`/api/orgs/${orgId}/inbox`, tok),
+        call<{ tree: GoalNode[] }>(`/api/orgs/${orgId}/goals`, tok),
       ])
-      setData(c); setChart(oc.tree); setInbox(ib.items); setErr(null)
+      setData(c); setChart(oc.tree); setInbox(ib.items); setGoals(gl.tree); setErr(null)
     } catch (e: any) { setErr(e?.message ?? 'Failed to load') }
   }, [orgId, getToken])
 
@@ -137,6 +141,16 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         {!chart && <p style={{ color: '#555', fontSize: 12 }}>Loading…</p>}
       </div>
 
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h2 style={s.h2}>Goals</h2>
+        <button style={s.ghostBtn} onClick={() => setGoalDlg(true)}>＋ Goal</button>
+      </div>
+      <div style={s.panel}>
+        {(goals ?? []).map(g => <GoalNodeRow key={g.id} node={g} depth={0} />)}
+        {goals && goals.length === 0 && <p style={{ color: '#888', fontSize: 12.5 }}>No goals yet — add the company’s top-level goal so every task traces to a “why”.</p>}
+        {!goals && <p style={{ color: '#555', fontSize: 12 }}>Loading…</p>}
+      </div>
+
       <h2 style={s.h2}>Task board</h2>
       <div style={s.board}>
         {COLS.map(col => {
@@ -158,6 +172,67 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
 
       {wizard && <AddAgentWizard orgId={orgId} getToken={getToken} onClose={() => setWizard(false)} onDone={() => { setWizard(false); load() }} />}
       {hire && <HireDialog orgId={orgId} getToken={getToken} onClose={() => setHire(false)} onDone={() => { setHire(false); load() }} />}
+      {goalDlg && <GoalDialog orgId={orgId} getToken={getToken} goals={goals ?? []} onClose={() => setGoalDlg(false)} onDone={() => { setGoalDlg(false); load() }} />}
+    </div>
+  )
+}
+
+// ─── Goals (tree + new-goal dialog) ──────────────────────────────────────────
+
+function GoalNodeRow({ node, depth }: { node: GoalNode; depth: number }) {
+  return (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '5px 0', paddingLeft: depth * 22 }}>
+        {depth > 0 && <span style={{ color: '#444' }}>└─</span>}
+        <span>🎯</span>
+        <span style={{ fontWeight: 600, fontSize: 13 }}>{node.title}</span>
+        {node.metric && <span style={s.badge}>{node.metric}</span>}
+        {node.status && node.status !== 'active' && <span style={{ fontSize: 10, color: '#888' }}>{node.status}</span>}
+      </div>
+      {node.children.map(c => <GoalNodeRow key={c.id} node={c} depth={depth + 1} />)}
+    </>
+  )
+}
+
+function flattenGoals(nodes: GoalNode[], depth = 0, acc: { id: string; label: string }[] = []) {
+  for (const n of nodes) { acc.push({ id: n.id, label: `${'— '.repeat(depth)}${n.title}` }); flattenGoals(n.children, depth + 1, acc) }
+  return acc
+}
+
+function GoalDialog({ orgId, getToken, goals, onClose, onDone }: { orgId: string; getToken: Getter; goals: GoalNode[]; onClose: () => void; onDone: () => void }) {
+  const [f, setF] = useState({ title: '', metric: '', description: '', parentGoalId: '' })
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const opts = flattenGoals(goals)
+  const save = async () => {
+    if (!f.title.trim()) return
+    setBusy(true); setErr(null)
+    try {
+      await call(`/api/orgs/${orgId}/goals`, await getToken(), { method: 'POST', body: JSON.stringify({ title: f.title, metric: f.metric || undefined, description: f.description || undefined, parentGoalId: f.parentGoalId || undefined }) })
+      onDone()
+    } catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setBusy(false)
+  }
+  return (
+    <div style={s.modalWrap} onClick={onClose}>
+      <div style={s.modal} onClick={e => e.stopPropagation()}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h2 style={s.h2}>New goal</h2><button onClick={onClose} style={s.x}>✕</button>
+        </div>
+        <div style={s.form}>
+          <label style={s.lab}>Goal<input style={s.inp} autoFocus value={f.title} placeholder="Build the #1 AI note-taking app" onChange={e => setF({ ...f, title: e.target.value })} /></label>
+          <label style={s.lab}>Success metric<input style={s.inp} value={f.metric} placeholder="$1M MRR" onChange={e => setF({ ...f, metric: e.target.value })} /></label>
+          <label style={s.lab}>Parent goal
+            <select style={s.inp} value={f.parentGoalId} onChange={e => setF({ ...f, parentGoalId: e.target.value })}>
+              <option value="">— top level —</option>
+              {opts.map(o => <option key={o.id} value={o.id}>{o.label}</option>)}
+            </select>
+          </label>
+          <label style={s.lab}>Description<textarea style={{ ...s.inp, minHeight: 56 }} value={f.description} onChange={e => setF({ ...f, description: e.target.value })} /></label>
+        </div>
+        {err && <div style={s.errBox}>⚠ {err}</div>}
+        <button style={{ ...s.primaryBtn, marginTop: 14, opacity: busy ? 0.6 : 1 }} disabled={busy} onClick={save}>{busy ? 'Saving…' : 'Create goal'}</button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Phase B of the Paperclip-parity epic (MCA-34). Gives every task a traceable why.

- **Schema**: goals (parent_goal_id tree, metric, status, owner) + tasks.goal_id.
- **services/goals.ts** (pure): buildGoalTree, goalAncestry, formatGoalContext. 6 unit tests.
- **API**: goal CRUD + GET /orgs/:id/goals (tree).
- **Alignment**: the executor injects a task’s goal ancestry (+ company mission) as a GOAL ALIGNMENT block in the system prompt — Paperclip’s headline differentiator.
- **Cockpit**: Goals tree view + New goal dialog (title, success metric, parent goal, description).

329/329 backend tests, tsc clean, next build ok. Closes MCA-38.