### PR TITLE
Approvals & governance (MCA-PC B2)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -102,6 +102,19 @@ export const tasks = sqliteTable('tasks', {
   completedAt: integer('completed_at', { mode: 'timestamp' }),
 })
 
+export const approvalRequests = sqliteTable('approval_requests', {
+  id: text('id').primaryKey(),
+  orgId: text('org_id').notNull(),
+  type: text('type').notNull(),                       // spend | hire | external_action | ...
+  summary: text('summary').notNull(),
+  payload: text('payload', { mode: 'json' }).$type<Record<string, unknown>>(),
+  status: text('status').notNull().default('pending'), // pending | approved | rejected
+  requestedByAgentId: text('requested_by_agent_id'),
+  decidedBy: text('decided_by'),
+  decidedAt: integer('decided_at', { mode: 'timestamp' }),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+})
+
 export const goals = sqliteTable('goals', {
   id: text('id').primaryKey(),
   orgId: text('org_id').notNull(),

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -64,6 +64,9 @@ export async function setupDatabase() {
     `ALTER TABLE tasks ADD COLUMN goal_id TEXT`,
     `CREATE TABLE IF NOT EXISTS goals (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, parent_goal_id TEXT, title TEXT NOT NULL, description TEXT, metric TEXT, status TEXT NOT NULL DEFAULT 'active', owner_agent_id TEXT, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_goals_org ON goals(org_id)`,
+    // MCA-PC B2: approvals & governance
+    `CREATE TABLE IF NOT EXISTS approval_requests (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, type TEXT NOT NULL, summary TEXT NOT NULL, payload TEXT, status TEXT NOT NULL DEFAULT 'pending', requested_by_agent_id TEXT, decided_by TEXT, decided_at INTEGER, created_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS idx_approvals_org ON approval_requests(org_id, status)`,
   ]
   for (const sql of alterStatements) {
     try { await dbClient.execute(sql) } catch { /* column already exists */ }

--- a/backend/src/routes/agent-api.ts
+++ b/backend/src/routes/agent-api.ts
@@ -101,6 +101,18 @@ export async function agentApiRoutes(app: FastifyInstance) {
     return { ok: true }
   })
 
+  // Request human sign-off for a sensitive action (MCA-PC B2).
+  app.post('/api/agent/approvals', async (req, reply) => {
+    const agent = (req as any).agent
+    const { type, summary, payload } = (req.body ?? {}) as any
+    if (!type || !summary) return reply.code(400).send({ error: 'type and summary required' })
+    await db.insert(schema.approvalRequests).values({
+      id: randomUUID(), orgId: agent.orgId, type, summary, payload: payload ?? null,
+      status: 'pending', requestedByAgentId: agent.id, decidedBy: null, decidedAt: null, createdAt: new Date(),
+    } as any)
+    return { ok: true }
+  })
+
   // Free-form progress / chatter message from the runtime.
   app.post('/api/agent/messages', async (req) => {
     const agent = (req as any).agent

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -249,6 +249,13 @@ export async function agentRoutes(app: FastifyInstance) {
     await db.update(schema.agents).set({ status }).where(eq(schema.agents.id, agentId))
     return { ok: true }
   })
+  // Governance controls (MCA-PC B2): pause / resume / terminate an agent.
+  for (const [verb, status] of [['pause', 'paused'], ['resume', 'idle'], ['terminate', 'terminated']] as const) {
+    app.post(`/api/agents/:agentId/${verb}`, async (req) => {
+      await db.update(schema.agents).set({ status }).where(eq(schema.agents.id, (req.params as any).agentId))
+      return { ok: true, status }
+    })
+  }
   app.delete('/api/agents/:agentId', async (req, reply) => {
     await db.delete(schema.agents).where(eq(schema.agents.id, (req.params as any).agentId))
     reply.code(204)
@@ -490,25 +497,27 @@ export async function taskRoutes(app: FastifyInstance) {
   app.get('/api/orgs/:orgId/inbox', async (req) => {
     const { orgId } = req.params as any
     const userId = (req as any).userId ?? 'anon'
-    const [tasks, dismissed, agents] = await Promise.all([
+    const [tasks, dismissed, agents, approvals] = await Promise.all([
       db.select(inboxCols).from(schema.tasks).where(eq(schema.tasks.orgId, orgId)).orderBy(desc(schema.tasks.createdAt)).limit(300),
       dismissedSet(orgId, userId),
       db.select({ id: schema.agents.id, name: schema.agents.name, avatarEmoji: schema.agents.avatarEmoji }).from(schema.agents).where(eq(schema.agents.orgId, orgId)),
+      db.select().from(schema.approvalRequests).where(and(eq(schema.approvalRequests.orgId, orgId), eq(schema.approvalRequests.status, 'pending'))).orderBy(desc(schema.approvalRequests.createdAt)).limit(50),
     ])
     const amap = new Map(agents.map(a => [a.id, a]))
     const items = buildInbox(tasks as any, dismissed).map(i => ({
       ...i, agentName: amap.get(i.agentId)?.name ?? '—', agentEmoji: amap.get(i.agentId)?.avatarEmoji ?? '🤖',
     }))
-    return { items, count: items.length }
+    return { items, approvals, count: items.length + approvals.length }
   })
   app.get('/api/orgs/:orgId/inbox/count', async (req) => {
     const { orgId } = req.params as any
     const userId = (req as any).userId ?? 'anon'
-    const [tasks, dismissed] = await Promise.all([
+    const [tasks, dismissed, pendingApprovals] = await Promise.all([
       db.select(inboxCols).from(schema.tasks).where(eq(schema.tasks.orgId, orgId)).limit(300),
       dismissedSet(orgId, userId),
+      db.select({ id: schema.approvalRequests.id }).from(schema.approvalRequests).where(and(eq(schema.approvalRequests.orgId, orgId), eq(schema.approvalRequests.status, 'pending'))),
     ])
-    return { count: buildInbox(tasks as any, dismissed).length }
+    return { count: buildInbox(tasks as any, dismissed).length + pendingApprovals.length }
   })
   app.post('/api/orgs/:orgId/inbox/dismiss', async (req, reply) => {
     const { orgId } = req.params as any
@@ -545,6 +554,30 @@ export async function taskRoutes(app: FastifyInstance) {
   app.delete('/api/goals/:goalId', async (req, reply) => {
     await db.delete(schema.goals).where(eq(schema.goals.id, (req.params as any).goalId))
     reply.code(204)
+  })
+
+  // ─── Approvals & governance (MCA-PC B2) ─────────────────────────────────
+  app.get('/api/orgs/:orgId/approvals', async (req) => {
+    const { orgId } = req.params as any
+    const status = (req.query as any)?.status
+    const conds = [eq(schema.approvalRequests.orgId, orgId)]
+    if (status) conds.push(eq(schema.approvalRequests.status, status))
+    return { approvals: await db.select().from(schema.approvalRequests).where(and(...conds)).orderBy(desc(schema.approvalRequests.createdAt)).limit(100) }
+  })
+  app.post('/api/orgs/:orgId/approvals', async (req, reply) => {
+    const { orgId } = req.params as any
+    const b = (req.body ?? {}) as any
+    if (!b.type || !b.summary) return reply.code(400).send({ error: 'type and summary are required' })
+    const approval = { id: randomUUID(), orgId, type: b.type, summary: b.summary, payload: b.payload ?? null, status: 'pending', requestedByAgentId: b.requestedByAgentId ?? null, decidedBy: null, decidedAt: null, createdAt: new Date() }
+    await db.insert(schema.approvalRequests).values(approval as any)
+    reply.code(201); return { approval }
+  })
+  app.post('/api/approvals/:id/decide', async (req, reply) => {
+    const { id } = req.params as any
+    const { decision } = (req.body ?? {}) as any
+    if (decision !== 'approved' && decision !== 'rejected') return reply.code(400).send({ error: 'decision must be approved|rejected' })
+    await db.update(schema.approvalRequests).set({ status: decision, decidedBy: (req as any).userId ?? 'human', decidedAt: new Date() }).where(eq(schema.approvalRequests.id, id))
+    return { approval: await db.query.approvalRequests.findFirst({ where: eq(schema.approvalRequests.id, id) }) }
   })
 
   app.get('/api/orgs/:orgId/tasks', async (req) => {

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -11,6 +11,7 @@ import { fireWebhook } from './outbound-webhooks'
 import { ensureFreshToken, searchDriveFiles } from './google-auth'
 import { isExternalAgent, notifyExternalAgent } from './agent-runtime'
 import { goalAncestry, formatGoalContext } from './goals'
+import { canAgentRun } from './governance'
 
 export interface ExecuteResult {
   output: string; tokensUsed: number; costUsd: number; durationMs: number
@@ -28,6 +29,13 @@ export async function executeAgentTask(opts: {
 
   const agent = await db.query.agents.findFirst({ where: eq(schema.agents.id, agentId) })
   if (!agent) throw new Error('Agent not found')
+
+  // MCA-PC B2: governance gate — paused/terminated agents do not execute.
+  if (!canAgentRun(agent.status)) {
+    await db.update(schema.tasks).set({ status: agent.status === 'terminated' ? 'failed' : 'pending' }).where(eq(schema.tasks.id, taskId))
+    const r: ExecuteResult = { output: `Agent is ${agent.status}; task not executed.`, tokensUsed: 0, costUsd: 0, durationMs: 0, provider: 'governance' }
+    onDone?.(r); return r
+  }
 
   // MCA-EXT: external / bring-your-own runtimes are not driven by the LLM here.
   // Assign the task and notify the runtime; it claims + posts results via the

--- a/backend/src/services/governance.ts
+++ b/backend/src/services/governance.ts
@@ -1,0 +1,33 @@
+// Governance & approvals (MCA-PC B2). Pure helpers: agent run-gating and
+// parsing of approval directives an agent can emit to request sign-off.
+
+export const TERMINAL_STATUS = ['terminated'] as const
+export const PAUSED_STATUS = ['paused'] as const
+
+/** Whether an agent in this status may execute work. */
+export function canAgentRun(status: string | null | undefined): boolean {
+  return status !== 'paused' && status !== 'terminated'
+}
+
+export interface ApprovalDirective { type: string; summary: string }
+
+// [APPROVAL: <type> | <summary>] — agents emit this to request human sign-off
+// for a sensitive/irreversible action (spend, external action, hire, etc.).
+const APPROVAL_RE = /\[APPROVAL:\s*([^|\]]+?)\s*\|\s*([^\]]+?)\s*\]/gi
+
+export function parseApprovalDirectives(output: string): ApprovalDirective[] {
+  const out: ApprovalDirective[] = []
+  let m: RegExpExecArray | null
+  APPROVAL_RE.lastIndex = 0
+  while ((m = APPROVAL_RE.exec(output ?? '')) !== null) {
+    out.push({ type: m[1].trim().toLowerCase().replace(/\s+/g, '_'), summary: m[2].trim() })
+  }
+  return out
+}
+
+export function stripApprovalDirectives(output: string): string {
+  return (output ?? '').replace(APPROVAL_RE, '').replace(/\n{3,}/g, '\n\n').trim()
+}
+
+export const APPROVAL_STATUS = ['pending', 'approved', 'rejected'] as const
+export type ApprovalStatus = (typeof APPROVAL_STATUS)[number]

--- a/backend/src/tests/governance.test.ts
+++ b/backend/src/tests/governance.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { canAgentRun, parseApprovalDirectives, stripApprovalDirectives } from '../services/governance.ts'
+
+describe('[MCA-PC B2] canAgentRun', () => {
+  it('blocks paused and terminated', () => {
+    assert.equal(canAgentRun('paused'), false)
+    assert.equal(canAgentRun('terminated'), false)
+  })
+  it('allows normal statuses', () => {
+    for (const s of ['idle', 'active', undefined, null]) assert.equal(canAgentRun(s as any), true)
+  })
+})
+
+describe('[MCA-PC B2] parseApprovalDirectives', () => {
+  it('parses type + summary and normalises the type', () => {
+    const d = parseApprovalDirectives('ok [APPROVAL: Spend | Buy $500 of ads] done')
+    assert.equal(d.length, 1)
+    assert.equal(d[0].type, 'spend')
+    assert.equal(d[0].summary, 'Buy $500 of ads')
+  })
+  it('parses multiple', () => {
+    assert.equal(parseApprovalDirectives('[APPROVAL: hire | a dev] [APPROVAL: external action | post tweet]').length, 2)
+  })
+  it('returns none when absent', () => {
+    assert.deepEqual(parseApprovalDirectives('no directives here'), [])
+  })
+  it('strips directives from visible output', () => {
+    assert.equal(stripApprovalDirectives('Plan ready. [APPROVAL: spend | x]'), 'Plan ready.')
+  })
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -26,6 +26,7 @@ type Cockpit = { agents: CAgent[]; tasks: CTask[]; summary: Record<string, numbe
 type OrgNode = { id: string; name: string; role: string; title?: string | null; runtime?: string; avatarEmoji?: string | null; status?: string; children: OrgNode[] }
 type InboxItem = { taskId: string; title: string; kind: string; priority: string; agentName: string; agentEmoji: string }
 type GoalNode = { id: string; title: string; metric?: string | null; status?: string; children: GoalNode[] }
+type Approval = { id: string; type: string; summary: string; status: string; requestedByAgentId?: string | null }
 
 const HB: Record<string, string> = { green: '#22c55e', amber: '#f59e0b', stale: '#ef4444', unknown: '#555' }
 const STATUS_C: Record<string, string> = { idle: '#888', active: '#22c55e', external: '#a96bff' }
@@ -45,6 +46,7 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const [data, setData] = useState<Cockpit | null>(null)
   const [chart, setChart] = useState<OrgNode[] | null>(null)
   const [inbox, setInbox] = useState<InboxItem[]>([])
+  const [approvals, setApprovals] = useState<Approval[]>([])
   const [goals, setGoals] = useState<GoalNode[] | null>(null)
   const [err, setErr] = useState<string | null>(null)
   const [wizard, setWizard] = useState(false)
@@ -57,16 +59,24 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
       const [c, oc, ib, gl] = await Promise.all([
         call<Cockpit>(`/api/orgs/${orgId}/cockpit`, tok),
         call<{ tree: OrgNode[] }>(`/api/orgs/${orgId}/orgchart`, tok),
-        call<{ items: InboxItem[] }>(`/api/orgs/${orgId}/inbox`, tok),
+        call<{ items: InboxItem[]; approvals: Approval[] }>(`/api/orgs/${orgId}/inbox`, tok),
         call<{ tree: GoalNode[] }>(`/api/orgs/${orgId}/goals`, tok),
       ])
-      setData(c); setChart(oc.tree); setInbox(ib.items); setGoals(gl.tree); setErr(null)
+      setData(c); setChart(oc.tree); setInbox(ib.items); setApprovals(ib.approvals ?? []); setGoals(gl.tree); setErr(null)
     } catch (e: any) { setErr(e?.message ?? 'Failed to load') }
   }, [orgId, getToken])
 
   const dismiss = async (taskId: string) => {
     setInbox(x => x.filter(i => i.taskId !== taskId))
     try { await call(`/api/orgs/${orgId}/inbox/dismiss`, await getToken(), { method: 'POST', body: JSON.stringify({ taskId }) }) } catch {}
+  }
+  const decide = async (id: string, decision: 'approved' | 'rejected') => {
+    setApprovals(x => x.filter(a => a.id !== id))
+    try { await call(`/api/approvals/${id}/decide`, await getToken(), { method: 'POST', body: JSON.stringify({ decision }) }) } catch {}
+  }
+  const agentControl = async (id: string, verb: 'pause' | 'resume' | 'terminate') => {
+    try { await call(`/api/agents/${id}/${verb}`, await getToken(), { method: 'POST' }) } catch {}
+    load()
   }
 
   useEffect(() => { load() }, [load])
@@ -79,7 +89,7 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
           <h1 style={s.h1}>Mission Control</h1>
-          {inbox.length > 0 && <span style={{ ...s.tag, background: '#211c08', color: '#FFB800' }}>📥 {inbox.length}</span>}
+          {(inbox.length + approvals.length) > 0 && <span style={{ ...s.tag, background: '#211c08', color: '#FFB800' }}>📥 {inbox.length + approvals.length}</span>}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <button onClick={load} style={s.ghostBtn}>↻ Refresh</button>
@@ -99,9 +109,17 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         ].map(k => <div key={k.l} style={s.statCard}><span style={{ ...s.statVal, color: k.c }}>{k.v}</span><span style={s.statLabel}>{k.l}</span></div>)}
       </div>
 
-      {inbox.length > 0 && (<>
-        <h2 style={s.h2}>Inbox <span style={s.colCount}>{inbox.length}</span></h2>
+      {(inbox.length + approvals.length) > 0 && (<>
+        <h2 style={s.h2}>Inbox <span style={s.colCount}>{inbox.length + approvals.length}</span></h2>
         <div style={s.panel}>
+          {approvals.map(a => (
+            <div key={a.id} style={s.inboxRow}>
+              <span style={{ ...s.tag, background: '#1a0f2a', color: '#a96bff' }}>Approval · {a.type}</span>
+              <div style={{ flex: 1, minWidth: 0 }}><div style={{ fontSize: 13, fontWeight: 560 }}>{a.summary}</div></div>
+              <button style={{ ...s.ghostBtn, color: '#22c55e' }} onClick={() => decide(a.id, 'approved')}>Approve</button>
+              <button style={{ ...s.ghostBtn, color: '#ff6b6b' }} onClick={() => decide(a.id, 'rejected')}>Reject</button>
+            </div>
+          ))}
           {inbox.map(i => (
             <div key={i.taskId} style={s.inboxRow}>
               <span style={{ ...s.tag, background: (KIND_C[i.kind] ?? KIND_C.attention).bg, color: (KIND_C[i.kind] ?? KIND_C.attention).fg }}>{KIND_LABEL[i.kind] ?? i.kind}</span>
@@ -128,7 +146,15 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
               <div style={{ fontSize: 12, color: '#888', marginTop: 2 }}>{a.role}</div>
               <div style={{ fontSize: 11, color: '#555', marginTop: 4 }}>{a.llmProvider} · {a.llmModel}</div>
             </div>
-            <span title={`heartbeat: ${a.heartbeat}`} style={{ width: 10, height: 10, borderRadius: 5, background: HB[a.heartbeat] ?? '#555', flexShrink: 0 }} />
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6, flexShrink: 0 }}>
+              <span title={`heartbeat: ${a.heartbeat}`} style={{ width: 10, height: 10, borderRadius: 5, background: a.status === 'terminated' ? '#444' : (HB[a.heartbeat] ?? '#555') }} />
+              <div style={{ display: 'flex', gap: 4 }}>
+                {a.status === 'paused'
+                  ? <button title="Resume" style={s.iconBtn} onClick={() => agentControl(a.id, 'resume')}>▶</button>
+                  : <button title="Pause" style={s.iconBtn} onClick={() => agentControl(a.id, 'pause')}>⏸</button>}
+                <button title="Terminate" style={s.iconBtn} onClick={() => agentControl(a.id, 'terminate')}>⏹</button>
+              </div>
+            </div>
           </div>
         ))}
         {data && data.agents.length === 0 && <p style={{ color: '#888' }}>No agents yet — add one.</p>}
@@ -446,6 +472,7 @@ const s: Record<string, React.CSSProperties> = {
   agentGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 12 },
   panel: { background: '#111', border: '1px solid #222', borderRadius: 12, padding: 16 },
   inboxRow: { display: 'flex', alignItems: 'center', gap: 10, padding: '10px 0', borderBottom: '1px solid #1a1a1a' },
+  iconBtn: { background: 'transparent', border: '1px solid #333', color: '#888', borderRadius: 6, padding: '1px 6px', fontSize: 11, cursor: 'pointer', lineHeight: 1.4 },
   agentCard: { background: '#111', border: '1px solid #222', borderRadius: 10, padding: 16, display: 'flex', alignItems: 'center', gap: 12 },
   badge: { fontSize: 10, color: '#aaa', background: '#1a1a1a', border: '1px solid #333', borderRadius: 6, padding: '1px 6px', fontWeight: 600 },
   board: { display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12 },


### PR DESCRIPTION
Phase B of the Paperclip-parity epic (MCA-34): operator control.

- **Schema**: approval_requests (type, summary, payload, status, requester, decider).
- **services/governance.ts** (pure): canAgentRun (gate), parseApprovalDirectives/stripApprovalDirectives. 6 unit tests.
- **API**: approvals list/create + POST /approvals/:id/decide; POST /agents/:id/{pause,resume,terminate}.
- **Gate**: executor refuses paused/terminated agents (task deferred or failed).
- **External**: POST /api/agent/approvals lets BYO runtimes request human sign-off.
- **Inbox**: pending approvals show in the unified inbox (count + list).
- **Cockpit**: Approve/Reject in the inbox + pause/resume/terminate on fleet cards.

335/335 backend tests, tsc clean, next build ok. Closes MCA-39.