### PR TITLE
Heartbeat engine (MCA-PC C1)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -66,6 +66,9 @@ export const agents = sqliteTable('agents', {
   reportsTo: text('reports_to'),                      // manager agent id
   title: text('title'),                              // job title (e.g. "Head of Engineering")
   jobDescription: text('job_description'),
+  // Heartbeat engine (MCA-PC C1)
+  heartbeatEverySec: integer('heartbeat_every_sec'),  // wake cadence; null = no auto-wake
+  nextWakeAt: integer('next_wake_at', { mode: 'timestamp' }),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -56,6 +56,9 @@ export async function setupDatabase() {
     `ALTER TABLE agents ADD COLUMN reports_to TEXT`,
     `ALTER TABLE agents ADD COLUMN title TEXT`,
     `ALTER TABLE agents ADD COLUMN job_description TEXT`,
+    // MCA-PC C1: heartbeat engine
+    `ALTER TABLE agents ADD COLUMN heartbeat_every_sec INTEGER`,
+    `ALTER TABLE agents ADD COLUMN next_wake_at INTEGER`,
     // MCA-PC A3: unified inbox
     `ALTER TABLE tasks ADD COLUMN inbox_state TEXT DEFAULT 'none'`,
     `CREATE TABLE IF NOT EXISTS inbox_dismissals (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, user_id TEXT NOT NULL, task_id TEXT NOT NULL, created_at INTEGER NOT NULL)`,

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -14,6 +14,7 @@ import { buildOrgChart } from '../services/orgchart'
 import { buildHirePrompt, parseHireProposal, isExternalRuntime } from '../services/hiring'
 import { buildInbox } from '../services/inbox'
 import { buildGoalTree } from '../services/goals'
+import { runHeartbeatSweep } from '../services/heartbeat-engine'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -571,6 +572,11 @@ export async function taskRoutes(app: FastifyInstance) {
     const approval = { id: randomUUID(), orgId, type: b.type, summary: b.summary, payload: b.payload ?? null, status: 'pending', requestedByAgentId: b.requestedByAgentId ?? null, decidedBy: null, decidedAt: null, createdAt: new Date() }
     await db.insert(schema.approvalRequests).values(approval as any)
     reply.code(201); return { approval }
+  })
+  // Heartbeat engine (MCA-PC C1): run a sweep on demand (orphan recovery + wakes).
+  app.post('/api/orgs/:orgId/heartbeat/sweep', async (req) => {
+    const { orgId } = req.params as any
+    return { result: await runHeartbeatSweep(orgId) }
   })
   app.post('/api/approvals/:id/decide', async (req, reply) => {
     const { id } = req.params as any

--- a/backend/src/services/heartbeat-engine.ts
+++ b/backend/src/services/heartbeat-engine.ts
@@ -1,0 +1,89 @@
+// Heartbeat engine (MCA-PC C1). A DB-backed wakeup sweep with per-agent
+// schedules, coalescing, agent-status recompute, and orphaned-run recovery.
+// Pure helpers are unit-tested; runHeartbeatSweep applies them against the DB.
+
+import { db, schema } from '../db/client'
+import { eq, and, inArray } from 'drizzle-orm'
+import { randomUUID } from 'crypto'
+import { canAgentRun } from './governance'
+import { isExternalAgent, heartbeatFreshness } from './agent-runtime'
+
+export const ORPHAN_STALE_MS = 30 * 60 * 1000  // in_progress > 30 min = orphaned
+
+export interface WakeAgent { id: string; status?: string | null; heartbeatEverySec?: number | null; nextWakeAt?: Date | number | null }
+
+/** Next wake timestamp (ms) for a cadence. */
+export function nextWake(nowMs: number, everySec: number): number {
+  return nowMs + Math.max(1, everySec) * 1000
+}
+
+/** Is the agent due for an auto-wake now? (has cadence, runnable, not already active, due). */
+export function dueForWake(agent: WakeAgent, nowMs: number): boolean {
+  const every = agent.heartbeatEverySec ?? 0
+  if (!every || every <= 0) return false
+  if (!canAgentRun(agent.status) || agent.status === 'active') return false
+  const next = agent.nextWakeAt == null ? null
+    : (agent.nextWakeAt instanceof Date ? agent.nextWakeAt.getTime() : Number(agent.nextWakeAt))
+  return next == null || next <= nowMs
+}
+
+export interface OrphanTask { id: string; status: string; createdAt: Date | number | null }
+
+/** Tasks stuck in_progress past staleMs (agent likely died) → to recover. */
+export function findOrphanedTaskIds(tasks: OrphanTask[], nowMs: number, staleMs = ORPHAN_STALE_MS): string[] {
+  return tasks.filter(t => {
+    if (t.status !== 'in_progress') return false
+    const ts = t.createdAt instanceof Date ? t.createdAt.getTime() : Number(t.createdAt ?? 0)
+    return nowMs - ts > staleMs
+  }).map(t => t.id)
+}
+
+export interface SweepResult { orphansRecovered: number; woken: number; statusUpdated: number }
+
+/** Run one heartbeat sweep. Scope to an org, or all orgs when omitted. */
+export async function runHeartbeatSweep(orgId?: string): Promise<SweepResult> {
+  const now = Date.now()
+  const res: SweepResult = { orphansRecovered: 0, woken: 0, statusUpdated: 0 }
+
+  const agents = await (orgId
+    ? db.select().from(schema.agents).where(eq(schema.agents.orgId, orgId))
+    : db.select().from(schema.agents))
+
+  // 1. Orphan recovery — reset stuck in_progress tasks for these agents.
+  const agentIds = agents.map(a => a.id)
+  if (agentIds.length) {
+    const inProgress = await db.select({ id: schema.tasks.id, status: schema.tasks.status, createdAt: schema.tasks.createdAt })
+      .from(schema.tasks).where(and(inArray(schema.tasks.agentId, agentIds), eq(schema.tasks.status, 'in_progress')))
+    const orphanIds = findOrphanedTaskIds(inProgress as any, now)
+    if (orphanIds.length) {
+      await db.update(schema.tasks).set({ status: 'pending', inboxState: 'needs_attention' } as any)
+        .where(inArray(schema.tasks.id, orphanIds))
+      res.orphansRecovered = orphanIds.length
+    }
+  }
+
+  for (const a of agents) {
+    // 2. Recompute external agent heartbeat freshness.
+    if (isExternalAgent(a)) {
+      const fresh = heartbeatFreshness(a.lastHeartbeatAt as any, now)
+      if (fresh !== a.heartbeatStatus) {
+        await db.update(schema.agents).set({ heartbeatStatus: fresh }).where(eq(schema.agents.id, a.id))
+        res.statusUpdated++
+      }
+    }
+    // 3. Wake due agents (coalesced) by enqueuing a heartbeat task.
+    if (dueForWake(a as any, now)) {
+      const external = isExternalAgent(a)
+      await db.insert(schema.tasks).values({
+        id: randomUUID(), orgId: a.orgId, agentId: a.id, assignedTo: a.id,
+        title: '[Heartbeat] check-in', input: 'Heartbeat wake: review your open work, make progress, and report.',
+        status: external ? 'assigned' : 'pending', priority: 'low',
+        kanbanColumn: external ? 'in_progress' : 'todo', createdAt: new Date(),
+      } as any)
+      await db.update(schema.agents).set({ nextWakeAt: new Date(nextWake(now, a.heartbeatEverySec ?? 3600)) })
+        .where(eq(schema.agents.id, a.id))
+      res.woken++
+    }
+  }
+  return res
+}

--- a/backend/src/services/scheduler.ts
+++ b/backend/src/services/scheduler.ts
@@ -11,6 +11,7 @@ import { eq, and, lte } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
 import { executeAgentTask } from './agent-executor'
 import { sendPushNotification } from '../routes/notifications'
+import { runHeartbeatSweep } from './heartbeat-engine'
 
 const TICK_INTERVAL_MS = 60_000  // check every minute
 let schedulerTimer: NodeJS.Timeout | null = null
@@ -42,6 +43,8 @@ async function runDueTasks() {
         console.error(`Scheduled task ${scheduled.id} failed:`, err)
       )
     }
+    // MCA-PC C1: heartbeat engine sweep (orphan recovery, status recompute, wakes).
+    runHeartbeatSweep().catch(err => console.error('Heartbeat sweep error:', err))
   } catch (err) {
     console.error('Scheduler tick error:', err)
   }

--- a/backend/src/tests/heartbeat-engine.test.ts
+++ b/backend/src/tests/heartbeat-engine.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { nextWake, dueForWake, findOrphanedTaskIds, ORPHAN_STALE_MS } from '../services/heartbeat-engine.ts'
+
+describe('[MCA-PC C1] nextWake', () => {
+  it('adds cadence seconds', () => assert.equal(nextWake(1000, 60), 1000 + 60_000))
+})
+
+describe('[MCA-PC C1] dueForWake', () => {
+  const now = 1_000_000
+  it('false without a cadence', () => assert.equal(dueForWake({ id: 'a', status: 'idle' }, now), false))
+  it('true when due and idle', () => assert.equal(dueForWake({ id: 'a', status: 'idle', heartbeatEverySec: 60, nextWakeAt: now - 1 }, now), true))
+  it('true when nextWakeAt is null', () => assert.equal(dueForWake({ id: 'a', status: 'idle', heartbeatEverySec: 60, nextWakeAt: null }, now), true))
+  it('false when not yet due', () => assert.equal(dueForWake({ id: 'a', status: 'idle', heartbeatEverySec: 60, nextWakeAt: now + 10_000 }, now), false))
+  it('false when active (coalescing)', () => assert.equal(dueForWake({ id: 'a', status: 'active', heartbeatEverySec: 60, nextWakeAt: now - 1 }, now), false))
+  it('false when paused/terminated', () => {
+    assert.equal(dueForWake({ id: 'a', status: 'paused', heartbeatEverySec: 60, nextWakeAt: 0 }, now), false)
+    assert.equal(dueForWake({ id: 'a', status: 'terminated', heartbeatEverySec: 60, nextWakeAt: 0 }, now), false)
+  })
+})
+
+describe('[MCA-PC C1] findOrphanedTaskIds', () => {
+  const now = 10 * ORPHAN_STALE_MS
+  it('flags stale in_progress tasks', () => {
+    const ids = findOrphanedTaskIds([
+      { id: 'old', status: 'in_progress', createdAt: now - ORPHAN_STALE_MS - 1 },
+      { id: 'fresh', status: 'in_progress', createdAt: now - 1000 },
+      { id: 'done', status: 'done', createdAt: 0 },
+    ], now)
+    assert.deepEqual(ids, ['old'])
+  })
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -78,6 +78,10 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
     try { await call(`/api/agents/${id}/${verb}`, await getToken(), { method: 'POST' }) } catch {}
     load()
   }
+  const sweep = async () => {
+    try { await call(`/api/orgs/${orgId}/heartbeat/sweep`, await getToken(), { method: 'POST' }) } catch {}
+    load()
+  }
 
   useEffect(() => { load() }, [load])
 
@@ -93,6 +97,7 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <button onClick={load} style={s.ghostBtn}>↻ Refresh</button>
+          <button onClick={sweep} style={s.ghostBtn} title="Run heartbeat engine: recover stalled tasks, refresh statuses, wake due agents">💓 Sweep</button>
           <button onClick={() => setHire(true)} style={s.ghostBtn}>✨ Hire with a prompt</button>
           <button onClick={() => setWizard(true)} style={s.primaryBtn}>＋ Add agent</button>
         </div>


### PR DESCRIPTION
Phase C of the Paperclip-parity epic (MCA-34): a DB-backed wakeup sweep.

- **Schema**: agents += heartbeat_every_sec, next_wake_at.
- **services/heartbeat-engine.ts** (pure-tested): dueForWake (coalescing — skips active/paused/terminated), nextWake, findOrphanedTaskIds; runHeartbeatSweep applies them: recovers orphaned in_progress tasks (>30m → pending + needs_attention), recomputes external agent heartbeat freshness, and wakes due agents (enqueues a heartbeat task; assigned for external, pending for internal). 8 unit tests.
- **Scheduler**: the 1-minute tick now runs the sweep; POST /orgs/:id/heartbeat/sweep triggers it on demand.
- **Cockpit**: a Sweep button.

343/343 backend tests, tsc clean, next build ok. Closes MCA-40.