### PR TITLE
Scoped budget policies (MCA-PC C2)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -105,6 +105,17 @@ export const tasks = sqliteTable('tasks', {
   completedAt: integer('completed_at', { mode: 'timestamp' }),
 })
 
+export const budgetPolicies = sqliteTable('budget_policies', {
+  id: text('id').primaryKey(),
+  orgId: text('org_id').notNull(),
+  scope: text('scope').notNull(),                     // company | agent | project | goal
+  scopeId: text('scope_id'),                          // null for company scope
+  limitUsd: real('limit_usd').notNull(),
+  warnPct: real('warn_pct').default(0.8),
+  hardStop: integer('hard_stop', { mode: 'boolean' }).default(true),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+})
+
 export const approvalRequests = sqliteTable('approval_requests', {
   id: text('id').primaryKey(),
   orgId: text('org_id').notNull(),

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -70,6 +70,9 @@ export async function setupDatabase() {
     // MCA-PC B2: approvals & governance
     `CREATE TABLE IF NOT EXISTS approval_requests (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, type TEXT NOT NULL, summary TEXT NOT NULL, payload TEXT, status TEXT NOT NULL DEFAULT 'pending', requested_by_agent_id TEXT, decided_by TEXT, decided_at INTEGER, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_approvals_org ON approval_requests(org_id, status)`,
+    // MCA-PC C2: scoped budget policies
+    `CREATE TABLE IF NOT EXISTS budget_policies (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, scope TEXT NOT NULL, scope_id TEXT, limit_usd REAL NOT NULL, warn_pct REAL DEFAULT 0.8, hard_stop INTEGER DEFAULT 1, created_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS idx_budget_policies_org ON budget_policies(org_id)`,
   ]
   for (const sql of alterStatements) {
     try { await dbClient.execute(sql) } catch { /* column already exists */ }

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -15,6 +15,7 @@ import { buildHirePrompt, parseHireProposal, isExternalRuntime } from '../servic
 import { buildInbox } from '../services/inbox'
 import { buildGoalTree } from '../services/goals'
 import { runHeartbeatSweep } from '../services/heartbeat-engine'
+import { spendForScope, evaluatePolicy } from '../services/budget'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -577,6 +578,33 @@ export async function taskRoutes(app: FastifyInstance) {
   app.post('/api/orgs/:orgId/heartbeat/sweep', async (req) => {
     const { orgId } = req.params as any
     return { result: await runHeartbeatSweep(orgId) }
+  })
+
+  // ─── Scoped budget policies (MCA-PC C2) ─────────────────────────────────
+  app.get('/api/orgs/:orgId/budgets', async (req) => {
+    const { orgId } = req.params as any
+    const [policies, tasks] = await Promise.all([
+      db.select().from(schema.budgetPolicies).where(eq(schema.budgetPolicies.orgId, orgId)),
+      db.select({ costUsd: schema.tasks.costUsd, agentId: schema.tasks.agentId, projectId: schema.tasks.projectId, goalId: schema.tasks.goalId }).from(schema.tasks).where(eq(schema.tasks.orgId, orgId)),
+    ])
+    const budgets = policies.map(p => {
+      const spend = spendForScope(tasks as any, p.scope as any, p.scope === 'company' ? null : p.scopeId)
+      const ev = evaluatePolicy(p as any, spend)
+      return { ...p, spend, state: ev.state, pct: ev.pct }
+    })
+    return { budgets }
+  })
+  app.post('/api/orgs/:orgId/budgets', async (req, reply) => {
+    const { orgId } = req.params as any
+    const b = (req.body ?? {}) as any
+    if (!b.scope || b.limitUsd == null) return reply.code(400).send({ error: 'scope and limitUsd required' })
+    const policy = { id: randomUUID(), orgId, scope: b.scope, scopeId: b.scopeId ?? null, limitUsd: Number(b.limitUsd), warnPct: b.warnPct ?? 0.8, hardStop: b.hardStop ?? true, createdAt: new Date() }
+    await db.insert(schema.budgetPolicies).values(policy as any)
+    reply.code(201); return { policy }
+  })
+  app.delete('/api/budgets/:id', async (req, reply) => {
+    await db.delete(schema.budgetPolicies).where(eq(schema.budgetPolicies.id, (req.params as any).id))
+    reply.code(204)
   })
   app.post('/api/approvals/:id/decide', async (req, reply) => {
     const { id } = req.params as any

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -12,6 +12,7 @@ import { ensureFreshToken, searchDriveFiles } from './google-auth'
 import { isExternalAgent, notifyExternalAgent } from './agent-runtime'
 import { goalAncestry, formatGoalContext } from './goals'
 import { canAgentRun } from './governance'
+import { enforceAgentBudget } from './budget'
 
 export interface ExecuteResult {
   output: string; tokensUsed: number; costUsd: number; durationMs: number
@@ -35,6 +36,17 @@ export async function executeAgentTask(opts: {
     await db.update(schema.tasks).set({ status: agent.status === 'terminated' ? 'failed' : 'pending' }).where(eq(schema.tasks.id, taskId))
     const r: ExecuteResult = { output: `Agent is ${agent.status}; task not executed.`, tokensUsed: 0, costUsd: 0, durationMs: 0, provider: 'governance' }
     onDone?.(r); return r
+  }
+
+  // MCA-PC C2: scoped budget hard-stop — pause the agent and block on breach.
+  {
+    const t0 = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+    const budget = await enforceAgentBudget(agent.orgId, agent.id, { projectId: t0?.projectId, goalId: t0?.goalId })
+    if (budget.blocked) {
+      await db.update(schema.tasks).set({ status: 'blocked', inboxState: 'needs_attention', output: budget.reason } as any).where(eq(schema.tasks.id, taskId))
+      const r: ExecuteResult = { output: budget.reason ?? 'Budget hard-stop.', tokensUsed: 0, costUsd: 0, durationMs: 0, provider: 'budget' }
+      onDone?.(r); return r
+    }
   }
 
   // MCA-EXT: external / bring-your-own runtimes are not driven by the LLM here.

--- a/backend/src/services/budget.ts
+++ b/backend/src/services/budget.ts
@@ -1,0 +1,74 @@
+// Scoped budget policies (MCA-PC C2). Pure helpers to compute spend per scope
+// and evaluate policies; runtime enforcement pauses agents on a hard-stop breach.
+
+import { db, schema } from '../db/client'
+import { eq, and } from 'drizzle-orm'
+
+export type BudgetScope = 'company' | 'agent' | 'project' | 'goal'
+export interface BudgetPolicy {
+  id: string; scope: BudgetScope; scopeId?: string | null
+  limitUsd: number; warnPct?: number | null; hardStop?: boolean | number | null
+}
+export interface CostTask { costUsd?: number | null; agentId?: string | null; projectId?: string | null; goalId?: string | null }
+export type BudgetState = 'ok' | 'warn' | 'breach'
+
+/** Total spend (USD) of tasks within a scope. */
+export function spendForScope(tasks: CostTask[], scope: BudgetScope, scopeId?: string | null): number {
+  const key = scope === 'agent' ? 'agentId' : scope === 'project' ? 'projectId' : scope === 'goal' ? 'goalId' : null
+  let sum = 0
+  for (const t of tasks) {
+    if (key && (t as any)[key] !== scopeId) continue   // company scope (key=null) counts all
+    sum += Number(t.costUsd ?? 0)
+  }
+  return sum
+}
+
+/** Policies that apply to a task context (company always; others by id match). */
+export function applicablePolicies(policies: BudgetPolicy[], ctx: { agentId?: string | null; projectId?: string | null; goalId?: string | null }): BudgetPolicy[] {
+  return policies.filter(p => {
+    if (p.scope === 'company') return true
+    if (p.scope === 'agent') return p.scopeId === ctx.agentId
+    if (p.scope === 'project') return !!ctx.projectId && p.scopeId === ctx.projectId
+    if (p.scope === 'goal') return !!ctx.goalId && p.scopeId === ctx.goalId
+    return false
+  })
+}
+
+/** Evaluate one policy against current spend. */
+export function evaluatePolicy(policy: BudgetPolicy, spend: number): { state: BudgetState; pct: number } {
+  const limit = Number(policy.limitUsd) || 0
+  if (limit <= 0) return { state: 'ok', pct: 0 }
+  const pct = spend / limit
+  const warn = policy.warnPct == null ? 0.8 : Number(policy.warnPct)
+  if (pct >= 1) return { state: 'breach', pct }
+  if (pct >= warn) return { state: 'warn', pct }
+  return { state: 'ok', pct }
+}
+
+const RANK: Record<BudgetState, number> = { ok: 0, warn: 1, breach: 2 }
+export function worstState(states: BudgetState[]): BudgetState {
+  return states.reduce<BudgetState>((w, s) => (RANK[s] > RANK[w] ? s : w), 'ok')
+}
+export const isHardStop = (p: BudgetPolicy) => p.hardStop === true || p.hardStop === 1
+
+/** Enforce policies for an agent's upcoming task. On a hard-stop breach, pause
+ *  the agent and return blocked. Best-effort; never throws. */
+export async function enforceAgentBudget(orgId: string, agentId: string, ctx: { projectId?: string | null; goalId?: string | null }): Promise<{ blocked: boolean; reason?: string }> {
+  try {
+    const policies = await db.select().from(schema.budgetPolicies).where(eq(schema.budgetPolicies.orgId, orgId)) as any as BudgetPolicy[]
+    if (!policies.length) return { blocked: false }
+    const tasks = await db.select({ costUsd: schema.tasks.costUsd, agentId: schema.tasks.agentId, projectId: schema.tasks.projectId, goalId: schema.tasks.goalId })
+      .from(schema.tasks).where(eq(schema.tasks.orgId, orgId)) as CostTask[]
+    for (const p of applicablePolicies(policies, { agentId, projectId: ctx.projectId, goalId: ctx.goalId })) {
+      const spend = spendForScope(tasks, p.scope, p.scope === 'company' ? null : p.scopeId)
+      const { state } = evaluatePolicy(p, spend)
+      if (state === 'breach' && isHardStop(p)) {
+        await db.update(schema.agents).set({ status: 'paused' }).where(eq(schema.agents.id, agentId))
+        return { blocked: true, reason: `Budget hard-stop: ${p.scope} limit $${p.limitUsd} reached (spent $${spend.toFixed(2)}). Agent paused.` }
+      }
+    }
+    return { blocked: false }
+  } catch {
+    return { blocked: false }
+  }
+}

--- a/backend/src/tests/budget.test.ts
+++ b/backend/src/tests/budget.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { spendForScope, applicablePolicies, evaluatePolicy, worstState } from '../services/budget.ts'
+
+const tasks = [
+  { costUsd: 1, agentId: 'a1', projectId: 'p1', goalId: 'g1' },
+  { costUsd: 2, agentId: 'a2', projectId: 'p1', goalId: null },
+  { costUsd: 4, agentId: 'a1', projectId: null, goalId: 'g1' },
+]
+
+describe('[MCA-PC C2] spendForScope', () => {
+  it('company sums everything', () => assert.equal(spendForScope(tasks, 'company'), 7))
+  it('agent scope filters by agentId', () => assert.equal(spendForScope(tasks, 'agent', 'a1'), 5))
+  it('project scope filters by projectId', () => assert.equal(spendForScope(tasks, 'project', 'p1'), 3))
+  it('goal scope filters by goalId', () => assert.equal(spendForScope(tasks, 'goal', 'g1'), 5))
+})
+
+describe('[MCA-PC C2] applicablePolicies', () => {
+  const policies = [
+    { id: '1', scope: 'company' as const, limitUsd: 10 },
+    { id: '2', scope: 'agent' as const, scopeId: 'a1', limitUsd: 5 },
+    { id: '3', scope: 'agent' as const, scopeId: 'a2', limitUsd: 5 },
+    { id: '4', scope: 'goal' as const, scopeId: 'g1', limitUsd: 3 },
+  ]
+  it('matches company + agent + goal for a1/g1', () => {
+    const ap = applicablePolicies(policies, { agentId: 'a1', projectId: null, goalId: 'g1' })
+    assert.deepEqual(ap.map(p => p.id).sort(), ['1', '2', '4'])
+  })
+})
+
+describe('[MCA-PC C2] evaluatePolicy', () => {
+  it('ok / warn / breach by pct', () => {
+    assert.equal(evaluatePolicy({ id: '1', scope: 'company', limitUsd: 100 }, 50).state, 'ok')
+    assert.equal(evaluatePolicy({ id: '1', scope: 'company', limitUsd: 100 }, 85).state, 'warn')
+    assert.equal(evaluatePolicy({ id: '1', scope: 'company', limitUsd: 100 }, 100).state, 'breach')
+  })
+  it('respects custom warnPct', () => {
+    assert.equal(evaluatePolicy({ id: '1', scope: 'company', limitUsd: 100, warnPct: 0.5 }, 60).state, 'warn')
+  })
+  it('zero limit is always ok', () => assert.equal(evaluatePolicy({ id: '1', scope: 'company', limitUsd: 0 }, 99).state, 'ok'))
+})
+
+describe('[MCA-PC C2] worstState', () => {
+  it('returns the most severe', () => {
+    assert.equal(worstState(['ok', 'warn', 'breach']), 'breach')
+    assert.equal(worstState(['ok', 'warn']), 'warn')
+    assert.equal(worstState(['ok']), 'ok')
+  })
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -27,6 +27,7 @@ type OrgNode = { id: string; name: string; role: string; title?: string | null; 
 type InboxItem = { taskId: string; title: string; kind: string; priority: string; agentName: string; agentEmoji: string }
 type GoalNode = { id: string; title: string; metric?: string | null; status?: string; children: GoalNode[] }
 type Approval = { id: string; type: string; summary: string; status: string; requestedByAgentId?: string | null }
+type Budget = { id: string; scope: string; scopeId?: string | null; limitUsd: number; spend: number; state: string; pct: number }
 
 const HB: Record<string, string> = { green: '#22c55e', amber: '#f59e0b', stale: '#ef4444', unknown: '#555' }
 const STATUS_C: Record<string, string> = { idle: '#888', active: '#22c55e', external: '#a96bff' }
@@ -48,21 +49,24 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const [inbox, setInbox] = useState<InboxItem[]>([])
   const [approvals, setApprovals] = useState<Approval[]>([])
   const [goals, setGoals] = useState<GoalNode[] | null>(null)
+  const [budgets, setBudgets] = useState<Budget[]>([])
   const [err, setErr] = useState<string | null>(null)
   const [wizard, setWizard] = useState(false)
   const [hire, setHire] = useState(false)
   const [goalDlg, setGoalDlg] = useState(false)
+  const [budgetDlg, setBudgetDlg] = useState(false)
 
   const load = useCallback(async () => {
     try {
       const tok = await getToken()
-      const [c, oc, ib, gl] = await Promise.all([
+      const [c, oc, ib, gl, bd] = await Promise.all([
         call<Cockpit>(`/api/orgs/${orgId}/cockpit`, tok),
         call<{ tree: OrgNode[] }>(`/api/orgs/${orgId}/orgchart`, tok),
         call<{ items: InboxItem[]; approvals: Approval[] }>(`/api/orgs/${orgId}/inbox`, tok),
         call<{ tree: GoalNode[] }>(`/api/orgs/${orgId}/goals`, tok),
+        call<{ budgets: Budget[] }>(`/api/orgs/${orgId}/budgets`, tok),
       ])
-      setData(c); setChart(oc.tree); setInbox(ib.items); setApprovals(ib.approvals ?? []); setGoals(gl.tree); setErr(null)
+      setData(c); setChart(oc.tree); setInbox(ib.items); setApprovals(ib.approvals ?? []); setGoals(gl.tree); setBudgets(bd.budgets ?? []); setErr(null)
     } catch (e: any) { setErr(e?.message ?? 'Failed to load') }
   }, [orgId, getToken])
 
@@ -81,6 +85,10 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const sweep = async () => {
     try { await call(`/api/orgs/${orgId}/heartbeat/sweep`, await getToken(), { method: 'POST' }) } catch {}
     load()
+  }
+  const delBudget = async (id: string) => {
+    setBudgets(x => x.filter(b => b.id !== id))
+    try { await call(`/api/budgets/${id}`, await getToken(), { method: 'DELETE' }) } catch {}
   }
 
   useEffect(() => { load() }, [load])
@@ -182,6 +190,25 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         {!goals && <p style={{ color: '#555', fontSize: 12 }}>Loading…</p>}
       </div>
 
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h2 style={s.h2}>Budgets</h2>
+        <button style={s.ghostBtn} onClick={() => setBudgetDlg(true)}>＋ Budget</button>
+      </div>
+      <div style={s.panel}>
+        {budgets.map(b => {
+          const c = b.state === 'breach' ? '#ff6b6b' : b.state === 'warn' ? '#FFB800' : '#22c55e'
+          return (
+            <div key={b.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '9px 0', borderBottom: '1px solid #1a1a1a' }}>
+              <div style={{ minWidth: 130, fontSize: 12.5 }}>{b.scope}{b.scopeId ? ` · ${b.scopeId.slice(0, 6)}` : ''}</div>
+              <div style={{ flex: 1, height: 8, background: '#1a1a1a', borderRadius: 4, overflow: 'hidden' }}><div style={{ height: '100%', width: `${Math.min(b.pct * 100, 100)}%`, background: c }} /></div>
+              <div style={{ minWidth: 120, textAlign: 'right', fontSize: 12, color: c }}>${b.spend.toFixed(2)} / ${b.limitUsd.toFixed(0)}</div>
+              <button style={s.iconBtn} onClick={() => delBudget(b.id)}>✕</button>
+            </div>
+          )
+        })}
+        {budgets.length === 0 && <p style={{ color: '#888', fontSize: 12.5 }}>No budgets — add a hard-stop to cap spend by company, agent, project, or goal.</p>}
+      </div>
+
       <h2 style={s.h2}>Task board</h2>
       <div style={s.board}>
         {COLS.map(col => {
@@ -204,6 +231,63 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
       {wizard && <AddAgentWizard orgId={orgId} getToken={getToken} onClose={() => setWizard(false)} onDone={() => { setWizard(false); load() }} />}
       {hire && <HireDialog orgId={orgId} getToken={getToken} onClose={() => setHire(false)} onDone={() => { setHire(false); load() }} />}
       {goalDlg && <GoalDialog orgId={orgId} getToken={getToken} goals={goals ?? []} onClose={() => setGoalDlg(false)} onDone={() => { setGoalDlg(false); load() }} />}
+      {budgetDlg && <BudgetDialog orgId={orgId} getToken={getToken} agents={data?.agents ?? []} onClose={() => setBudgetDlg(false)} onDone={() => { setBudgetDlg(false); load() }} />}
+    </div>
+  )
+}
+
+// ─── Budget policy dialog ────────────────────────────────────────────────────
+
+function BudgetDialog({ orgId, getToken, agents, onClose, onDone }: { orgId: string; getToken: Getter; agents: CAgent[]; onClose: () => void; onDone: () => void }) {
+  const [f, setF] = useState({ scope: 'company', scopeId: '', limitUsd: '', warnPct: '0.8', hardStop: true })
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const save = async () => {
+    if (!f.limitUsd) return
+    setBusy(true); setErr(null)
+    try {
+      await call(`/api/orgs/${orgId}/budgets`, await getToken(), { method: 'POST', body: JSON.stringify({ scope: f.scope, scopeId: f.scope === 'company' ? null : (f.scopeId || null), limitUsd: Number(f.limitUsd), warnPct: Number(f.warnPct), hardStop: f.hardStop }) })
+      onDone()
+    } catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setBusy(false)
+  }
+  return (
+    <div style={s.modalWrap} onClick={onClose}>
+      <div style={s.modal} onClick={e => e.stopPropagation()}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h2 style={s.h2}>New budget</h2><button onClick={onClose} style={s.x}>✕</button>
+        </div>
+        <div style={s.form}>
+          <label style={s.lab}>Scope
+            <select style={s.inp} value={f.scope} onChange={e => setF({ ...f, scope: e.target.value, scopeId: '' })}>
+              <option value="company">Company (all spend)</option>
+              <option value="agent">Agent</option>
+              <option value="project">Project</option>
+              <option value="goal">Goal</option>
+            </select>
+          </label>
+          {f.scope === 'agent' && (
+            <label style={s.lab}>Agent
+              <select style={s.inp} value={f.scopeId} onChange={e => setF({ ...f, scopeId: e.target.value })}>
+                <option value="">— pick —</option>
+                {agents.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+              </select>
+            </label>
+          )}
+          {(f.scope === 'project' || f.scope === 'goal') && (
+            <label style={s.lab}>{f.scope === 'project' ? 'Project' : 'Goal'} id<input style={s.inp} value={f.scopeId} onChange={e => setF({ ...f, scopeId: e.target.value })} /></label>
+          )}
+          <div style={{ display: 'flex', gap: 10 }}>
+            <label style={{ ...s.lab, flex: 1 }}>Limit (USD)<input style={s.inp} type="number" value={f.limitUsd} placeholder="100" onChange={e => setF({ ...f, limitUsd: e.target.value })} /></label>
+            <label style={{ ...s.lab, width: 110 }}>Warn at<input style={s.inp} type="number" step="0.05" value={f.warnPct} onChange={e => setF({ ...f, warnPct: e.target.value })} /></label>
+          </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12.5, color: '#aaa' }}>
+            <input type="checkbox" checked={f.hardStop} onChange={e => setF({ ...f, hardStop: e.target.checked })} /> Hard-stop (pause agents on breach)
+          </label>
+        </div>
+        {err && <div style={s.errBox}>⚠ {err}</div>}
+        <button style={{ ...s.primaryBtn, marginTop: 14, opacity: busy ? 0.6 : 1 }} disabled={busy} onClick={save}>{busy ? 'Saving…' : 'Create budget'}</button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Phase C of the Paperclip-parity epic (MCA-34): budgets with hard-stops.

- **Schema**: budget_policies (scope company|agent|project|goal, limitUsd, warnPct, hardStop).
- **services/budget.ts** (pure-tested): spendForScope, applicablePolicies, evaluatePolicy (ok/warn/breach), worstState. enforceAgentBudget pauses the agent + blocks the task on a hard-stop breach. 9 unit tests.
- **API**: budgets CRUD + GET /orgs/:id/budgets (live spend + state per policy).
- **Enforcement**: the executor checks applicable policies before running; overspend pauses the agent and blocks the task (surfacing in the inbox).
- **Cockpit**: Budgets panel (spend bars colored by state) + New budget dialog (scope, limit, warn %, hard-stop).

352/352 backend tests, tsc clean, next build ok. Closes MCA-41.