### PR TITLE
Routines+ webhook/API triggers (MCA-PC C3)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -186,6 +186,10 @@ export const scheduledTasks = sqliteTable('scheduled_tasks', {
   enabled: integer('enabled', { mode: 'boolean' }).default(true),
   lastRunAt: integer('last_run_at', { mode: 'timestamp' }),
   nextRunAt: integer('next_run_at', { mode: 'timestamp' }),
+  // Routines+ (MCA-PC C3): trigger sources beyond cron
+  triggerType: text('trigger_type').default('cron'),  // cron | webhook | api
+  webhookToken: text('webhook_token'),               // for webhook/api triggers
+  lastTriggeredAt: integer('last_triggered_at', { mode: 'timestamp' }),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -70,6 +70,10 @@ export async function setupDatabase() {
     // MCA-PC B2: approvals & governance
     `CREATE TABLE IF NOT EXISTS approval_requests (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, type TEXT NOT NULL, summary TEXT NOT NULL, payload TEXT, status TEXT NOT NULL DEFAULT 'pending', requested_by_agent_id TEXT, decided_by TEXT, decided_at INTEGER, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_approvals_org ON approval_requests(org_id, status)`,
+    // MCA-PC C3: routines+ triggers
+    `ALTER TABLE scheduled_tasks ADD COLUMN trigger_type TEXT DEFAULT 'cron'`,
+    `ALTER TABLE scheduled_tasks ADD COLUMN webhook_token TEXT`,
+    `ALTER TABLE scheduled_tasks ADD COLUMN last_triggered_at INTEGER`,
     // MCA-PC C2: scoped budget policies
     `CREATE TABLE IF NOT EXISTS budget_policies (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, scope TEXT NOT NULL, scope_id TEXT, limit_usd REAL NOT NULL, warn_pct REAL DEFAULT 0.8, hard_stop INTEGER DEFAULT 1, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_budget_policies_org ON budget_policies(org_id)`,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,7 +17,7 @@ import { memoryRoutes } from './routes/memory'
 import { multiOrgRoutes } from './routes/multi-org'
 import { usageRoutes } from './middleware/ratelimit'
 import { modelRoutes } from './routes/models'
-import { scheduledRoutes } from './routes/scheduled'
+import { scheduledRoutes, routineTriggerRoutes } from './routes/scheduled'
 import { webhookRoutes } from './routes/webhooks'
 import { telegramWebhookRoutes } from './routes/telegram-webhook'
 import { agentApiRoutes } from './routes/agent-api'
@@ -88,6 +88,8 @@ async function start() {
   // Agent-facing API (MCA-EXT): external runtimes authenticate with an agent
   // token via this plugin's own onRequest hook, not Clerk.
   await app.register(agentApiRoutes)
+  // Public routine webhook/API trigger (MCA-PC C3) — token-authenticated by URL.
+  await app.register(routineTriggerRoutes)
   await app.register(authRoutes)
   await app.register(telemetryPlugin)
   await app.register(auditLogPlugin)

--- a/backend/src/routes/scheduled.ts
+++ b/backend/src/routes/scheduled.ts
@@ -2,7 +2,8 @@ import { FastifyInstance } from 'fastify'
 import { db, schema } from '../db/client'
 import { eq, and } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
-import { calcNextRun } from '../services/scheduler'
+import { calcNextRun, fireRoutine } from '../services/scheduler'
+import { makeWebhookToken, normalizeTriggerType, cronSentinel } from '../services/routines'
 
 const COMMON_CRONS = [
   { label: 'Every hour',     cron: '0 * * * *' },
@@ -28,19 +29,23 @@ export async function scheduledRoutes(app: FastifyInstance) {
   // Create scheduled task
   app.post('/api/orgs/:orgId/scheduled', async (req, reply) => {
     const { orgId } = req.params as any
-    const { agentId, title, input, cronExpression } = req.body as any
-    if (!agentId || !title || !cronExpression) return reply.code(400).send({ error: 'agentId, title, cronExpression required' })
+    const b = req.body as any
+    const { agentId, title, input } = b
+    const triggerType = normalizeTriggerType(b.triggerType)
+    if (!agentId || !title) return reply.code(400).send({ error: 'agentId, title required' })
+    if (triggerType === 'cron' && !b.cronExpression) return reply.code(400).send({ error: 'cronExpression required for cron routines' })
 
-    const nextRunAt = calcNextRun(cronExpression)
+    const cronExpression = triggerType === 'cron' ? b.cronExpression : cronSentinel(triggerType)
+    const nextRunAt = triggerType === 'cron' ? calcNextRun(cronExpression) : null
+    const webhookToken = triggerType === 'cron' ? null : makeWebhookToken()
     const task = {
-      id: randomUUID(), orgId, agentId, title,
-      input: input ?? title, cronExpression,
-      enabled: true, lastRunAt: null, nextRunAt,
-      createdAt: new Date(),
+      id: randomUUID(), orgId, agentId, title, input: input ?? title, cronExpression,
+      enabled: true, lastRunAt: null, nextRunAt, triggerType, webhookToken,
+      lastTriggeredAt: null, createdAt: new Date(),
     }
-    await db.insert(schema.scheduledTasks).values(task)
+    await db.insert(schema.scheduledTasks).values(task as any)
     reply.code(201)
-    return { task: { ...task, nextRunAt: nextRunAt.toISOString() } }
+    return { task: { ...task, nextRunAt: nextRunAt?.toISOString() ?? null }, triggerUrl: webhookToken ? `/api/routines/${webhookToken}/trigger` : undefined }
   })
 
   // Update (enable/disable, change cron)
@@ -74,5 +79,17 @@ export async function scheduledRoutes(app: FastifyInstance) {
       const next = calcNextRun(cronExpression)
       return { next: next.toISOString(), cronExpression }
     } catch { return { error: 'Invalid cron expression' } }
+  })
+}
+
+// Public webhook/API trigger (MCA-PC C3) — fires a routine by its token, no Clerk
+// session. External systems POST here to run a routine on demand.
+export async function routineTriggerRoutes(app: FastifyInstance) {
+  app.post('/api/routines/:token/trigger', async (req, reply) => {
+    const { token } = req.params as any
+    const routine = await db.query.scheduledTasks.findFirst({ where: eq(schema.scheduledTasks.webhookToken, token) })
+    if (!routine || !routine.enabled) return reply.code(404).send({ error: 'Routine not found' })
+    const taskId = await fireRoutine(routine, new Date())
+    return { ok: true, taskId }
   })
 }

--- a/backend/src/services/routines.ts
+++ b/backend/src/services/routines.ts
@@ -1,0 +1,25 @@
+// Routines+ (MCA-PC C3). Pure helpers for trigger sources beyond cron
+// (webhook + API). Each trigger fires a routine which creates a tracked task.
+import { randomBytes } from 'crypto'
+
+export type TriggerType = 'cron' | 'webhook' | 'api'
+
+/** Opaque token used in the public webhook-trigger URL. */
+export function makeWebhookToken(): string {
+  return 'rt_' + randomBytes(24).toString('hex')
+}
+
+/** Whether a routine is fired by the cron scheduler (default/back-compat). */
+export function isCronTriggered(triggerType: string | null | undefined): boolean {
+  return !triggerType || triggerType === 'cron'
+}
+
+/** Validate a requested trigger type. */
+export function normalizeTriggerType(t: string | null | undefined): TriggerType {
+  return t === 'webhook' || t === 'api' ? t : 'cron'
+}
+
+/** Sentinel stored in the NOT NULL cron column for non-cron routines. */
+export function cronSentinel(triggerType: TriggerType): string {
+  return triggerType === 'cron' ? '' : `@${triggerType}`
+}

--- a/backend/src/services/scheduler.ts
+++ b/backend/src/services/scheduler.ts
@@ -51,39 +51,36 @@ async function runDueTasks() {
 }
 
 async function runScheduledTask(scheduled: any, triggerTime: Date) {
-  const taskId = randomUUID()
+  await fireRoutine(scheduled, triggerTime)
+}
 
-  // Create a task record
+// MCA-PC C3: fire a routine from any trigger (cron, webhook, or API). Creates a
+// tracked task, executes it, notifies, and advances the schedule (cron only).
+export async function fireRoutine(routine: any, triggerTime: Date): Promise<string> {
+  const taskId = randomUUID()
+  const label = routine.triggerType && routine.triggerType !== 'cron' ? 'Routine' : 'Scheduled'
+
   await db.insert(schema.tasks).values({
-    id: taskId,
-    orgId: scheduled.orgId,
-    agentId: scheduled.agentId,
-    title: `[Scheduled] ${scheduled.title}`,
-    input: scheduled.input ?? scheduled.title,
-    status: 'pending',
-    priority: 'medium',
-    createdAt: new Date(),
+    id: taskId, orgId: routine.orgId, agentId: routine.agentId,
+    title: `[${label}] ${routine.title}`, input: routine.input ?? routine.title,
+    status: 'pending', priority: 'medium', createdAt: new Date(),
   })
 
-  // Execute
   try {
-    await executeAgentTask({ agentId: scheduled.agentId, taskId, input: scheduled.input ?? scheduled.title })
+    await executeAgentTask({ agentId: routine.agentId, taskId, input: routine.input ?? routine.title })
   } catch (err) {
-    console.error(`Scheduled execution failed for ${scheduled.id}:`, err)
+    console.error(`Routine execution failed for ${routine.id}:`, err)
   }
 
-  // Notify org owner
-  const org = await db.query.organisations.findFirst({ where: eq(schema.organisations.id, scheduled.orgId) })
+  const org = await db.query.organisations.findFirst({ where: eq(schema.organisations.id, routine.orgId) })
   if (org?.ownerId) {
-    sendPushNotification(org.ownerId, `Scheduled task ran: ${scheduled.title}`, `Agent completed the scheduled task`, { taskId, scheduledId: scheduled.id }).catch(() => {})
+    sendPushNotification(org.ownerId, `Routine ran: ${routine.title}`, 'Agent completed the routine', { taskId, routineId: routine.id }).catch(() => {})
   }
 
-  // Update last/next run
-  const nextRun = calcNextRun(scheduled.cronExpression)
-  await db.update(schema.scheduledTasks).set({
-    lastRunAt: triggerTime,
-    nextRunAt: nextRun,
-  }).where(eq(schema.scheduledTasks.id, scheduled.id))
+  const update: any = { lastRunAt: triggerTime, lastTriggeredAt: triggerTime }
+  if (!routine.triggerType || routine.triggerType === 'cron') update.nextRunAt = calcNextRun(routine.cronExpression)
+  await db.update(schema.scheduledTasks).set(update).where(eq(schema.scheduledTasks.id, routine.id))
+  return taskId
 }
 
 // ─ Minimal cron parser ───────────────────────────────────────────────────────

--- a/backend/src/tests/routines.test.ts
+++ b/backend/src/tests/routines.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { makeWebhookToken, isCronTriggered, normalizeTriggerType, cronSentinel } from '../services/routines.ts'
+
+describe('[MCA-PC C3] makeWebhookToken', () => {
+  it('is rt_-prefixed and unique', () => {
+    const a = makeWebhookToken(), b = makeWebhookToken()
+    assert.match(a, /^rt_[0-9a-f]{48}$/)
+    assert.notEqual(a, b)
+  })
+})
+
+describe('[MCA-PC C3] isCronTriggered', () => {
+  it('true for cron / null (back-compat)', () => {
+    assert.equal(isCronTriggered('cron'), true)
+    assert.equal(isCronTriggered(null), true)
+    assert.equal(isCronTriggered(undefined), true)
+  })
+  it('false for webhook / api', () => {
+    assert.equal(isCronTriggered('webhook'), false)
+    assert.equal(isCronTriggered('api'), false)
+  })
+})
+
+describe('[MCA-PC C3] normalizeTriggerType / cronSentinel', () => {
+  it('normalizes unknown to cron', () => {
+    assert.equal(normalizeTriggerType('webhook'), 'webhook')
+    assert.equal(normalizeTriggerType('api'), 'api')
+    assert.equal(normalizeTriggerType('nonsense'), 'cron')
+  })
+  it('sentinel marks non-cron routines', () => {
+    assert.equal(cronSentinel('cron'), '')
+    assert.equal(cronSentinel('webhook'), '@webhook')
+    assert.equal(cronSentinel('api'), '@api')
+  })
+})


### PR DESCRIPTION
Phase C of the Paperclip-parity epic (MCA-34): routines beyond cron.

- **Schema**: scheduled_tasks += trigger_type (cron|webhook|api), webhook_token, last_triggered_at.
- **services/routines.ts** (pure-tested): makeWebhookToken, isCronTriggered, normalizeTriggerType, cronSentinel. 5 unit tests.
- **Scheduler**: refactored to an exported fireRoutine — every trigger (cron, webhook, or API) creates a tracked task, executes it, notifies, and advances the schedule (cron only). The 1-min cron tick is unchanged.
- **Create**: POST /orgs/:id/scheduled accepts triggerType; webhook/api routines get a token + trigger URL.
- **Public trigger**: POST /api/routines/:token/trigger fires a routine on demand (token-in-URL auth, no Clerk) — for external systems and API kicks.

357/357 backend tests, tsc clean. Closes MCA-42.