### PR TITLE
Company portability — export/import (MCA-PC D3)

### DIFF
--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -16,6 +16,7 @@ import { buildInbox } from '../services/inbox'
 import { buildGoalTree } from '../services/goals'
 import { runHeartbeatSweep } from '../services/heartbeat-engine'
 import { spendForScope, evaluatePolicy } from '../services/budget'
+import { buildExport, remapImport } from '../services/portability'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -605,6 +606,39 @@ export async function taskRoutes(app: FastifyInstance) {
   app.delete('/api/budgets/:id', async (req, reply) => {
     await db.delete(schema.budgetPolicies).where(eq(schema.budgetPolicies.id, (req.params as any).id))
     reply.code(204)
+  })
+
+  // ─── Company portability (MCA-PC D3) ────────────────────────────────────
+  app.get('/api/orgs/:orgId/export', async (req) => {
+    const { orgId } = req.params as any
+    const [org, agents, goals, budgets, routines] = await Promise.all([
+      db.query.organisations.findFirst({ where: eq(schema.organisations.id, orgId) }),
+      db.select().from(schema.agents).where(eq(schema.agents.orgId, orgId)),
+      db.select().from(schema.goals).where(eq(schema.goals.orgId, orgId)),
+      db.select().from(schema.budgetPolicies).where(eq(schema.budgetPolicies.orgId, orgId)),
+      db.select().from(schema.scheduledTasks).where(eq(schema.scheduledTasks.orgId, orgId)),
+    ])
+    return { bundle: buildExport({ org, agents, goals, budgets, routines }) }
+  })
+  app.post('/api/orgs/import', async (req, reply) => {
+    const body = (req.body ?? {}) as any
+    const bundle = body.bundle ?? body
+    if (!bundle?.org || !Array.isArray(bundle.agents)) return reply.code(400).send({ error: 'invalid bundle' })
+    const userId = (req as any).userId ?? 'system'
+    const newOrgId = randomUUID()
+    await db.insert(schema.organisations).values({
+      id: newOrgId, name: bundle.org.name ?? 'Imported Org', description: bundle.org.description ?? null,
+      mission: bundle.org.mission ?? null, culture: bundle.org.culture ?? null,
+      deployMode: bundle.org.deployMode ?? null, cloudProvider: bundle.org.cloudProvider ?? null,
+      preferredLlm: bundle.org.preferredLlm ?? null, ownerId: userId, createdAt: new Date(),
+    } as any)
+    const r = remapImport(bundle, newOrgId, () => randomUUID())
+    if (r.agents.length) await db.insert(schema.agents).values(r.agents as any)
+    if (r.goals.length) await db.insert(schema.goals).values(r.goals as any)
+    if (r.budgets.length) await db.insert(schema.budgetPolicies).values(r.budgets as any)
+    if (r.routines.length) await db.insert(schema.scheduledTasks).values(r.routines as any)
+    reply.code(201)
+    return { orgId: newOrgId, counts: { agents: r.agents.length, goals: r.goals.length, budgets: r.budgets.length, routines: r.routines.length } }
   })
   app.post('/api/approvals/:id/decide', async (req, reply) => {
     const { id } = req.params as any

--- a/backend/src/services/portability.ts
+++ b/backend/src/services/portability.ts
@@ -1,0 +1,64 @@
+// Company portability (MCA-PC D3). Export an org as a portable, secret-scrubbed
+// template; import remaps every id and reference into a fresh org.
+
+export interface ExportBundle {
+  version: number
+  org: Record<string, any>
+  agents: any[]
+  goals: any[]
+  budgets: any[]
+  routines: any[]
+}
+
+// Agent fields that are safe to carry between deployments (NO secrets/runtime state).
+const AGENT_FIELDS = ['name', 'role', 'title', 'jobDescription', 'personality', 'cv',
+  'termsOfReference', 'llmProvider', 'llmModel', 'skills', 'avatarEmoji', 'agentType',
+  'runtime', 'persona', 'expertise', 'advisorPersona', 'heartbeatEverySec'] as const
+
+const pick = (o: any, keys: readonly string[]) => Object.fromEntries(keys.filter(k => o?.[k] != null).map(k => [k, o[k]]))
+
+/** Build a portable bundle. Secrets (apiTokenHash, webhookToken, oauth, heartbeat
+ *  state, external endpoints) are omitted by construction. refId = original id. */
+export function buildExport(data: { org: any; agents: any[]; goals: any[]; budgets: any[]; routines: any[] }): ExportBundle {
+  return {
+    version: 1,
+    org: pick(data.org, ['name', 'description', 'mission', 'culture', 'deployMode', 'cloudProvider', 'preferredLlm']),
+    agents: data.agents.map(a => ({ refId: a.id, reportsTo: a.reportsTo ?? null, ...pick(a, AGENT_FIELDS) })),
+    goals: data.goals.map(g => ({ refId: g.id, title: g.title, description: g.description ?? null, metric: g.metric ?? null, status: g.status ?? 'active', parentGoalId: g.parentGoalId ?? null, ownerAgentId: g.ownerAgentId ?? null })),
+    budgets: data.budgets.map(b => ({ scope: b.scope, scopeId: b.scopeId ?? null, limitUsd: b.limitUsd, warnPct: b.warnPct ?? 0.8, hardStop: b.hardStop ?? true })),
+    routines: data.routines.map(r => ({ refId: r.id, title: r.title, input: r.input ?? null, cronExpression: r.cronExpression, triggerType: r.triggerType ?? 'cron', agentId: r.agentId, enabled: r.enabled ?? true })),
+  }
+}
+
+export interface RemapResult { agents: any[]; goals: any[]; budgets: any[]; routines: any[] }
+
+/** Remap a bundle into a new org: fresh ids, references rewired, collisions avoided.
+ *  genId supplies new ids (and webhook tokens); pure for deterministic testing. */
+export function remapImport(bundle: ExportBundle, newOrgId: string, genId: () => string): RemapResult {
+  const agentMap = new Map<string, string>()
+  for (const a of bundle.agents) agentMap.set(a.refId, genId())
+  const goalMap = new Map<string, string>()
+  for (const g of bundle.goals) goalMap.set(g.refId, genId())
+
+  const agents = bundle.agents.map(a => {
+    const { refId, reportsTo, ...rest } = a
+    return { id: agentMap.get(refId)!, orgId: newOrgId, ...rest, status: 'idle', reportsTo: reportsTo ? (agentMap.get(reportsTo) ?? null) : null, createdAt: new Date() }
+  })
+  const goals = bundle.goals.map(g => ({
+    id: goalMap.get(g.refId)!, orgId: newOrgId, title: g.title, description: g.description, metric: g.metric,
+    status: g.status ?? 'active', parentGoalId: g.parentGoalId ? (goalMap.get(g.parentGoalId) ?? null) : null,
+    ownerAgentId: g.ownerAgentId ? (agentMap.get(g.ownerAgentId) ?? null) : null, createdAt: new Date(),
+  }))
+  const budgets = bundle.budgets.map(b => ({
+    id: genId(), orgId: newOrgId, scope: b.scope,
+    scopeId: b.scope === 'agent' ? (agentMap.get(b.scopeId) ?? null) : b.scope === 'goal' ? (goalMap.get(b.scopeId) ?? null) : null,
+    limitUsd: b.limitUsd, warnPct: b.warnPct ?? 0.8, hardStop: b.hardStop ?? true, createdAt: new Date(),
+  }))
+  const routines = bundle.routines.map(r => {
+    const tt = r.triggerType ?? 'cron'
+    return { id: genId(), orgId: newOrgId, agentId: agentMap.get(r.agentId) ?? null, title: r.title, input: r.input ?? r.title,
+      cronExpression: r.cronExpression, triggerType: tt, webhookToken: tt === 'cron' ? null : genId(),
+      enabled: r.enabled ?? true, nextRunAt: null, lastRunAt: null, lastTriggeredAt: null, createdAt: new Date() }
+  })
+  return { agents, goals, budgets, routines }
+}

--- a/backend/src/tests/portability.test.ts
+++ b/backend/src/tests/portability.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildExport, remapImport } from '../services/portability.ts'
+
+const sample = {
+  org: { id: 'o1', name: 'Acme', mission: 'win', telegramBotToken: 'SECRET', ownerId: 'u1' },
+  agents: [
+    { id: 'ceo', name: 'CEO', role: 'CEO', reportsTo: null, apiTokenHash: 'HASH', llmProvider: 'anthropic', llmModel: 'm', skills: [] },
+    { id: 'eng', name: 'Eng', role: 'Engineer', reportsTo: 'ceo', externalEndpoint: 'http://x', heartbeatEverySec: 60 },
+  ],
+  goals: [{ id: 'g1', title: 'Root', parentGoalId: null, ownerAgentId: 'ceo' }, { id: 'g2', title: 'Sub', parentGoalId: 'g1', ownerAgentId: null }],
+  budgets: [{ scope: 'agent', scopeId: 'eng', limitUsd: 50, hardStop: true }, { scope: 'company', scopeId: null, limitUsd: 500 }],
+  routines: [{ id: 'r1', title: 'Daily', cronExpression: '0 8 * * *', triggerType: 'cron', agentId: 'eng', enabled: true, webhookToken: 'OLD' }],
+}
+
+describe('[MCA-PC D3] buildExport', () => {
+  const b = buildExport(sample as any)
+  it('scrubs secrets', () => {
+    assert.equal((b.org as any).telegramBotToken, undefined)
+    assert.equal((b.org as any).ownerId, undefined)
+    assert.equal((b.agents[0] as any).apiTokenHash, undefined)
+    assert.equal((b.agents[1] as any).externalEndpoint, undefined)
+    assert.equal((b.routines[0] as any).webhookToken, undefined)
+  })
+  it('keeps refIds and references', () => {
+    assert.equal(b.agents[1].refId, 'eng')
+    assert.equal(b.agents[1].reportsTo, 'ceo')
+    assert.equal(b.goals[1].parentGoalId, 'g1')
+  })
+})
+
+describe('[MCA-PC D3] remapImport', () => {
+  let n = 0
+  const gen = () => `new${n++}`
+  const r = remapImport(buildExport(sample as any), 'ORG2', gen)
+  it('remaps agent ids + reportsTo into the new org', () => {
+    const ceo = r.agents.find(a => a.name === 'CEO')!, eng = r.agents.find(a => a.name === 'Eng')!
+    assert.equal(eng.orgId, 'ORG2')
+    assert.equal(eng.reportsTo, ceo.id)
+    assert.notEqual(ceo.id, 'ceo')
+  })
+  it('remaps goal parent + owner refs', () => {
+    const root = r.goals.find(g => g.title === 'Root')!, sub = r.goals.find(g => g.title === 'Sub')!
+    assert.equal(sub.parentGoalId, root.id)
+    assert.equal(root.ownerAgentId, r.agents.find(a => a.name === 'CEO')!.id)
+  })
+  it('remaps agent-scoped budget; company budget stays null', () => {
+    const ab = r.budgets.find(b => b.scope === 'agent')!, cb = r.budgets.find(b => b.scope === 'company')!
+    assert.equal(ab.scopeId, r.agents.find(a => a.name === 'Eng')!.id)
+    assert.equal(cb.scopeId, null)
+  })
+  it('remaps routine agent + drops old token', () => {
+    assert.equal(r.routines[0].agentId, r.agents.find(a => a.name === 'Eng')!.id)
+    assert.equal(r.routines[0].webhookToken, null)  // cron → no token
+  })
+})


### PR DESCRIPTION
Phase D of the Paperclip-parity epic (MCA-34): reusable companies.

- **services/portability.ts** (pure-tested): buildExport produces a secret-scrubbed bundle (omits apiTokenHash, webhook tokens, oauth, heartbeat/runtime state, telegram token). remapImport assigns fresh ids and rewires every reference — reportsTo, parentGoalId, goal ownerAgentId, budget scopeId (agent/goal), routine agentId — and regenerates tokens. 6 unit tests.
- **API**: GET /api/orgs/:id/export → portable bundle; POST /api/orgs/import → creates a new org and inserts the remapped agents, goals, budgets, and routines.

This is the foundation for company templates (pairs with 7Ei_OS templates + the vault). 363/363 backend tests, tsc clean. Closes MCA-45.