### PR TITLE
Scoped secret store (MCA-PC D4)

### DIFF
--- a/adapters/openclaw/mc_adapter.py
+++ b/adapters/openclaw/mc_adapter.py
@@ -209,12 +209,24 @@ def poll_once():
     return len(tasks)
 
 
+def load_secrets():
+    """Fetch this agent's scoped secrets (MCA-PC D4) and inject them as env vars."""
+    code, data = _req("GET", "/api/agent/secrets")
+    if code == 200 and isinstance(data, dict):
+        secs = data.get("secrets", {}) or {}
+        for k, v in secs.items():
+            os.environ[str(k)] = str(v)
+        if secs:
+            print(f"  loaded {len(secs)} scoped secret(s) into env")
+
+
 def main():
     if not TOKEN:
         print("MC_AGENT_TOKEN is required", file=sys.stderr); sys.exit(2)
     mode = "llm" if choose_executor() is llm_execute else "shell"
     print(f"7Ei MC adapter → {BASE}  (executor={mode}, shell={'on' if ALLOW_SHELL else 'off'}, workdir={WORKDIR})")
     heartbeat("green")
+    load_secrets()
     if "--once" in sys.argv:
         n = poll_once(); print(f"processed {n} task(s)"); return
     while True:

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -105,6 +105,16 @@ export const tasks = sqliteTable('tasks', {
   completedAt: integer('completed_at', { mode: 'timestamp' }),
 })
 
+export const secrets = sqliteTable('secrets', {
+  id: text('id').primaryKey(),
+  orgId: text('org_id').notNull(),
+  scope: text('scope').notNull(),                     // company | agent
+  scopeId: text('scope_id'),                          // agent id for agent scope
+  key: text('key').notNull(),
+  valueEncrypted: text('value_encrypted').notNull(),  // AES-256-GCM
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+})
+
 export const budgetPolicies = sqliteTable('budget_policies', {
   id: text('id').primaryKey(),
   orgId: text('org_id').notNull(),

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -70,6 +70,9 @@ export async function setupDatabase() {
     // MCA-PC B2: approvals & governance
     `CREATE TABLE IF NOT EXISTS approval_requests (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, type TEXT NOT NULL, summary TEXT NOT NULL, payload TEXT, status TEXT NOT NULL DEFAULT 'pending', requested_by_agent_id TEXT, decided_by TEXT, decided_at INTEGER, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_approvals_org ON approval_requests(org_id, status)`,
+    // MCA-PC D4: scoped secret store
+    `CREATE TABLE IF NOT EXISTS secrets (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, scope TEXT NOT NULL, scope_id TEXT, key TEXT NOT NULL, value_encrypted TEXT NOT NULL, created_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS idx_secrets_org ON secrets(org_id)`,
     // MCA-PC C3: routines+ triggers
     `ALTER TABLE scheduled_tasks ADD COLUMN trigger_type TEXT DEFAULT 'cron'`,
     `ALTER TABLE scheduled_tasks ADD COLUMN webhook_token TEXT`,

--- a/backend/src/routes/agent-api.ts
+++ b/backend/src/routes/agent-api.ts
@@ -4,6 +4,7 @@ import { db, schema } from '../db/client'
 import { eq, and, inArray, desc } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
 import { agentAuth } from '../middleware/agent-token'
+import { decrypt, resolveSecretsForAgent } from '../services/secrets'
 
 // ─── AGENT-FACING API (MCA-EXT) ────────────────────────────────────────────
 //
@@ -36,6 +37,15 @@ export async function agentApiRoutes(app: FastifyInstance) {
         skills: a.skills ?? [],
       },
     }
+  })
+
+  // Scoped secrets for this runtime (MCA-PC D4) — decrypted, company+agent scope.
+  // Lets a BYO runtime inject secrets as env without ever putting them in a prompt.
+  app.get('/api/agent/secrets', async (req) => {
+    const agent = (req as any).agent
+    const rows = await db.select().from(schema.secrets).where(eq(schema.secrets.orgId, agent.orgId))
+    const decrypted = rows.map(s => { try { return { scope: s.scope, scopeId: s.scopeId, key: s.key, value: decrypt(s.valueEncrypted) } } catch { return null } }).filter(Boolean) as any[]
+    return { secrets: resolveSecretsForAgent(decrypted, agent.id) }
   })
 
   // Liveness/heartbeat — also returns who the runtime is authenticated as.

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -17,6 +17,7 @@ import { buildGoalTree } from '../services/goals'
 import { runHeartbeatSweep } from '../services/heartbeat-engine'
 import { spendForScope, evaluatePolicy } from '../services/budget'
 import { buildExport, remapImport } from '../services/portability'
+import { encrypt, decrypt, maskValue } from '../services/secrets'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -605,6 +606,27 @@ export async function taskRoutes(app: FastifyInstance) {
   })
   app.delete('/api/budgets/:id', async (req, reply) => {
     await db.delete(schema.budgetPolicies).where(eq(schema.budgetPolicies.id, (req.params as any).id))
+    reply.code(204)
+  })
+
+  // ─── Scoped secret store (MCA-PC D4) ────────────────────────────────────
+  app.get('/api/orgs/:orgId/secrets', async (req) => {
+    const { orgId } = req.params as any
+    const rows = await db.select().from(schema.secrets).where(eq(schema.secrets.orgId, orgId))
+    // Never return plaintext — only key, scope, and a masked hint.
+    return { secrets: rows.map(s => { let m = '••••'; try { m = maskValue(decrypt(s.valueEncrypted)) } catch {} ; return { id: s.id, scope: s.scope, scopeId: s.scopeId, key: s.key, masked: m } }) }
+  })
+  app.post('/api/orgs/:orgId/secrets', async (req, reply) => {
+    const { orgId } = req.params as any
+    const b = (req.body ?? {}) as any
+    if (!b.key || b.value == null) return reply.code(400).send({ error: 'key and value required' })
+    const scope = b.scope === 'agent' ? 'agent' : 'company'
+    const row = { id: randomUUID(), orgId, scope, scopeId: scope === 'agent' ? (b.scopeId ?? null) : null, key: b.key, valueEncrypted: encrypt(String(b.value)), createdAt: new Date() }
+    await db.insert(schema.secrets).values(row)
+    reply.code(201); return { secret: { id: row.id, scope: row.scope, scopeId: row.scopeId, key: row.key, masked: maskValue(String(b.value)) } }
+  })
+  app.delete('/api/secrets/:id', async (req, reply) => {
+    await db.delete(schema.secrets).where(eq(schema.secrets.id, (req.params as any).id))
     reply.code(204)
   })
 

--- a/backend/src/services/secrets.ts
+++ b/backend/src/services/secrets.ts
@@ -1,0 +1,38 @@
+// Scoped secret store (MCA-PC D4). AES-256-GCM at rest; scoped to company or
+// agent; injected into runs via the agent API — never into LLM prompts.
+import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'crypto'
+
+const KEY = createHash('sha256').update(process.env.SECRETS_ENC_KEY ?? 'dev-7ei-mc-secrets-key').digest() // 32 bytes
+
+/** Encrypt → "iv.tag.ciphertext" (all base64). */
+export function encrypt(plain: string): string {
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', KEY, iv)
+  const enc = Buffer.concat([cipher.update(String(plain), 'utf8'), cipher.final()])
+  return [iv.toString('base64'), cipher.getAuthTag().toString('base64'), enc.toString('base64')].join('.')
+}
+
+/** Decrypt an "iv.tag.ciphertext" blob. */
+export function decrypt(blob: string): string {
+  const [ivb, tagb, encb] = String(blob).split('.')
+  const decipher = createDecipheriv('aes-256-gcm', KEY, Buffer.from(ivb, 'base64'))
+  decipher.setAuthTag(Buffer.from(tagb, 'base64'))
+  return Buffer.concat([decipher.update(Buffer.from(encb, 'base64')), decipher.final()]).toString('utf8')
+}
+
+/** Mask a value for display — last 4 chars only. */
+export function maskValue(v: string): string {
+  const s = String(v ?? '')
+  return s.length <= 4 ? '••••' : '••••' + s.slice(-4)
+}
+
+export interface ScopedSecret { scope: string; scopeId?: string | null; key: string; value: string }
+
+/** Resolve the effective secrets for an agent: company scope first, then agent
+ *  scope overrides. Pure (takes already-decrypted values). */
+export function resolveSecretsForAgent(secrets: ScopedSecret[], agentId: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const s of secrets) if (s.scope === 'company') out[s.key] = s.value
+  for (const s of secrets) if (s.scope === 'agent' && s.scopeId === agentId) out[s.key] = s.value
+  return out
+}

--- a/backend/src/tests/secrets.test.ts
+++ b/backend/src/tests/secrets.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { encrypt, decrypt, maskValue, resolveSecretsForAgent } from '../services/secrets.ts'
+
+describe('[MCA-PC D4] encrypt/decrypt', () => {
+  it('round-trips and does not store plaintext', () => {
+    const v = 'sk-super-secret-123'
+    const blob = encrypt(v)
+    assert.notEqual(blob, v)
+    assert.ok(!blob.includes(v))
+    assert.equal(decrypt(blob), v)
+  })
+  it('produces a fresh IV each time (different ciphertext)', () => {
+    assert.notEqual(encrypt('x'), encrypt('x'))
+  })
+})
+
+describe('[MCA-PC D4] maskValue', () => {
+  it('shows only the last 4', () => {
+    assert.equal(maskValue('sk-abcd1234'), '••••1234')
+    assert.equal(maskValue('ab'), '••••')
+  })
+})
+
+describe('[MCA-PC D4] resolveSecretsForAgent', () => {
+  const secrets = [
+    { scope: 'company', key: 'OPENAI_KEY', value: 'co' },
+    { scope: 'company', key: 'SHARED', value: 'c' },
+    { scope: 'agent', scopeId: 'a1', key: 'SHARED', value: 'a' },
+    { scope: 'agent', scopeId: 'a2', key: 'OTHER', value: 'x' },
+  ]
+  it('agent scope overrides company; unrelated agent secrets excluded', () => {
+    const r = resolveSecretsForAgent(secrets, 'a1')
+    assert.equal(r.OPENAI_KEY, 'co')
+    assert.equal(r.SHARED, 'a')      // agent override
+    assert.equal(r.OTHER, undefined) // belongs to a2
+  })
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -28,6 +28,7 @@ type InboxItem = { taskId: string; title: string; kind: string; priority: string
 type GoalNode = { id: string; title: string; metric?: string | null; status?: string; children: GoalNode[] }
 type Approval = { id: string; type: string; summary: string; status: string; requestedByAgentId?: string | null }
 type Budget = { id: string; scope: string; scopeId?: string | null; limitUsd: number; spend: number; state: string; pct: number }
+type Secret = { id: string; scope: string; scopeId?: string | null; key: string; masked: string }
 
 const HB: Record<string, string> = { green: '#22c55e', amber: '#f59e0b', stale: '#ef4444', unknown: '#555' }
 const STATUS_C: Record<string, string> = { idle: '#888', active: '#22c55e', external: '#a96bff' }
@@ -50,23 +51,26 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const [approvals, setApprovals] = useState<Approval[]>([])
   const [goals, setGoals] = useState<GoalNode[] | null>(null)
   const [budgets, setBudgets] = useState<Budget[]>([])
+  const [secrets, setSecrets] = useState<Secret[]>([])
   const [err, setErr] = useState<string | null>(null)
   const [wizard, setWizard] = useState(false)
   const [hire, setHire] = useState(false)
   const [goalDlg, setGoalDlg] = useState(false)
   const [budgetDlg, setBudgetDlg] = useState(false)
+  const [secretDlg, setSecretDlg] = useState(false)
 
   const load = useCallback(async () => {
     try {
       const tok = await getToken()
-      const [c, oc, ib, gl, bd] = await Promise.all([
+      const [c, oc, ib, gl, bd, se] = await Promise.all([
         call<Cockpit>(`/api/orgs/${orgId}/cockpit`, tok),
         call<{ tree: OrgNode[] }>(`/api/orgs/${orgId}/orgchart`, tok),
         call<{ items: InboxItem[]; approvals: Approval[] }>(`/api/orgs/${orgId}/inbox`, tok),
         call<{ tree: GoalNode[] }>(`/api/orgs/${orgId}/goals`, tok),
         call<{ budgets: Budget[] }>(`/api/orgs/${orgId}/budgets`, tok),
+        call<{ secrets: Secret[] }>(`/api/orgs/${orgId}/secrets`, tok),
       ])
-      setData(c); setChart(oc.tree); setInbox(ib.items); setApprovals(ib.approvals ?? []); setGoals(gl.tree); setBudgets(bd.budgets ?? []); setErr(null)
+      setData(c); setChart(oc.tree); setInbox(ib.items); setApprovals(ib.approvals ?? []); setGoals(gl.tree); setBudgets(bd.budgets ?? []); setSecrets(se.secrets ?? []); setErr(null)
     } catch (e: any) { setErr(e?.message ?? 'Failed to load') }
   }, [orgId, getToken])
 
@@ -89,6 +93,10 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const delBudget = async (id: string) => {
     setBudgets(x => x.filter(b => b.id !== id))
     try { await call(`/api/budgets/${id}`, await getToken(), { method: 'DELETE' }) } catch {}
+  }
+  const delSecret = async (id: string) => {
+    setSecrets(x => x.filter(s => s.id !== id))
+    try { await call(`/api/secrets/${id}`, await getToken(), { method: 'DELETE' }) } catch {}
   }
 
   useEffect(() => { load() }, [load])
@@ -209,6 +217,22 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         {budgets.length === 0 && <p style={{ color: '#888', fontSize: 12.5 }}>No budgets — add a hard-stop to cap spend by company, agent, project, or goal.</p>}
       </div>
 
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h2 style={s.h2}>Secrets</h2>
+        <button style={s.ghostBtn} onClick={() => setSecretDlg(true)}>＋ Secret</button>
+      </div>
+      <div style={s.panel}>
+        {secrets.map(sec => (
+          <div key={sec.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '9px 0', borderBottom: '1px solid #1a1a1a' }}>
+            <span style={s.badge}>🔒 {sec.scope}{sec.scopeId ? ` · ${sec.scopeId.slice(0, 6)}` : ''}</span>
+            <div style={{ flex: 1, fontSize: 13, fontWeight: 560 }}>{sec.key}</div>
+            <code style={{ fontSize: 12, color: '#888' }}>{sec.masked}</code>
+            <button style={s.iconBtn} onClick={() => delSecret(sec.id)}>✕</button>
+          </div>
+        ))}
+        {secrets.length === 0 && <p style={{ color: '#888', fontSize: 12.5 }}>No secrets — store API keys here; runtimes fetch them scoped, never via prompts.</p>}
+      </div>
+
       <h2 style={s.h2}>Task board</h2>
       <div style={s.board}>
         {COLS.map(col => {
@@ -232,6 +256,54 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
       {hire && <HireDialog orgId={orgId} getToken={getToken} onClose={() => setHire(false)} onDone={() => { setHire(false); load() }} />}
       {goalDlg && <GoalDialog orgId={orgId} getToken={getToken} goals={goals ?? []} onClose={() => setGoalDlg(false)} onDone={() => { setGoalDlg(false); load() }} />}
       {budgetDlg && <BudgetDialog orgId={orgId} getToken={getToken} agents={data?.agents ?? []} onClose={() => setBudgetDlg(false)} onDone={() => { setBudgetDlg(false); load() }} />}
+      {secretDlg && <SecretDialog orgId={orgId} getToken={getToken} agents={data?.agents ?? []} onClose={() => setSecretDlg(false)} onDone={() => { setSecretDlg(false); load() }} />}
+    </div>
+  )
+}
+
+// ─── Secret dialog ───────────────────────────────────────────────────────────
+
+function SecretDialog({ orgId, getToken, agents, onClose, onDone }: { orgId: string; getToken: Getter; agents: CAgent[]; onClose: () => void; onDone: () => void }) {
+  const [f, setF] = useState({ scope: 'company', scopeId: '', key: '', value: '' })
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const save = async () => {
+    if (!f.key.trim() || !f.value) return
+    setBusy(true); setErr(null)
+    try {
+      await call(`/api/orgs/${orgId}/secrets`, await getToken(), { method: 'POST', body: JSON.stringify({ scope: f.scope, scopeId: f.scope === 'agent' ? (f.scopeId || null) : null, key: f.key.trim(), value: f.value }) })
+      onDone()
+    } catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setBusy(false)
+  }
+  return (
+    <div style={s.modalWrap} onClick={onClose}>
+      <div style={s.modal} onClick={e => e.stopPropagation()}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h2 style={s.h2}>New secret</h2><button onClick={onClose} style={s.x}>✕</button>
+        </div>
+        <p style={{ color: '#888', fontSize: 12, margin: '4px 0 0' }}>Stored AES-256-GCM encrypted. Runtimes fetch scoped secrets via the agent API — never injected into prompts.</p>
+        <div style={s.form}>
+          <label style={s.lab}>Scope
+            <select style={s.inp} value={f.scope} onChange={e => setF({ ...f, scope: e.target.value, scopeId: '' })}>
+              <option value="company">Company (all agents)</option>
+              <option value="agent">Agent</option>
+            </select>
+          </label>
+          {f.scope === 'agent' && (
+            <label style={s.lab}>Agent
+              <select style={s.inp} value={f.scopeId} onChange={e => setF({ ...f, scopeId: e.target.value })}>
+                <option value="">— pick —</option>
+                {agents.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
+              </select>
+            </label>
+          )}
+          <label style={s.lab}>Key<input style={s.inp} value={f.key} placeholder="OPENAI_API_KEY" onChange={e => setF({ ...f, key: e.target.value })} /></label>
+          <label style={s.lab}>Value<input style={s.inp} type="password" value={f.value} placeholder="sk-…" onChange={e => setF({ ...f, value: e.target.value })} /></label>
+        </div>
+        {err && <div style={s.errBox}>⚠ {err}</div>}
+        <button style={{ ...s.primaryBtn, marginTop: 14, opacity: busy ? 0.6 : 1 }} disabled={busy} onClick={save}>{busy ? 'Saving…' : 'Store secret'}</button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Phase D of the Paperclip-parity epic (MCA-34): secrets stay out of prompts.

- **Schema**: secrets (scope company|agent, key, value_encrypted).
- **services/secrets.ts** (tested): AES-256-GCM encrypt/decrypt (key from SECRETS_ENC_KEY), maskValue, resolveSecretsForAgent (agent scope overrides company). 4 unit tests.
- **Control plane**: CRUD — the list returns only key + scope + masked hint, never plaintext.
- **Injection**: GET /api/agent/secrets returns decrypted, scoped secrets to the authenticated runtime — so BYO agents get them as env, never in an LLM prompt.
- **Cockpit**: Secrets panel + Add-secret dialog.
- **Adapter**: load_secrets() pulls scoped secrets into env at startup.

367/367 backend tests, tsc clean, next build ok. Closes MCA-46.