### PR TITLE
Workspaces & operator branches (MCA-PC D1)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -101,8 +101,21 @@ export const tasks = sqliteTable('tasks', {
   parentTaskId: text('parent_task_id'),
   inboxState: text('inbox_state').default('none'),   // none|needs_attention|blocked|awaiting_review|done (MCA-PC A3)
   goalId: text('goal_id'),                            // links task to a goal (MCA-PC B1)
+  workspaceId: text('workspace_id'),                  // execution workspace (MCA-PC D1)
+  branch: text('branch'),                             // operator branch
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   completedAt: integer('completed_at', { mode: 'timestamp' }),
+})
+
+export const workspaces = sqliteTable('workspaces', {
+  id: text('id').primaryKey(),
+  orgId: text('org_id').notNull(),
+  projectId: text('project_id'),
+  name: text('name').notNull(),
+  repoUrl: text('repo_url'),
+  baseBranch: text('base_branch').default('main'),
+  previewUrl: text('preview_url'),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 
 export const secrets = sqliteTable('secrets', {

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -70,6 +70,11 @@ export async function setupDatabase() {
     // MCA-PC B2: approvals & governance
     `CREATE TABLE IF NOT EXISTS approval_requests (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, type TEXT NOT NULL, summary TEXT NOT NULL, payload TEXT, status TEXT NOT NULL DEFAULT 'pending', requested_by_agent_id TEXT, decided_by TEXT, decided_at INTEGER, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_approvals_org ON approval_requests(org_id, status)`,
+    // MCA-PC D1: workspaces & operator branches
+    `ALTER TABLE tasks ADD COLUMN workspace_id TEXT`,
+    `ALTER TABLE tasks ADD COLUMN branch TEXT`,
+    `CREATE TABLE IF NOT EXISTS workspaces (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, project_id TEXT, name TEXT NOT NULL, repo_url TEXT, base_branch TEXT DEFAULT 'main', preview_url TEXT, created_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS idx_workspaces_org ON workspaces(org_id)`,
     // MCA-PC D4: scoped secret store
     `CREATE TABLE IF NOT EXISTS secrets (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, scope TEXT NOT NULL, scope_id TEXT, key TEXT NOT NULL, value_encrypted TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_secrets_org ON secrets(org_id)`,

--- a/backend/src/routes/agent-api.ts
+++ b/backend/src/routes/agent-api.ts
@@ -5,6 +5,9 @@ import { eq, and, inArray, desc } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
 import { agentAuth } from '../middleware/agent-token'
 import { decrypt, resolveSecretsForAgent } from '../services/secrets'
+import { workspaceRuntime } from '../services/workspaces'
+
+const RUNTIME_BRANCH: Record<string, string> = { openclaw: 'claw', cursor: 'cursor', claude_code: 'cc' }
 
 // ─── AGENT-FACING API (MCA-EXT) ────────────────────────────────────────────
 //
@@ -72,6 +75,17 @@ export async function agentApiRoutes(app: FastifyInstance) {
     const tasks = await db.select().from(schema.tasks)
       .where(and(eq(schema.tasks.agentId, agent.id), inArray(schema.tasks.status, states)))
       .orderBy(desc(schema.tasks.createdAt)).limit(50)
+    // MCA-PC D1: enrich tasks that target a workspace with runtime/branch info.
+    const wsIds = [...new Set(tasks.map(t => (t as any).workspaceId).filter(Boolean))] as string[]
+    if (wsIds.length) {
+      const wss = await db.select().from(schema.workspaces).where(inArray(schema.workspaces.id, wsIds))
+      const wmap = new Map(wss.map(w => [w.id, w]))
+      const prefix = RUNTIME_BRANCH[agent.runtime] ?? 'op'
+      for (const t of tasks as any[]) {
+        const w = t.workspaceId ? wmap.get(t.workspaceId) : null
+        if (w) t.workspace = workspaceRuntime(w as any, t.id, prefix)
+      }
+    }
     return { tasks }
   })
 

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -630,6 +630,24 @@ export async function taskRoutes(app: FastifyInstance) {
     reply.code(204)
   })
 
+  // ─── Workspaces & runtime (MCA-PC D1) ───────────────────────────────────
+  app.get('/api/orgs/:orgId/workspaces', async (req) => {
+    const { orgId } = req.params as any
+    return { workspaces: await db.select().from(schema.workspaces).where(eq(schema.workspaces.orgId, orgId)) }
+  })
+  app.post('/api/orgs/:orgId/workspaces', async (req, reply) => {
+    const { orgId } = req.params as any
+    const b = (req.body ?? {}) as any
+    if (!b.name) return reply.code(400).send({ error: 'name required' })
+    const ws = { id: randomUUID(), orgId, projectId: b.projectId ?? null, name: b.name, repoUrl: b.repoUrl ?? null, baseBranch: b.baseBranch ?? 'main', previewUrl: b.previewUrl ?? null, createdAt: new Date() }
+    await db.insert(schema.workspaces).values(ws)
+    reply.code(201); return { workspace: ws }
+  })
+  app.delete('/api/workspaces/:id', async (req, reply) => {
+    await db.delete(schema.workspaces).where(eq(schema.workspaces.id, (req.params as any).id))
+    reply.code(204)
+  })
+
   // ─── Company portability (MCA-PC D3) ────────────────────────────────────
   app.get('/api/orgs/:orgId/export', async (req) => {
     const { orgId } = req.params as any

--- a/backend/src/services/workspaces.ts
+++ b/backend/src/services/workspaces.ts
@@ -1,0 +1,34 @@
+// Workspaces & runtime (MCA-PC D1). The control plane models workspaces and
+// operator branches; self-hosted runtimes do the actual `git worktree` work.
+
+export interface Workspace {
+  id: string; name: string; repoUrl?: string | null; baseBranch?: string | null
+}
+
+const slug = (s: string) => String(s).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 24)
+
+/** Deterministic operator branch for a task: "<prefix>/<slug>-<taskShort>". */
+export function operatorBranch(taskId: string, opts?: { prefix?: string; title?: string }): string {
+  const prefix = (opts?.prefix || 'op').replace(/\/+$/, '')
+  const short = String(taskId).replace(/-/g, '').slice(0, 8)
+  const title = opts?.title ? `${slug(opts.title)}-` : ''
+  return `${prefix}/${title}${short}`
+}
+
+/** Isolated worktree path under a base checkout for a task. */
+export function worktreePath(baseDir: string, taskId: string): string {
+  const short = String(taskId).replace(/-/g, '').slice(0, 8)
+  return `${String(baseDir).replace(/\/+$/, '')}/.worktrees/task-${short}`
+}
+
+/** Build the runtime payload a self-hosted agent needs to materialise a workspace. */
+export function workspaceRuntime(ws: Workspace, taskId: string, branchPrefix?: string): {
+  workspaceId: string; name: string; repoUrl: string | null; baseBranch: string; branch: string; worktree: string
+} {
+  const base = ws.baseBranch || 'main'
+  return {
+    workspaceId: ws.id, name: ws.name, repoUrl: ws.repoUrl ?? null, baseBranch: base,
+    branch: operatorBranch(taskId, { prefix: branchPrefix || 'op' }),
+    worktree: worktreePath('.', taskId),
+  }
+}

--- a/backend/src/tests/workspaces.test.ts
+++ b/backend/src/tests/workspaces.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { operatorBranch, worktreePath, workspaceRuntime } from '../services/workspaces.ts'
+
+describe('[MCA-PC D1] operatorBranch', () => {
+  it('is deterministic with prefix + short id', () => {
+    assert.equal(operatorBranch('abcdef12-3456-7890', { prefix: 'cursor' }), 'cursor/abcdef12')
+  })
+  it('includes a slugged title when provided', () => {
+    assert.equal(operatorBranch('abcdef12-0000', { prefix: 'cc', title: 'Add Login!' }), 'cc/add-login-abcdef12')
+  })
+  it('defaults the prefix to op', () => {
+    assert.match(operatorBranch('abcdef1234'), /^op\/abcdef12$/)
+  })
+})
+
+describe('[MCA-PC D1] worktreePath', () => {
+  it('nests under .worktrees', () => {
+    assert.equal(worktreePath('/repo', 'abcdef12-99'), '/repo/.worktrees/task-abcdef12')
+  })
+})
+
+describe('[MCA-PC D1] workspaceRuntime', () => {
+  it('resolves repo, base, branch, worktree', () => {
+    const r = workspaceRuntime({ id: 'w1', name: 'app', repoUrl: 'git@x', baseBranch: 'develop' }, 'abcdef12-1', 'claw')
+    assert.equal(r.workspaceId, 'w1')
+    assert.equal(r.baseBranch, 'develop')
+    assert.equal(r.branch, 'claw/abcdef12')
+  })
+  it('defaults baseBranch to main', () => {
+    assert.equal(workspaceRuntime({ id: 'w', name: 'n' }, 't1').baseBranch, 'main')
+  })
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -29,6 +29,7 @@ type GoalNode = { id: string; title: string; metric?: string | null; status?: st
 type Approval = { id: string; type: string; summary: string; status: string; requestedByAgentId?: string | null }
 type Budget = { id: string; scope: string; scopeId?: string | null; limitUsd: number; spend: number; state: string; pct: number }
 type Secret = { id: string; scope: string; scopeId?: string | null; key: string; masked: string }
+type Workspace = { id: string; name: string; repoUrl?: string | null; baseBranch?: string | null; previewUrl?: string | null }
 
 const HB: Record<string, string> = { green: '#22c55e', amber: '#f59e0b', stale: '#ef4444', unknown: '#555' }
 const STATUS_C: Record<string, string> = { idle: '#888', active: '#22c55e', external: '#a96bff' }
@@ -52,25 +53,28 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const [goals, setGoals] = useState<GoalNode[] | null>(null)
   const [budgets, setBudgets] = useState<Budget[]>([])
   const [secrets, setSecrets] = useState<Secret[]>([])
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([])
   const [err, setErr] = useState<string | null>(null)
   const [wizard, setWizard] = useState(false)
   const [hire, setHire] = useState(false)
   const [goalDlg, setGoalDlg] = useState(false)
   const [budgetDlg, setBudgetDlg] = useState(false)
   const [secretDlg, setSecretDlg] = useState(false)
+  const [wsDlg, setWsDlg] = useState(false)
 
   const load = useCallback(async () => {
     try {
       const tok = await getToken()
-      const [c, oc, ib, gl, bd, se] = await Promise.all([
+      const [c, oc, ib, gl, bd, se, ws] = await Promise.all([
         call<Cockpit>(`/api/orgs/${orgId}/cockpit`, tok),
         call<{ tree: OrgNode[] }>(`/api/orgs/${orgId}/orgchart`, tok),
         call<{ items: InboxItem[]; approvals: Approval[] }>(`/api/orgs/${orgId}/inbox`, tok),
         call<{ tree: GoalNode[] }>(`/api/orgs/${orgId}/goals`, tok),
         call<{ budgets: Budget[] }>(`/api/orgs/${orgId}/budgets`, tok),
         call<{ secrets: Secret[] }>(`/api/orgs/${orgId}/secrets`, tok),
+        call<{ workspaces: Workspace[] }>(`/api/orgs/${orgId}/workspaces`, tok),
       ])
-      setData(c); setChart(oc.tree); setInbox(ib.items); setApprovals(ib.approvals ?? []); setGoals(gl.tree); setBudgets(bd.budgets ?? []); setSecrets(se.secrets ?? []); setErr(null)
+      setData(c); setChart(oc.tree); setInbox(ib.items); setApprovals(ib.approvals ?? []); setGoals(gl.tree); setBudgets(bd.budgets ?? []); setSecrets(se.secrets ?? []); setWorkspaces(ws.workspaces ?? []); setErr(null)
     } catch (e: any) { setErr(e?.message ?? 'Failed to load') }
   }, [orgId, getToken])
 
@@ -97,6 +101,10 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const delSecret = async (id: string) => {
     setSecrets(x => x.filter(s => s.id !== id))
     try { await call(`/api/secrets/${id}`, await getToken(), { method: 'DELETE' }) } catch {}
+  }
+  const delWorkspace = async (id: string) => {
+    setWorkspaces(x => x.filter(w => w.id !== id))
+    try { await call(`/api/workspaces/${id}`, await getToken(), { method: 'DELETE' }) } catch {}
   }
 
   useEffect(() => { load() }, [load])
@@ -233,6 +241,25 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         {secrets.length === 0 && <p style={{ color: '#888', fontSize: 12.5 }}>No secrets — store API keys here; runtimes fetch them scoped, never via prompts.</p>}
       </div>
 
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h2 style={s.h2}>Workspaces</h2>
+        <button style={s.ghostBtn} onClick={() => setWsDlg(true)}>＋ Workspace</button>
+      </div>
+      <div style={s.panel}>
+        {workspaces.map(w => (
+          <div key={w.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '9px 0', borderBottom: '1px solid #1a1a1a' }}>
+            <span>🗂️</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 560 }}>{w.name} <span style={s.badge}>{w.baseBranch || 'main'}</span></div>
+              {w.repoUrl && <div style={{ fontSize: 11, color: '#888' }}>{w.repoUrl}</div>}
+            </div>
+            {w.previewUrl && <a href={w.previewUrl} target="_blank" rel="noreferrer" style={{ ...s.badge, color: '#4aa8ff' }}>preview ↗</a>}
+            <button style={s.iconBtn} onClick={() => delWorkspace(w.id)}>✕</button>
+          </div>
+        ))}
+        {workspaces.length === 0 && <p style={{ color: '#888', fontSize: 12.5 }}>No workspaces — define a repo; runtimes get an operator branch + worktree per task.</p>}
+      </div>
+
       <h2 style={s.h2}>Task board</h2>
       <div style={s.board}>
         {COLS.map(col => {
@@ -257,6 +284,44 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
       {goalDlg && <GoalDialog orgId={orgId} getToken={getToken} goals={goals ?? []} onClose={() => setGoalDlg(false)} onDone={() => { setGoalDlg(false); load() }} />}
       {budgetDlg && <BudgetDialog orgId={orgId} getToken={getToken} agents={data?.agents ?? []} onClose={() => setBudgetDlg(false)} onDone={() => { setBudgetDlg(false); load() }} />}
       {secretDlg && <SecretDialog orgId={orgId} getToken={getToken} agents={data?.agents ?? []} onClose={() => setSecretDlg(false)} onDone={() => { setSecretDlg(false); load() }} />}
+      {wsDlg && <WorkspaceDialog orgId={orgId} getToken={getToken} onClose={() => setWsDlg(false)} onDone={() => { setWsDlg(false); load() }} />}
+    </div>
+  )
+}
+
+// ─── Workspace dialog ────────────────────────────────────────────────────────
+
+function WorkspaceDialog({ orgId, getToken, onClose, onDone }: { orgId: string; getToken: Getter; onClose: () => void; onDone: () => void }) {
+  const [f, setF] = useState({ name: '', repoUrl: '', baseBranch: 'main', previewUrl: '' })
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const save = async () => {
+    if (!f.name.trim()) return
+    setBusy(true); setErr(null)
+    try {
+      await call(`/api/orgs/${orgId}/workspaces`, await getToken(), { method: 'POST', body: JSON.stringify({ name: f.name, repoUrl: f.repoUrl || undefined, baseBranch: f.baseBranch || 'main', previewUrl: f.previewUrl || undefined }) })
+      onDone()
+    } catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setBusy(false)
+  }
+  return (
+    <div style={s.modalWrap} onClick={onClose}>
+      <div style={s.modal} onClick={e => e.stopPropagation()}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h2 style={s.h2}>New workspace</h2><button onClick={onClose} style={s.x}>✕</button>
+        </div>
+        <p style={{ color: '#888', fontSize: 12, margin: '4px 0 0' }}>Runtimes create a git worktree + operator branch per task in this workspace.</p>
+        <div style={s.form}>
+          <label style={s.lab}>Name<input style={s.inp} autoFocus value={f.name} placeholder="mission-control-app" onChange={e => setF({ ...f, name: e.target.value })} /></label>
+          <label style={s.lab}>Repo URL<input style={s.inp} value={f.repoUrl} placeholder="git@github.com:Arturito7ei/…" onChange={e => setF({ ...f, repoUrl: e.target.value })} /></label>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <label style={{ ...s.lab, flex: 1 }}>Base branch<input style={s.inp} value={f.baseBranch} onChange={e => setF({ ...f, baseBranch: e.target.value })} /></label>
+            <label style={{ ...s.lab, flex: 1 }}>Preview URL<input style={s.inp} value={f.previewUrl} placeholder="https://…" onChange={e => setF({ ...f, previewUrl: e.target.value })} /></label>
+          </div>
+        </div>
+        {err && <div style={s.errBox}>⚠ {err}</div>}
+        <button style={{ ...s.primaryBtn, marginTop: 14, opacity: busy ? 0.6 : 1 }} disabled={busy} onClick={save}>{busy ? 'Saving…' : 'Create workspace'}</button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Phase D of the Paperclip-parity epic (MCA-34): isolated execution workspaces (sovereign MVP).

- **Schema**: workspaces (repoUrl, baseBranch, previewUrl) + tasks.workspaceId/branch.
- **services/workspaces.ts** (pure-tested): operatorBranch (deterministic per-task branch with runtime prefix), worktreePath, workspaceRuntime. 6 unit tests.
- **API**: workspaces CRUD; the agent task payload (GET /api/agent/tasks) is enriched with workspace runtime info — repo, base branch, a per-task operator branch, and a worktree path — so self-hosted runtimes (OpenClaw/Cursor) materialise an isolated git worktree per task.
- **Cockpit**: Workspaces panel + dialog (name, repo, base branch, preview URL).

The control plane models workspaces + branches; the actual git-worktree work is the runtime's job (keeps the Fly backend stateless + sovereign). 373/373 backend tests, tsc clean. Closes MCA-43.