### PR TITLE
Plugin registry + manifest validation (MCA-PC D2)

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -107,6 +107,16 @@ export const tasks = sqliteTable('tasks', {
   completedAt: integer('completed_at', { mode: 'timestamp' }),
 })
 
+export const plugins = sqliteTable('plugins', {
+  id: text('id').primaryKey(),
+  orgId: text('org_id').notNull(),
+  name: text('name').notNull(),
+  version: text('version').notNull(),
+  manifest: text('manifest', { mode: 'json' }).$type<Record<string, unknown>>(),
+  enabled: integer('enabled', { mode: 'boolean' }).default(false),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+})
+
 export const workspaces = sqliteTable('workspaces', {
   id: text('id').primaryKey(),
   orgId: text('org_id').notNull(),

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -70,6 +70,9 @@ export async function setupDatabase() {
     // MCA-PC B2: approvals & governance
     `CREATE TABLE IF NOT EXISTS approval_requests (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, type TEXT NOT NULL, summary TEXT NOT NULL, payload TEXT, status TEXT NOT NULL DEFAULT 'pending', requested_by_agent_id TEXT, decided_by TEXT, decided_at INTEGER, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_approvals_org ON approval_requests(org_id, status)`,
+    // MCA-PC D2: plugin registry
+    `CREATE TABLE IF NOT EXISTS plugins (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, name TEXT NOT NULL, version TEXT NOT NULL, manifest TEXT, enabled INTEGER DEFAULT 0, created_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS idx_plugins_org ON plugins(org_id)`,
     // MCA-PC D1: workspaces & operator branches
     `ALTER TABLE tasks ADD COLUMN workspace_id TEXT`,
     `ALTER TABLE tasks ADD COLUMN branch TEXT`,

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -18,6 +18,7 @@ import { runHeartbeatSweep } from '../services/heartbeat-engine'
 import { spendForScope, evaluatePolicy } from '../services/budget'
 import { buildExport, remapImport } from '../services/portability'
 import { encrypt, decrypt, maskValue } from '../services/secrets'
+import { validateManifest, grantedCapabilities, exposedTools } from '../services/plugins'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -627,6 +628,32 @@ export async function taskRoutes(app: FastifyInstance) {
   })
   app.delete('/api/secrets/:id', async (req, reply) => {
     await db.delete(schema.secrets).where(eq(schema.secrets.id, (req.params as any).id))
+    reply.code(204)
+  })
+
+  // ─── Plugin registry (MCA-PC D2) ────────────────────────────────────────
+  app.get('/api/orgs/:orgId/plugins', async (req) => {
+    const { orgId } = req.params as any
+    const rows = await db.select().from(schema.plugins).where(eq(schema.plugins.orgId, orgId))
+    return { plugins: rows.map(p => ({ id: p.id, name: p.name, version: p.version, enabled: p.enabled, capabilities: grantedCapabilities((p.manifest ?? {}) as any), tools: exposedTools((p.manifest ?? {}) as any), description: (p.manifest as any)?.description ?? null })) }
+  })
+  app.post('/api/orgs/:orgId/plugins', async (req, reply) => {
+    const { orgId } = req.params as any
+    const manifest = (req.body as any)?.manifest ?? req.body
+    const v = validateManifest(manifest)
+    if (!v.ok) return reply.code(400).send({ error: 'invalid manifest', errors: v.errors })
+    const row = { id: randomUUID(), orgId, name: manifest.name, version: manifest.version, manifest, enabled: false, createdAt: new Date() }
+    await db.insert(schema.plugins).values(row as any)
+    reply.code(201); return { plugin: { id: row.id, name: row.name, version: row.version, enabled: false, capabilities: grantedCapabilities(manifest), tools: exposedTools(manifest) } }
+  })
+  app.patch('/api/plugins/:id', async (req) => {
+    const { id } = req.params as any
+    const { enabled } = (req.body ?? {}) as any
+    await db.update(schema.plugins).set({ enabled: !!enabled }).where(eq(schema.plugins.id, id))
+    return { ok: true, enabled: !!enabled }
+  })
+  app.delete('/api/plugins/:id', async (req, reply) => {
+    await db.delete(schema.plugins).where(eq(schema.plugins.id, (req.params as any).id))
     reply.code(204)
   })
 

--- a/backend/src/services/plugins.ts
+++ b/backend/src/services/plugins.ts
@@ -1,0 +1,49 @@
+// Plugin registry (MCA-PC D2). A thin core with rich edges: plugins declare a
+// manifest with capability-gated permissions and exposed tools. This MVP is the
+// registry + manifest validation + capability gating; out-of-process workers
+// are future work.
+
+// Capabilities a plugin may request. Anything outside this set is rejected.
+export const ALLOWED_CAPABILITIES = [
+  'read:tasks', 'write:tasks', 'read:agents', 'read:knowledge', 'write:knowledge',
+  'read:goals', 'notify', 'http:outbound', 'schedule',
+] as const
+export type Capability = (typeof ALLOWED_CAPABILITIES)[number]
+
+export interface PluginManifest {
+  name: string
+  version: string
+  description?: string
+  capabilities?: string[]
+  tools?: { name: string; description?: string }[]
+}
+
+export interface ValidationResult { ok: boolean; errors: string[] }
+
+/** Validate a plugin manifest. Returns all problems (empty = valid). */
+export function validateManifest(m: any): ValidationResult {
+  const errors: string[] = []
+  if (!m || typeof m !== 'object') return { ok: false, errors: ['manifest must be an object'] }
+  if (!m.name || typeof m.name !== 'string') errors.push('name is required')
+  else if (!/^[a-z0-9][a-z0-9-]{1,48}$/.test(m.name)) errors.push('name must be kebab-case (a-z, 0-9, -)')
+  if (!m.version || typeof m.version !== 'string') errors.push('version is required')
+  if (m.capabilities != null) {
+    if (!Array.isArray(m.capabilities)) errors.push('capabilities must be an array')
+    else for (const c of m.capabilities) if (!(ALLOWED_CAPABILITIES as readonly string[]).includes(c)) errors.push(`unknown capability: ${c}`)
+  }
+  if (m.tools != null) {
+    if (!Array.isArray(m.tools)) errors.push('tools must be an array')
+    else m.tools.forEach((t: any, i: number) => { if (!t?.name || typeof t.name !== 'string') errors.push(`tools[${i}].name is required`) })
+  }
+  return { ok: errors.length === 0, errors }
+}
+
+/** The capabilities actually granted (validated subset of allowed). */
+export function grantedCapabilities(m: PluginManifest): Capability[] {
+  return ((m.capabilities ?? []) as string[]).filter(c => (ALLOWED_CAPABILITIES as readonly string[]).includes(c)) as Capability[]
+}
+
+/** Names of tools a plugin exposes. */
+export function exposedTools(m: PluginManifest): string[] {
+  return (m.tools ?? []).map(t => t.name).filter(Boolean)
+}

--- a/backend/src/tests/plugins.test.ts
+++ b/backend/src/tests/plugins.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { validateManifest, grantedCapabilities, exposedTools, ALLOWED_CAPABILITIES } from '../services/plugins.ts'
+
+const valid = { name: 'weekly-report', version: '1.0.0', capabilities: ['read:tasks', 'notify'], tools: [{ name: 'generate' }] }
+
+describe('[MCA-PC D2] validateManifest', () => {
+  it('accepts a valid manifest', () => {
+    const r = validateManifest(valid)
+    assert.equal(r.ok, true)
+    assert.deepEqual(r.errors, [])
+  })
+  it('requires name + version', () => {
+    const r = validateManifest({})
+    assert.equal(r.ok, false)
+    assert.ok(r.errors.some(e => /name/.test(e)))
+    assert.ok(r.errors.some(e => /version/.test(e)))
+  })
+  it('rejects non-kebab name', () => {
+    assert.ok(validateManifest({ name: 'Bad Name', version: '1' }).errors.some(e => /kebab/.test(e)))
+  })
+  it('rejects unknown capabilities', () => {
+    const r = validateManifest({ name: 'p', version: '1', capabilities: ['read:tasks', 'delete:everything'] })
+    assert.ok(r.errors.some(e => /unknown capability: delete:everything/.test(e)))
+  })
+  it('rejects malformed tools', () => {
+    assert.ok(validateManifest({ name: 'p', version: '1', tools: [{ description: 'no name' }] }).errors.some(e => /tools\[0\]\.name/.test(e)))
+  })
+})
+
+describe('[MCA-PC D2] grantedCapabilities / exposedTools', () => {
+  it('filters to allowed capabilities', () => {
+    const g = grantedCapabilities({ name: 'p', version: '1', capabilities: ['read:tasks', 'bogus'] as any })
+    assert.deepEqual(g, ['read:tasks'])
+  })
+  it('lists exposed tool names', () => {
+    assert.deepEqual(exposedTools(valid), ['generate'])
+  })
+  it('ALLOWED_CAPABILITIES is non-empty', () => assert.ok(ALLOWED_CAPABILITIES.length > 0))
+})

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -30,6 +30,7 @@ type Approval = { id: string; type: string; summary: string; status: string; req
 type Budget = { id: string; scope: string; scopeId?: string | null; limitUsd: number; spend: number; state: string; pct: number }
 type Secret = { id: string; scope: string; scopeId?: string | null; key: string; masked: string }
 type Workspace = { id: string; name: string; repoUrl?: string | null; baseBranch?: string | null; previewUrl?: string | null }
+type Plugin = { id: string; name: string; version: string; enabled: boolean; capabilities: string[]; tools: string[]; description?: string | null }
 
 const HB: Record<string, string> = { green: '#22c55e', amber: '#f59e0b', stale: '#ef4444', unknown: '#555' }
 const STATUS_C: Record<string, string> = { idle: '#888', active: '#22c55e', external: '#a96bff' }
@@ -54,6 +55,7 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const [budgets, setBudgets] = useState<Budget[]>([])
   const [secrets, setSecrets] = useState<Secret[]>([])
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
+  const [plugins, setPlugins] = useState<Plugin[]>([])
   const [err, setErr] = useState<string | null>(null)
   const [wizard, setWizard] = useState(false)
   const [hire, setHire] = useState(false)
@@ -61,11 +63,12 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const [budgetDlg, setBudgetDlg] = useState(false)
   const [secretDlg, setSecretDlg] = useState(false)
   const [wsDlg, setWsDlg] = useState(false)
+  const [pluginDlg, setPluginDlg] = useState(false)
 
   const load = useCallback(async () => {
     try {
       const tok = await getToken()
-      const [c, oc, ib, gl, bd, se, ws] = await Promise.all([
+      const [c, oc, ib, gl, bd, se, ws, pl] = await Promise.all([
         call<Cockpit>(`/api/orgs/${orgId}/cockpit`, tok),
         call<{ tree: OrgNode[] }>(`/api/orgs/${orgId}/orgchart`, tok),
         call<{ items: InboxItem[]; approvals: Approval[] }>(`/api/orgs/${orgId}/inbox`, tok),
@@ -73,8 +76,9 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         call<{ budgets: Budget[] }>(`/api/orgs/${orgId}/budgets`, tok),
         call<{ secrets: Secret[] }>(`/api/orgs/${orgId}/secrets`, tok),
         call<{ workspaces: Workspace[] }>(`/api/orgs/${orgId}/workspaces`, tok),
+        call<{ plugins: Plugin[] }>(`/api/orgs/${orgId}/plugins`, tok),
       ])
-      setData(c); setChart(oc.tree); setInbox(ib.items); setApprovals(ib.approvals ?? []); setGoals(gl.tree); setBudgets(bd.budgets ?? []); setSecrets(se.secrets ?? []); setWorkspaces(ws.workspaces ?? []); setErr(null)
+      setData(c); setChart(oc.tree); setInbox(ib.items); setApprovals(ib.approvals ?? []); setGoals(gl.tree); setBudgets(bd.budgets ?? []); setSecrets(se.secrets ?? []); setWorkspaces(ws.workspaces ?? []); setPlugins(pl.plugins ?? []); setErr(null)
     } catch (e: any) { setErr(e?.message ?? 'Failed to load') }
   }, [orgId, getToken])
 
@@ -105,6 +109,14 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
   const delWorkspace = async (id: string) => {
     setWorkspaces(x => x.filter(w => w.id !== id))
     try { await call(`/api/workspaces/${id}`, await getToken(), { method: 'DELETE' }) } catch {}
+  }
+  const togglePlugin = async (id: string, enabled: boolean) => {
+    setPlugins(x => x.map(p => p.id === id ? { ...p, enabled } : p))
+    try { await call(`/api/plugins/${id}`, await getToken(), { method: 'PATCH', body: JSON.stringify({ enabled }) }) } catch {}
+  }
+  const delPlugin = async (id: string) => {
+    setPlugins(x => x.filter(p => p.id !== id))
+    try { await call(`/api/plugins/${id}`, await getToken(), { method: 'DELETE' }) } catch {}
   }
 
   useEffect(() => { load() }, [load])
@@ -260,6 +272,25 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
         {workspaces.length === 0 && <p style={{ color: '#888', fontSize: 12.5 }}>No workspaces — define a repo; runtimes get an operator branch + worktree per task.</p>}
       </div>
 
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h2 style={s.h2}>Plugins</h2>
+        <button style={s.ghostBtn} onClick={() => setPluginDlg(true)}>＋ Install plugin</button>
+      </div>
+      <div style={s.panel}>
+        {plugins.map(p => (
+          <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '9px 0', borderBottom: '1px solid #1a1a1a' }}>
+            <span>🧩</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 560 }}>{p.name} <span style={{ color: '#555', fontSize: 11 }}>v{p.version}</span></div>
+              <div style={{ fontSize: 11, color: '#888' }}>{p.capabilities.join(', ') || 'no capabilities'}{p.tools.length ? ` · tools: ${p.tools.join(', ')}` : ''}</div>
+            </div>
+            <button style={{ ...s.iconBtn, color: p.enabled ? '#22c55e' : '#888' }} onClick={() => togglePlugin(p.id, !p.enabled)}>{p.enabled ? 'On' : 'Off'}</button>
+            <button style={s.iconBtn} onClick={() => delPlugin(p.id)}>✕</button>
+          </div>
+        ))}
+        {plugins.length === 0 && <p style={{ color: '#888', fontSize: 12.5 }}>No plugins — install a manifest to extend Mission Control (capability-gated).</p>}
+      </div>
+
       <h2 style={s.h2}>Task board</h2>
       <div style={s.board}>
         {COLS.map(col => {
@@ -285,6 +316,47 @@ export default function CockpitPanel({ orgId, getToken }: { orgId: string; getTo
       {budgetDlg && <BudgetDialog orgId={orgId} getToken={getToken} agents={data?.agents ?? []} onClose={() => setBudgetDlg(false)} onDone={() => { setBudgetDlg(false); load() }} />}
       {secretDlg && <SecretDialog orgId={orgId} getToken={getToken} agents={data?.agents ?? []} onClose={() => setSecretDlg(false)} onDone={() => { setSecretDlg(false); load() }} />}
       {wsDlg && <WorkspaceDialog orgId={orgId} getToken={getToken} onClose={() => setWsDlg(false)} onDone={() => { setWsDlg(false); load() }} />}
+      {pluginDlg && <PluginDialog orgId={orgId} getToken={getToken} onClose={() => setPluginDlg(false)} onDone={() => { setPluginDlg(false); load() }} />}
+    </div>
+  )
+}
+
+// ─── Plugin install dialog ───────────────────────────────────────────────────
+
+const SAMPLE_MANIFEST = `{
+  "name": "weekly-report",
+  "version": "1.0.0",
+  "description": "Posts a weekly summary",
+  "capabilities": ["read:tasks", "notify"],
+  "tools": [{ "name": "generate", "description": "Build the report" }]
+}`
+
+function PluginDialog({ orgId, getToken, onClose, onDone }: { orgId: string; getToken: Getter; onClose: () => void; onDone: () => void }) {
+  const [text, setText] = useState(SAMPLE_MANIFEST)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const install = async () => {
+    setBusy(true); setErr(null)
+    let manifest: any
+    try { manifest = JSON.parse(text) } catch { setErr('Manifest is not valid JSON'); setBusy(false); return }
+    try {
+      const res = await fetch(`${API}/api/orgs/${orgId}/plugins`, { method: 'POST', headers: { Authorization: `Bearer ${await getToken()}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ manifest }) })
+      if (!res.ok) { const j = await res.json().catch(() => ({})); throw new Error((j.errors?.join('; ')) || j.error || 'Install failed') }
+      onDone()
+    } catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setBusy(false)
+  }
+  return (
+    <div style={s.modalWrap} onClick={onClose}>
+      <div style={{ ...s.modal, maxWidth: 520 }} onClick={e => e.stopPropagation()}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <h2 style={s.h2}>Install plugin</h2><button onClick={onClose} style={s.x}>✕</button>
+        </div>
+        <p style={{ color: '#888', fontSize: 12, margin: '4px 0 0' }}>Paste a manifest. Capabilities are gated to an allow-list; unknown ones are rejected.</p>
+        <textarea style={{ ...s.inp, minHeight: 200, marginTop: 12, fontFamily: 'monospace', fontSize: 12 }} value={text} onChange={e => setText(e.target.value)} />
+        {err && <div style={s.errBox}>⚠ {err}</div>}
+        <button style={{ ...s.primaryBtn, marginTop: 14, opacity: busy ? 0.6 : 1 }} disabled={busy} onClick={install}>{busy ? 'Installing…' : 'Install'}</button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Final story of the Paperclip-parity epic (MCA-34): a thin-core/rich-edges plugin foundation.

- **Schema**: plugins (manifest json, enabled).
- **services/plugins.ts** (pure-tested): an ALLOWED_CAPABILITIES allow-list; validateManifest (name kebab-case, version, capabilities gated, tools shape); grantedCapabilities; exposedTools. 8 unit tests.
- **API**: plugins CRUD — install validates the manifest (400 + structured errors on bad input), enable/disable, list, delete.
- **Cockpit**: Plugins panel (capabilities + tools + on/off toggle) + install dialog (paste a manifest).

This is the registry + capability-gating foundation; out-of-process plugin workers are deliberately future work. 381/381 backend tests, tsc clean, next build ok. Closes MCA-44.