### PR TITLE
Memory tab + Obsidian vault connector

### DIFF
--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -18,6 +18,7 @@ import { runHeartbeatSweep } from '../services/heartbeat-engine'
 import { spendForScope, evaluatePolicy } from '../services/budget'
 import { buildExport, remapImport } from '../services/portability'
 import { encrypt, decrypt, maskValue } from '../services/secrets'
+import { VAULT_ROOT, isSafeVaultPath, ghContentsUrl, parseDirEntries, decodeFileContent } from '../services/vault-connector'
 import { validateManifest, grantedCapabilities, exposedTools } from '../services/plugins'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
@@ -673,6 +674,37 @@ export async function taskRoutes(app: FastifyInstance) {
   app.delete('/api/workspaces/:id', async (req, reply) => {
     await db.delete(schema.workspaces).where(eq(schema.workspaces.id, (req.params as any).id))
     reply.code(204)
+  })
+
+  // ─── Obsidian vault connector · Memory tab ──────────────────────────────
+  // Reads the shared vault repo's markdown via GitHub, using a token stored in
+  // the org secret store (company secret GITHUB_VAULT_TOKEN) or env VAULT_GH_TOKEN.
+  const resolveVaultToken = async (orgId: string): Promise<string | null> => {
+    if (process.env.VAULT_GH_TOKEN) return process.env.VAULT_GH_TOKEN
+    const row = await db.query.secrets.findFirst({ where: and(eq(schema.secrets.orgId, orgId), eq(schema.secrets.scope, 'company'), eq(schema.secrets.key, 'GITHUB_VAULT_TOKEN')) })
+    try { return row ? decrypt(row.valueEncrypted) : null } catch { return null }
+  }
+  const ghFetch = (url: string, token: string) => fetch(url, { headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'User-Agent': '7ei-mc' } })
+
+  app.get('/api/orgs/:orgId/memory/tree', async (req, reply) => {
+    const { orgId } = req.params as any
+    const path = ((req.query as any)?.path) || VAULT_ROOT
+    if (!isSafeVaultPath(path)) return reply.code(400).send({ error: 'invalid path' })
+    const token = await resolveVaultToken(orgId)
+    if (!token) return reply.code(400).send({ error: 'No vault token — add a company secret GITHUB_VAULT_TOKEN (GitHub PAT with read access to the vault repo).' })
+    const res = await ghFetch(ghContentsUrl(path), token)
+    if (!res.ok) return reply.code(res.status).send({ error: `GitHub ${res.status}` })
+    return { path, entries: parseDirEntries(await res.json() as any) }
+  })
+  app.get('/api/orgs/:orgId/memory/file', async (req, reply) => {
+    const { orgId } = req.params as any
+    const path = ((req.query as any)?.path) || ''
+    if (!isSafeVaultPath(path) || !/\.(md|markdown|txt)$/i.test(path)) return reply.code(400).send({ error: 'invalid path' })
+    const token = await resolveVaultToken(orgId)
+    if (!token) return reply.code(400).send({ error: 'No vault token configured.' })
+    const res = await ghFetch(ghContentsUrl(path), token)
+    if (!res.ok) return reply.code(res.status).send({ error: `GitHub ${res.status}` })
+    return { path, markdown: decodeFileContent(await res.json() as any) }
   })
 
   // ─── Company portability (MCA-PC D3) ────────────────────────────────────

--- a/backend/src/services/vault-connector.ts
+++ b/backend/src/services/vault-connector.ts
@@ -1,0 +1,37 @@
+// Obsidian vault connector (Memory tab). The deployed backend can't reach a
+// local Obsidian vault, so it reads the shared vault's markdown from its private
+// GitHub repo via the Contents API, using a stored GitHub token. Pure helpers
+// here; the route wires the token + fetch.
+
+export const VAULT_REPO = process.env.VAULT_REPO ?? 'Arturito7ei/7Ei-MC_TARCO'
+export const VAULT_ROOT = process.env.VAULT_ROOT ?? 'vault'
+
+/** Guard against path traversal; only allow the vault root subtree. */
+export function isSafeVaultPath(path: string): boolean {
+  const p = String(path ?? '').replace(/^\/+/, '')
+  if (p.includes('..') || p.includes('\\')) return false
+  return p === VAULT_ROOT || p.startsWith(VAULT_ROOT + '/') || p === '' 
+}
+
+/** GitHub Contents API URL for a path in the vault repo. */
+export function ghContentsUrl(path: string, repo = VAULT_REPO): string {
+  const clean = String(path ?? '').replace(/^\/+/, '')
+  return `https://api.github.com/repos/${repo}/contents/${encodeURI(clean)}`
+}
+
+export interface VaultEntry { name: string; path: string; type: 'dir' | 'file' }
+
+/** Normalise a Contents API directory listing → sorted entries (dirs first, md/dirs only). */
+export function parseDirEntries(arr: any[]): VaultEntry[] {
+  const entries: VaultEntry[] = (Array.isArray(arr) ? arr : [])
+    .filter(e => e && (e.type === 'dir' || (e.type === 'file' && /\.(md|markdown|txt)$/i.test(e.name))))
+    .map(e => ({ name: e.name, path: e.path, type: e.type === 'dir' ? 'dir' : 'file' }))
+  return entries.sort((a, b) =>
+    a.type !== b.type ? (a.type === 'dir' ? -1 : 1) : a.name.localeCompare(b.name))
+}
+
+/** Decode a Contents API file object → UTF-8 text. */
+export function decodeFileContent(obj: any): string {
+  if (!obj || typeof obj.content !== 'string') return ''
+  return Buffer.from(obj.content, (obj.encoding as BufferEncoding) || 'base64').toString('utf8')
+}

--- a/backend/src/tests/vault-connector.test.ts
+++ b/backend/src/tests/vault-connector.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isSafeVaultPath, ghContentsUrl, parseDirEntries, decodeFileContent } from '../services/vault-connector.ts'
+
+describe('[Memory] isSafeVaultPath', () => {
+  it('allows the vault subtree', () => {
+    assert.equal(isSafeVaultPath('vault'), true)
+    assert.equal(isSafeVaultPath('vault/Protocols/MOC-Protocols.md'), true)
+  })
+  it('blocks traversal + outside paths', () => {
+    assert.equal(isSafeVaultPath('vault/../secrets'), false)
+    assert.equal(isSafeVaultPath('etc/passwd'), false)
+    assert.equal(isSafeVaultPath('vault\\x'), false)
+  })
+})
+
+describe('[Memory] ghContentsUrl', () => {
+  it('builds a Contents API URL for the vault repo', () => {
+    assert.equal(ghContentsUrl('vault/Memory'), 'https://api.github.com/repos/Arturito7ei/7Ei-MC_TARCO/contents/vault/Memory')
+  })
+})
+
+describe('[Memory] parseDirEntries', () => {
+  it('keeps dirs + markdown, sorts dirs first', () => {
+    const out = parseDirEntries([
+      { name: 'recent.md', path: 'vault/Memory/recent.md', type: 'file' },
+      { name: 'image.png', path: 'vault/Memory/image.png', type: 'file' },
+      { name: 'sub', path: 'vault/Memory/sub', type: 'dir' },
+    ])
+    assert.deepEqual(out.map(e => e.name), ['sub', 'recent.md'])  // png filtered, dir first
+  })
+})
+
+describe('[Memory] decodeFileContent', () => {
+  it('decodes base64 content', () => {
+    const obj = { content: Buffer.from('# Hello', 'utf8').toString('base64'), encoding: 'base64' }
+    assert.equal(decodeFileContent(obj), '# Hello')
+  })
+  it('returns empty on missing content', () => assert.equal(decodeFileContent({}), ''))
+})

--- a/web/app/dashboard/MemoryPanel.tsx
+++ b/web/app/dashboard/MemoryPanel.tsx
@@ -1,0 +1,117 @@
+'use client'
+import { useCallback, useEffect, useState } from 'react'
+
+// Memory tab — browses the shared Obsidian vault (the 7Ei-MC_TARCO repo) through
+// the backend vault connector. Left: folder tree. Right: rendered markdown.
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'
+type Getter = () => Promise<string | null>
+async function call<T>(path: string, token: string | null): Promise<T> {
+  const res = await fetch(`${API}${path}`, { headers: token ? { Authorization: `Bearer ${token}` } : {} })
+  if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error ?? 'Request failed')
+  return res.json()
+}
+const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+// Minimal, safe markdown → HTML (escape first, then format a useful subset).
+function mdToHtml(md: string): string {
+  const lines = esc(md).split('\n')
+  const out: string[] = []
+  let inCode = false, inList = false
+  const inline = (t: string) => t
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>')
+    .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>')
+    .replace(/\[\[([^\]]+)\]\]/g, '<span class="wl">$1</span>')
+  for (const raw of lines) {
+    if (/^```/.test(raw)) { if (inList) { out.push('</ul>'); inList = false } inCode = !inCode; out.push(inCode ? '<pre>' : '</pre>'); continue }
+    if (inCode) { out.push(raw); continue }
+    const h = raw.match(/^(#{1,4})\s+(.*)/)
+    if (h) { if (inList) { out.push('</ul>'); inList = false } out.push(`<h${h[1].length}>${inline(h[2])}</h${h[1].length}>`); continue }
+    if (/^\s*[-*]\s+/.test(raw)) { if (!inList) { out.push('<ul>'); inList = true } out.push(`<li>${inline(raw.replace(/^\s*[-*]\s+/, ''))}</li>`); continue }
+    if (inList) { out.push('</ul>'); inList = false }
+    if (/^\s*---\s*$/.test(raw)) { out.push('<hr/>'); continue }
+    if (raw.trim() === '') { out.push('') ; continue }
+    out.push(`<p>${inline(raw)}</p>`)
+  }
+  if (inList) out.push('</ul>'); if (inCode) out.push('</pre>')
+  return out.join('\n')
+}
+
+type Entry = { name: string; path: string; type: 'dir' | 'file' }
+
+export default function MemoryPanel({ orgId, getToken }: { orgId: string; getToken: Getter }) {
+  const [path, setPath] = useState('vault')
+  const [entries, setEntries] = useState<Entry[]>([])
+  const [file, setFile] = useState<{ path: string; html: string } | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const loadDir = useCallback(async (p: string) => {
+    setLoading(true); setErr(null)
+    try { const r = await call<{ entries: Entry[] }>(`/api/orgs/${orgId}/memory/tree?path=${encodeURIComponent(p)}`, await getToken()); setEntries(r.entries); setPath(p) }
+    catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setLoading(false)
+  }, [orgId, getToken])
+
+  const openFile = async (p: string) => {
+    setLoading(true); setErr(null)
+    try { const r = await call<{ markdown: string }>(`/api/orgs/${orgId}/memory/file?path=${encodeURIComponent(p)}`, await getToken()); setFile({ path: p, html: mdToHtml(r.markdown) }) }
+    catch (e: any) { setErr(e?.message ?? 'Failed') }
+    setLoading(false)
+  }
+
+  useEffect(() => { loadDir('vault') }, [loadDir])
+
+  const parent = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : null
+  const crumbs = path.split('/')
+
+  return (
+    <div style={s.page}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h1 style={s.h1}>Memory <span style={s.pill}>Obsidian vault · 7Ei-MC_TARCO</span></h1>
+        <button style={s.ghost} onClick={() => { setFile(null); loadDir(path) }}>↻ Refresh</button>
+      </div>
+      {err && <div style={s.err}>⚠ {err}{/vault token/i.test(err) && <div style={{ marginTop: 6, color: '#888' }}>Add a company secret <code style={s.code}>GITHUB_VAULT_TOKEN</code> in the Cockpit → Secrets panel (a GitHub PAT with read access to the vault repo).</div>}</div>}
+
+      <div style={s.split}>
+        <div style={s.tree}>
+          <div style={s.crumbs}>
+            {crumbs.map((c, i) => <span key={i}><a style={s.crumb} onClick={() => { setFile(null); loadDir(crumbs.slice(0, i + 1).join('/')) }}>{c}</a>{i < crumbs.length - 1 ? ' / ' : ''}</span>)}
+          </div>
+          {parent && <div style={s.row} onClick={() => { setFile(null); loadDir(parent) }}>↩ ..</div>}
+          {entries.map(e => (
+            <div key={e.path} style={{ ...s.row, ...(file?.path === e.path ? s.rowSel : {}) }}
+              onClick={() => e.type === 'dir' ? (setFile(null), loadDir(e.path)) : openFile(e.path)}>
+              {e.type === 'dir' ? '📁' : '📄'} {e.name}
+            </div>
+          ))}
+          {!entries.length && !loading && <div style={{ color: '#555', fontSize: 12, padding: 6 }}>empty</div>}
+        </div>
+        <div style={s.viewer}>
+          {loading && <div style={{ color: '#555', fontSize: 12 }}>Loading…</div>}
+          {!file && !loading && <div style={{ color: '#888', fontSize: 13 }}>Pick a note on the left to read it. Protocols, memory, agent registry, and company docs all live in the shared vault.</div>}
+          {file && <div style={s.md} dangerouslySetInnerHTML={{ __html: file.html }} />}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const s: Record<string, React.CSSProperties> = {
+  page: { padding: 28, maxWidth: 1200, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16 },
+  h1: { fontSize: 28, fontWeight: 800, margin: 0, letterSpacing: -0.5, display: 'flex', alignItems: 'center', gap: 10 },
+  pill: { fontSize: 11, color: '#888', background: '#111', border: '1px solid #222', borderRadius: 999, padding: '2px 10px', fontWeight: 500 },
+  ghost: { background: '#1a1a1a', border: '1px solid #333', color: '#FFB800', padding: '9px 14px', borderRadius: 9, cursor: 'pointer', fontSize: 13, fontWeight: 600 },
+  err: { background: '#2a1414', border: '1px solid #5a2a2a', color: '#ff8080', borderRadius: 8, padding: '10px 12px', fontSize: 13 },
+  code: { background: '#000', border: '1px solid #222', borderRadius: 4, padding: '1px 5px', fontSize: 11, color: '#FFB800' },
+  split: { display: 'grid', gridTemplateColumns: '280px 1fr', gap: 14, alignItems: 'start' },
+  tree: { background: '#0d0d0d', border: '1px solid #222', borderRadius: 12, padding: 10, maxHeight: '70vh', overflow: 'auto' },
+  crumbs: { fontSize: 11, color: '#888', padding: '4px 6px 8px', borderBottom: '1px solid #1a1a1a', marginBottom: 6, wordBreak: 'break-all' },
+  crumb: { color: '#4aa8ff', cursor: 'pointer' },
+  row: { fontSize: 13, padding: '6px 8px', borderRadius: 7, cursor: 'pointer', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' },
+  rowSel: { background: '#211c08', color: '#FFB800' },
+  viewer: { background: '#111', border: '1px solid #222', borderRadius: 12, padding: '18px 22px', minHeight: '40vh', maxHeight: '70vh', overflow: 'auto' },
+  md: { fontSize: 14, lineHeight: 1.65, color: '#d6d6de' },
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import CockpitPanel from './CockpitPanel'
+import MemoryPanel from './MemoryPanel'
 let useAuth: () => { getToken: () => Promise<string | null>; isLoaded: boolean; isSignedIn: boolean }
 try {
   useAuth = require('@clerk/nextjs').useAuth
@@ -33,7 +34,7 @@ const STATUS_C: Record<string, string> = { idle: '#555', active: '#22c55e', paus
 const JIRA_STATUS_C: Record<string, string> = { 'To Do': '#555', 'In Progress': '#3b82f6', 'Done': '#22c55e', 'Blocked': '#ef4444', 'In Review': '#f59e0b' }
 const PROVIDER_LABELS: Record<string, string> = { anthropic: 'Anthropic', openai: 'OpenAI', google: 'Google', deepseek: 'DeepSeek', moonshot: 'Kimi / Moonshot', qwen: 'Qwen', minimax: 'MiniMax', ollama: 'Ollama (local)' }
 
-type Tab = 'overview' | 'cockpit' | 'agents' | 'tasks' | 'projects' | 'skills' | 'costs' | 'comms' | 'jira' | 'usage' | 'settings'
+type Tab = 'overview' | 'cockpit' | 'memory' | 'agents' | 'tasks' | 'projects' | 'skills' | 'costs' | 'comms' | 'jira' | 'usage' | 'settings'
 
 export default function DashboardPage() {
   const { getToken, isLoaded, isSignedIn } = useAuth()
@@ -281,6 +282,7 @@ export default function DashboardPage() {
   const NAV: { id: Tab; icon: string; label: string }[] = [
     { id: 'overview', icon: '🏠', label: 'Overview' },
     { id: 'cockpit', icon: '🛰️', label: 'Cockpit' },
+    { id: 'memory', icon: '🧠', label: 'Memory' },
     { id: 'agents', icon: '🤖', label: 'Agents' },
     { id: 'tasks', icon: '📋', label: 'Tasks' },
     { id: 'projects', icon: '📁', label: 'Projects' },
@@ -310,6 +312,8 @@ export default function DashboardPage() {
       <main style={s.main}>
 
         {tab === 'cockpit' && <CockpitPanel orgId={org.id} getToken={getToken} />}
+
+        {tab === 'memory' && <MemoryPanel orgId={org.id} getToken={getToken} />}
 
         {tab === 'overview' && (
           <div style={s.page}>


### PR DESCRIPTION
Adds a **Memory** tab to the app that surfaces the shared Obsidian vault (there is no hosted Obsidian MCP; the deployed backend cannot reach a local vault, so it reads the private **7Ei-MC_TARCO** repo via GitHub).

- **services/vault-connector.ts** (pure-tested): isSafeVaultPath (traversal guard, vault-subtree only), ghContentsUrl, parseDirEntries (dirs + markdown, sorted), decodeFileContent. 6 unit tests.
- **API**: GET /api/orgs/:id/memory/tree + /memory/file — token resolved from the **D4 secret store** (company secret `GITHUB_VAULT_TOKEN`) or env `VAULT_GH_TOKEN`.
- **Web**: Memory tab (🧠) — folder tree (Protocols, Memory, 07-Agents, Company…) + a safe markdown viewer (HTML-escaped then formatted).

**To activate:** backend restored + add a company secret `GITHUB_VAULT_TOKEN` (GitHub PAT, read on the vault repo) via Cockpit → Secrets. 387/387 backend tests, tsc clean, next build ok.