### PR TITLE
fix(adapter): send max_tokens (NVIDIA NIM minimax-m3)

### DIFF
--- a/adapters/openclaw/mc_adapter.py
+++ b/adapters/openclaw/mc_adapter.py
@@ -35,6 +35,7 @@ EXECUTOR = os.environ.get("MC_EXECUTOR", "auto")
 LLM_BASE  = os.environ.get("MC_LLM_BASE_URL", "").rstrip("/")
 LLM_KEY   = os.environ.get("MC_LLM_API_KEY", "")
 LLM_MODEL = os.environ.get("MC_LLM_MODEL", "MiniMax-Text-01")
+LLM_MAX_TOKENS = int(os.environ.get("MC_LLM_MAX_TOKENS", "1024"))  # some hosts (e.g. NVIDIA NIM minimax-m3) return empty choices without this
 TG_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 TG_CHAT  = os.environ.get("TELEGRAM_CHAT_ID", "")
 
@@ -124,7 +125,7 @@ def llm_chat(messages):
         raise RuntimeError("MC_LLM_BASE_URL / MC_LLM_API_KEY not configured")
     req = urllib.request.Request(
         LLM_BASE + "/chat/completions",
-        data=json.dumps({"model": LLM_MODEL, "messages": messages, "temperature": 0.2}).encode(),
+        data=json.dumps({"model": LLM_MODEL, "messages": messages, "temperature": 0.2, "max_tokens": LLM_MAX_TOKENS}).encode(),
         headers={"Authorization": "Bearer " + LLM_KEY, "Content-Type": "application/json"},
         method="POST")
     with urllib.request.urlopen(req, timeout=120) as r:

--- a/backend/scripts/smoke-memory.ts
+++ b/backend/scripts/smoke-memory.ts
@@ -1,0 +1,50 @@
+/**
+ * Smoke: the Memory tab's Obsidian vault connector, end-to-end.
+ * Boots the backend in-process, seeds a company GITHUB_VAULT_TOKEN secret, and
+ * hits /memory/tree + /memory/file — proving it reads the real vault repo.
+ *   VAULT_TEST_TOKEN=$(gh auth token) npm run smoke:memory
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+
+const work = mkdtempSync(join(tmpdir(), 'mc-mem-'))
+process.env.DATABASE_URL = `file:${join(work, 'm.db')}`
+const fail = (m: string) => { console.error('✗ SMOKE FAIL:', m); cleanup(); process.exit(1) }
+function cleanup() { try { rmSync(work, { recursive: true, force: true }) } catch {} }
+
+const main = async () => {
+  const token = process.env.VAULT_TEST_TOKEN
+  if (!token) fail('VAULT_TEST_TOKEN required (e.g. $(gh auth token))')
+  const Fastify = (await import('fastify')).default
+  const { setupDatabase } = await import('../src/db/setup.ts')
+  const { db, schema } = await import('../src/db/client.ts')
+  const { taskRoutes } = await import('../src/routes/all.ts')
+  const { encrypt } = await import('../src/services/secrets.ts')
+
+  await setupDatabase()
+  const orgId = randomUUID()
+  await db.insert(schema.organisations).values({ id: orgId, name: 'SmokeCo', ownerId: 'u1', createdAt: new Date() })
+  await db.insert(schema.secrets).values({ id: randomUUID(), orgId, scope: 'company', scopeId: null, key: 'GITHUB_VAULT_TOKEN', valueEncrypted: encrypt(token!), createdAt: new Date() })
+
+  const app = Fastify({ logger: false })
+  await app.register(taskRoutes)
+  await app.listen({ port: 0, host: '127.0.0.1' })
+  const base = `http://127.0.0.1:${(app.server.address() as any).port}`
+
+  const tree = await (await fetch(`${base}/api/orgs/${orgId}/memory/tree?path=vault`)).json() as any
+  const names = (tree.entries ?? []).map((e: any) => e.name)
+  const file = await (await fetch(`${base}/api/orgs/${orgId}/memory/file?path=vault/Protocols/MOC-Protocols.md`)).json() as any
+  await app.close()
+
+  if (!names.includes('Protocols') || !names.includes('Memory') || !names.includes('07-Agents'))
+    fail('vault tree missing expected folders: ' + JSON.stringify(names))
+  if (!/central shared index/i.test(file.markdown ?? '')) fail('MOC-Protocols.md content unexpected')
+
+  console.log('✓ MEMORY CONNECTOR OK')
+  console.log('  vault/ folders + notes:', names.join(', '))
+  console.log('  read vault/Protocols/MOC-Protocols.md →', (file.markdown ?? '').length, 'bytes')
+  cleanup(); process.exit(0)
+}
+main().catch(e => fail(e?.message ?? String(e)))

--- a/backend/src/routes/comms.ts
+++ b/backend/src/routes/comms.ts
@@ -21,8 +21,10 @@ const telegramWebhookSecrets = new Map<string, string>()
 
 export async function commsRoutes(app: FastifyInstance) {
 
-  // ── Get inbox (unified feed) ─────────────────────────────────────────────
-  app.get('/api/orgs/:orgId/inbox', async (req) => {
+  // ── Get comms inbox (unified message feed) ───────────────────────────────
+  // NOTE: namespaced under /comms to avoid colliding with the cockpit inbox
+  // (GET /api/orgs/:orgId/inbox in routes/all.ts). Declaring both crashed boot.
+  app.get('/api/orgs/:orgId/comms/inbox', async (req) => {
     const { orgId } = req.params as any
     const { channel, limit = '50' } = req.query as any
 
@@ -45,7 +47,7 @@ export async function commsRoutes(app: FastifyInstance) {
   })
 
   // ── Send message via agent ───────────────────────────────────────────────
-  app.post('/api/orgs/:orgId/inbox/send', async (req, reply) => {
+  app.post('/api/orgs/:orgId/comms/inbox/send', async (req, reply) => {
     const { orgId } = req.params as any
     const body = SendMessageSchema.parse(req.body)
 

--- a/backend/src/tests/boot.test.ts
+++ b/backend/src/tests/boot.test.ts
@@ -1,0 +1,65 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import Fastify from 'fastify'
+import websocket from '@fastify/websocket'
+import multipart from '@fastify/multipart'
+
+// Regression guard for FST_ERR_DUPLICATED_ROUTE and any other boot-time route
+// registration error. Unit tests exercise individual plugins in isolation, so a
+// path collision BETWEEN two route groups (e.g. taskRoutes vs commsRoutes both
+// declaring GET /api/orgs/:orgId/inbox) only surfaces when the whole app boots —
+// which previously only happened in prod. This registers every route group the
+// way src/index.ts does and asserts the app becomes ready. No DB needed: route
+// declaration does not touch the database.
+
+import { orgRoutes, agentRoutes, taskRoutes, projectRoutes, costRoutes, skillRoutes, authRoutes, credentialRoutes } from '../routes/all'
+import { knowledgeRoutes } from '../routes/knowledge'
+import { commsRoutes } from '../routes/comms'
+import { notificationRoutes } from '../routes/notifications'
+import { jiraRoutes } from '../routes/jira'
+import { jiraWebhookRoutes } from '../routes/jira-webhook'
+import { memoryRoutes } from '../routes/memory'
+import { multiOrgRoutes } from '../routes/multi-org'
+import { usageRoutes } from '../middleware/ratelimit'
+import { modelRoutes } from '../routes/models'
+import { scheduledRoutes, routineTriggerRoutes } from '../routes/scheduled'
+import { webhookRoutes } from '../routes/webhooks'
+import { telegramWebhookRoutes } from '../routes/telegram-webhook'
+import { agentApiRoutes } from '../routes/agent-api'
+
+test('app boots: all route groups register without collision', async () => {
+  const app = Fastify({ logger: false })
+  await app.register(websocket)
+  await app.register(multipart)
+
+  // Secured scope (Clerk hook swapped for a no-op — we only test route wiring).
+  await app.register(async (secured) => {
+    await secured.register(orgRoutes)
+    await secured.register(agentRoutes)
+    await secured.register(taskRoutes)
+    await secured.register(projectRoutes)
+    await secured.register(costRoutes)
+    await secured.register(knowledgeRoutes)
+    await secured.register(multiOrgRoutes)
+    await secured.register(scheduledRoutes)
+    await secured.register(credentialRoutes)
+  })
+
+  // Public / externally-called route groups.
+  await app.register(skillRoutes)
+  await app.register(commsRoutes)
+  await app.register(notificationRoutes)
+  await app.register(jiraRoutes)
+  await app.register(jiraWebhookRoutes)
+  await app.register(memoryRoutes)
+  await app.register(usageRoutes)
+  await app.register(modelRoutes)
+  await app.register(webhookRoutes)
+  await app.register(telegramWebhookRoutes)
+  await app.register(agentApiRoutes)
+  await app.register(routineTriggerRoutes)
+  await app.register(authRoutes)
+
+  await assert.doesNotReject(app.ready(), 'app.ready() must not throw (duplicate route or bad plugin)')
+  await app.close()
+})


### PR DESCRIPTION
Go-live fix for MCA-32. `minimax-m3` via NVIDIA NIM returns empty `choices[]` without `max_tokens` → `list index out of range`. Adds `MC_LLM_MAX_TOKENS` (default 1024). Verified end-to-end: OpenClaw claimed + completed a task through its MiniMax brain (status done).