### PR TITLE
feat(google): expand OAuth scopes to Gmail + Calendar

### DIFF
--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -7,7 +7,7 @@ import { requireOrgRole } from '../middleware/rbac'
 import { executeAgentTask } from '../services/agent-executor'
 import { upsertDocument } from '../services/vector-search'
 import { streamLLM } from '../services/llm-router'
-import { buildAuthUrl, exchangeCode } from '../services/google-auth'
+import { buildAuthUrl, exchangeCode, SCOPES as GOOGLE_SCOPES } from '../services/google-auth'
 import { generateAgentToken } from '../middleware/agent-token'
 import { isExternalAgent, heartbeatFreshness } from '../services/agent-runtime'
 import { buildOrgChart } from '../services/orgchart'
@@ -1154,11 +1154,11 @@ export async function authRoutes(app: FastifyInstance) {
       await db.insert(schema.oauthTokens).values({
         id: randomUUID(), orgId, provider: 'google',
         accessToken: tokens.accessToken, refreshToken: tokens.refreshToken,
-        expiresAt: tokens.expiresAt, scopes: 'drive.readonly drive.file',
+        expiresAt: tokens.expiresAt, scopes: GOOGLE_SCOPES,
         createdAt: new Date(),
       })
     }
-    reply.redirect(`${process.env.ALLOWED_ORIGINS?.split(',')[0] ?? '/'}/knowledge?connected=google`)
+    reply.redirect(`${process.env.ALLOWED_ORIGINS?.split(',')[0] ?? '/'}/dashboard?connected=google`)
   })
 
   app.get('/api/orgs/:orgId/auth/google/status', async (req) => {

--- a/backend/src/services/google-auth.ts
+++ b/backend/src/services/google-auth.ts
@@ -1,6 +1,19 @@
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
-const SCOPES = 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.file'
+// One Google connection powers Gmail, Calendar, and Drive in the Connectors tab.
+// NOTE: gmail.* and calendar.events are sensitive/restricted scopes — the Google
+// Cloud OAuth consent screen must list them (and, for production/verified apps,
+// pass Google verification). In "testing" consent mode they work for listed test users.
+export const SCOPES = [
+  'openid',
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/userinfo.profile',
+  'https://www.googleapis.com/auth/drive.readonly',
+  'https://www.googleapis.com/auth/drive.file',
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.send',
+  'https://www.googleapis.com/auth/calendar.events',
+].join(' ')
 
 export function buildAuthUrl(orgId: string): string {
   const params = new URLSearchParams({
@@ -9,6 +22,7 @@ export function buildAuthUrl(orgId: string): string {
     response_type: 'code',
     scope: SCOPES,
     access_type: 'offline',
+    include_granted_scopes: 'true',
     prompt: 'consent',
     state: orgId,
   })

--- a/backend/src/tests/google-scopes.test.ts
+++ b/backend/src/tests/google-scopes.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { SCOPES, buildAuthUrl } from '../services/google-auth'
+
+test('Google OAuth scopes cover Drive, Gmail, Calendar, and identity', () => {
+  for (const s of [
+    'drive.readonly', 'drive.file',
+    'gmail.readonly', 'gmail.send',
+    'calendar.events',
+    'userinfo.email',
+  ]) assert.ok(SCOPES.includes(s), `missing scope: ${s}`)
+})
+
+test('buildAuthUrl requests offline access + incremental scopes', () => {
+  process.env.GOOGLE_CLIENT_ID = 'test-client'
+  process.env.PUBLIC_URL = 'https://api.example.com'
+  const url = buildAuthUrl('org-1')
+  assert.match(url, /access_type=offline/)
+  assert.match(url, /include_granted_scopes=true/)
+  assert.match(url, /state=org-1/)
+  assert.match(url, /gmail\.send/)
+})


### PR DESCRIPTION
The Connectors Google trio shared a **Drive-only** OAuth. Expands scopes so connecting Google grants Gmail (read+send), Calendar events, and Drive, plus identity (openid/email/profile). Adds `include_granted_scopes`, stores the real scope list, redirects to /dashboard after consent. +2 regression tests.

**Action required (Google Cloud Console):** add these scopes to the OAuth consent screen. `gmail.*` and `calendar.events` are sensitive/restricted — in *Testing* consent mode they work for listed test users without verification; production needs Google verification.