### PR TITLE
feat: Obsidian connector + vault selector + shared agent memory

### DIFF
--- a/backend/src/routes/agent-api.ts
+++ b/backend/src/routes/agent-api.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'crypto'
 import { agentAuth } from '../middleware/agent-token'
 import { decrypt, resolveSecretsForAgent } from '../services/secrets'
 import { workspaceRuntime } from '../services/workspaces'
+import { parseVaultConfig, isSafeVaultPath, isMarkdownPath, vaultList, vaultRead, vaultWrite } from '../services/vault-connector'
 
 const RUNTIME_BRANCH: Record<string, string> = { openclaw: 'claw', cursor: 'cursor', claude_code: 'cc' }
 
@@ -49,6 +50,51 @@ export async function agentApiRoutes(app: FastifyInstance) {
     const rows = await db.select().from(schema.secrets).where(eq(schema.secrets.orgId, agent.orgId))
     const decrypted = rows.map(s => { try { return { scope: s.scope, scopeId: s.scopeId, key: s.key, value: decrypt(s.valueEncrypted) } } catch { return null } }).filter(Boolean) as any[]
     return { secrets: resolveSecretsForAgent(decrypted, agent.id) }
+  })
+
+  // ── Shared memory (Obsidian vault) ───────────────────────────────────────
+  // All agents read/write ONE shared vault (the org's Obsidian repo). This is
+  // how agents leave notes other agents can read. Config + token come from the
+  // org's Connectors → Obsidian setup. Writes commit as the agent.
+  const resolveVault = async (orgId: string) => {
+    const rows = await db.select().from(schema.secrets).where(and(eq(schema.secrets.orgId, orgId), eq(schema.secrets.scope, 'company')))
+    const get = (k: string): string | null => { const r = rows.find(x => x.key === k); if (!r) return null; try { return decrypt(r.valueEncrypted) } catch { return null } }
+    return { token: process.env.VAULT_GH_TOKEN || get('GITHUB_VAULT_TOKEN'), cfg: parseVaultConfig(get('VAULT_CONFIG')) }
+  }
+
+  app.get('/api/agent/memory/tree', async (req, reply) => {
+    const agent = (req as any).agent
+    const { token, cfg } = await resolveVault(agent.orgId)
+    if (!token) return reply.code(400).send({ error: 'vault not connected' })
+    const path = ((req.query as any)?.path) || cfg.root
+    if (!isSafeVaultPath(path, cfg.root)) return reply.code(400).send({ error: 'invalid path' })
+    const r = await vaultList(token, cfg, path)
+    if (!r.ok) return reply.code(r.status).send({ error: `GitHub ${r.status}` })
+    return { path, repo: cfg.repo, root: cfg.root, entries: r.entries }
+  })
+
+  app.get('/api/agent/memory/file', async (req, reply) => {
+    const agent = (req as any).agent
+    const { token, cfg } = await resolveVault(agent.orgId)
+    if (!token) return reply.code(400).send({ error: 'vault not connected' })
+    const path = ((req.query as any)?.path) || ''
+    if (!isSafeVaultPath(path, cfg.root) || !isMarkdownPath(path)) return reply.code(400).send({ error: 'invalid path' })
+    const r = await vaultRead(token, cfg, path)
+    if (!r.ok) return reply.code(r.status).send({ error: `GitHub ${r.status}` })
+    return { path, markdown: r.markdown }
+  })
+
+  app.put('/api/agent/memory/file', async (req, reply) => {
+    const agent = (req as any).agent
+    const { token, cfg } = await resolveVault(agent.orgId)
+    if (!token) return reply.code(400).send({ error: 'vault not connected' })
+    const body = (req.body ?? {}) as any
+    const path = String(body.path ?? '')
+    if (!isSafeVaultPath(path, cfg.root) || !isMarkdownPath(path)) return reply.code(400).send({ error: 'path must be a .md/.markdown/.txt file inside the vault root' })
+    const committer = { name: `${agent.name} (7Ei agent)`, email: 'agents@7ei.ai' }
+    const r = await vaultWrite(token, cfg, path, String(body.markdown ?? ''), body.message || `mc(${agent.name}): update ${path}`, committer)
+    if (!r.ok) return reply.code(r.status).send({ error: r.error ?? `GitHub ${r.status}` })
+    return { ok: true, path, commit: r.commit }
   })
 
   // Liveness/heartbeat — also returns who the runtime is authenticated as.

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -7,7 +7,7 @@ import { requireOrgRole } from '../middleware/rbac'
 import { executeAgentTask } from '../services/agent-executor'
 import { upsertDocument } from '../services/vector-search'
 import { streamLLM } from '../services/llm-router'
-import { buildAuthUrl, exchangeCode } from '../services/google-auth'
+import { buildAuthUrl, exchangeCode, SCOPES as GOOGLE_SCOPES } from '../services/google-auth'
 import { generateAgentToken } from '../middleware/agent-token'
 import { isExternalAgent, heartbeatFreshness } from '../services/agent-runtime'
 import { buildOrgChart } from '../services/orgchart'
@@ -1154,11 +1154,11 @@ export async function authRoutes(app: FastifyInstance) {
       await db.insert(schema.oauthTokens).values({
         id: randomUUID(), orgId, provider: 'google',
         accessToken: tokens.accessToken, refreshToken: tokens.refreshToken,
-        expiresAt: tokens.expiresAt, scopes: 'drive.readonly drive.file',
+        expiresAt: tokens.expiresAt, scopes: GOOGLE_SCOPES,
         createdAt: new Date(),
       })
     }
-    reply.redirect(`${process.env.ALLOWED_ORIGINS?.split(',')[0] ?? '/'}/knowledge?connected=google`)
+    reply.redirect(`${process.env.ALLOWED_ORIGINS?.split(',')[0] ?? '/'}/dashboard?connected=google`)
   })
 
   app.get('/api/orgs/:orgId/auth/google/status', async (req) => {

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -18,7 +18,7 @@ import { runHeartbeatSweep } from '../services/heartbeat-engine'
 import { spendForScope, evaluatePolicy } from '../services/budget'
 import { buildExport, remapImport } from '../services/portability'
 import { encrypt, decrypt, maskValue } from '../services/secrets'
-import { VAULT_ROOT, isSafeVaultPath, ghContentsUrl, parseDirEntries, decodeFileContent } from '../services/vault-connector'
+import { isSafeVaultPath, isMarkdownPath, parseVaultConfig, vaultList, vaultRead, vaultWrite } from '../services/vault-connector'
 import { validateManifest, grantedCapabilities, exposedTools } from '../services/plugins'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
@@ -679,32 +679,54 @@ export async function taskRoutes(app: FastifyInstance) {
   // ─── Obsidian vault connector · Memory tab ──────────────────────────────
   // Reads the shared vault repo's markdown via GitHub, using a token stored in
   // the org secret store (company secret GITHUB_VAULT_TOKEN) or env VAULT_GH_TOKEN.
+  // Vault (Obsidian shared memory) — token + config resolved per org. Config is
+  // set via the Connectors tab's Obsidian card (VAULT_CONFIG); token in GITHUB_VAULT_TOKEN.
   const resolveVaultToken = async (orgId: string): Promise<string | null> => {
     if (process.env.VAULT_GH_TOKEN) return process.env.VAULT_GH_TOKEN
     const row = await db.query.secrets.findFirst({ where: and(eq(schema.secrets.orgId, orgId), eq(schema.secrets.scope, 'company'), eq(schema.secrets.key, 'GITHUB_VAULT_TOKEN')) })
     try { return row ? decrypt(row.valueEncrypted) : null } catch { return null }
   }
-  const ghFetch = (url: string, token: string) => fetch(url, { headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'User-Agent': '7ei-mc' } })
+  const resolveVaultConfig = async (orgId: string) => {
+    const row = await db.query.secrets.findFirst({ where: and(eq(schema.secrets.orgId, orgId), eq(schema.secrets.scope, 'company'), eq(schema.secrets.key, 'VAULT_CONFIG')) })
+    let raw: string | null = null
+    try { raw = row ? decrypt(row.valueEncrypted) : null } catch {}
+    return parseVaultConfig(raw)
+  }
+  const NO_VAULT = { error: 'Vault not connected — configure it in Connectors → Obsidian Vault (repo, root, branch, GitHub token).' }
 
   app.get('/api/orgs/:orgId/memory/tree', async (req, reply) => {
     const { orgId } = req.params as any
-    const path = ((req.query as any)?.path) || VAULT_ROOT
-    if (!isSafeVaultPath(path)) return reply.code(400).send({ error: 'invalid path' })
+    const cfg = await resolveVaultConfig(orgId)
+    const path = ((req.query as any)?.path) || cfg.root
+    if (!isSafeVaultPath(path, cfg.root)) return reply.code(400).send({ error: 'invalid path' })
     const token = await resolveVaultToken(orgId)
-    if (!token) return reply.code(400).send({ error: 'No vault token — add a company secret GITHUB_VAULT_TOKEN (GitHub PAT with read access to the vault repo).' })
-    const res = await ghFetch(ghContentsUrl(path), token)
-    if (!res.ok) return reply.code(res.status).send({ error: `GitHub ${res.status}` })
-    return { path, entries: parseDirEntries(await res.json() as any) }
+    if (!token) return reply.code(400).send(NO_VAULT)
+    const r = await vaultList(token, cfg, path)
+    if (!r.ok) return reply.code(r.status).send({ error: `GitHub ${r.status}` })
+    return { path, repo: cfg.repo, root: cfg.root, branch: cfg.branch, entries: r.entries }
   })
   app.get('/api/orgs/:orgId/memory/file', async (req, reply) => {
     const { orgId } = req.params as any
+    const cfg = await resolveVaultConfig(orgId)
     const path = ((req.query as any)?.path) || ''
-    if (!isSafeVaultPath(path) || !/\.(md|markdown|txt)$/i.test(path)) return reply.code(400).send({ error: 'invalid path' })
+    if (!isSafeVaultPath(path, cfg.root) || !isMarkdownPath(path)) return reply.code(400).send({ error: 'invalid path' })
     const token = await resolveVaultToken(orgId)
-    if (!token) return reply.code(400).send({ error: 'No vault token configured.' })
-    const res = await ghFetch(ghContentsUrl(path), token)
-    if (!res.ok) return reply.code(res.status).send({ error: `GitHub ${res.status}` })
-    return { path, markdown: decodeFileContent(await res.json() as any) }
+    if (!token) return reply.code(400).send(NO_VAULT)
+    const r = await vaultRead(token, cfg, path)
+    if (!r.ok) return reply.code(r.status).send({ error: `GitHub ${r.status}` })
+    return { path, markdown: r.markdown }
+  })
+  app.put('/api/orgs/:orgId/memory/file', async (req, reply) => {
+    const { orgId } = req.params as any
+    const body = (req.body ?? {}) as any
+    const path = String(body.path ?? '')
+    const cfg = await resolveVaultConfig(orgId)
+    if (!isSafeVaultPath(path, cfg.root) || !isMarkdownPath(path)) return reply.code(400).send({ error: 'path must be a .md/.markdown/.txt file inside the vault root' })
+    const token = await resolveVaultToken(orgId)
+    if (!token) return reply.code(400).send(NO_VAULT)
+    const r = await vaultWrite(token, cfg, path, String(body.markdown ?? ''), body.message || `mc: update ${path}`)
+    if (!r.ok) return reply.code(r.status).send({ error: r.error ?? `GitHub ${r.status}` })
+    return { ok: true, path, commit: r.commit }
   })
 
   // ─── Company portability (MCA-PC D3) ────────────────────────────────────

--- a/backend/src/routes/connectors.ts
+++ b/backend/src/routes/connectors.ts
@@ -6,6 +6,7 @@ import { encrypt, decrypt } from '../services/secrets'
 import { buildAuthUrl } from '../services/google-auth'
 import { getJiraCfg, clearJiraCfg } from './jira'
 import { CONNECTORS, getConnector, tokenTestRequest, parseAccount, buildStatus } from '../services/connectors'
+import { parseVaultConfig, vaultList } from '../services/vault-connector'
 
 // ─── Connectors tab (unified connection manager) ────────────────────────────
 // Token/basic credentials → D4 secret store (AES-256-GCM). Google trio →
@@ -37,11 +38,13 @@ export async function connectorRoutes(app: FastifyInstance) {
   // Status for all six connectors.
   app.get('/api/orgs/:orgId/connectors', async (req) => {
     const { orgId } = req.params as any
-    const [ghTok, ghAcc, hfTok, hfAcc, jcfg, gConn] = await Promise.all([
+    const [ghTok, ghAcc, hfTok, hfAcc, jcfg, gConn, vaultTok, vaultRaw] = await Promise.all([
       getSecret(orgId, 'GITHUB_TOKEN'), getSecret(orgId, 'GITHUB_ACCOUNT'),
       getSecret(orgId, 'HUGGINGFACE_TOKEN'), getSecret(orgId, 'HUGGINGFACE_ACCOUNT'),
       getJiraCfg(orgId), googleConnected(orgId),
+      getSecret(orgId, 'GITHUB_VAULT_TOKEN'), getSecret(orgId, 'VAULT_CONFIG'),
     ])
+    const vcfg = parseVaultConfig(vaultRaw)
     const byId: Record<string, { connected: boolean; detail?: string | null }> = {
       github: { connected: !!ghTok, detail: ghAcc },
       huggingface: { connected: !!hfTok, detail: hfAcc },
@@ -49,6 +52,7 @@ export async function connectorRoutes(app: FastifyInstance) {
       gmail: { connected: gConn, detail: gConn ? 'Google account' : null },
       gcal: { connected: gConn, detail: gConn ? 'Google account' : null },
       gdrive: { connected: gConn, detail: gConn ? 'Google account' : null },
+      obsidian: { connected: !!vaultTok, detail: vaultTok ? `${vcfg.repo} · ${vcfg.root}/ (${vcfg.branch})` : null },
     }
     return { connectors: CONNECTORS.map(m => buildStatus(m, byId[m.id])) }
   })
@@ -61,6 +65,19 @@ export async function connectorRoutes(app: FastifyInstance) {
     const body = (req.body ?? {}) as any
 
     if (meta.authType === 'oauth') return { authUrl: buildAuthUrl(orgId) }
+
+    if (id === 'obsidian') {
+      const repo = String(body.repo ?? '').trim()
+      const token = String(body.token ?? '').trim()
+      if (!repo || !token) return reply.code(400).send({ error: 'repo (owner/name) and token required' })
+      const cfg = { repo, root: (String(body.root ?? '').trim() || 'vault'), branch: (String(body.branch ?? '').trim() || 'main') }
+      let check
+      try { check = await vaultList(token, cfg, cfg.root) } catch { return reply.code(502).send({ error: 'GitHub unreachable' }) }
+      if (!check.ok) return reply.code(401).send({ error: `Cannot read ${repo}/${cfg.root} (GitHub ${check.status}) — check repo, root, branch, and token scope` })
+      await setSecret(orgId, 'VAULT_CONFIG', JSON.stringify(cfg))
+      await setSecret(orgId, 'GITHUB_VAULT_TOKEN', token)
+      return { connected: true, detail: `${repo} · ${cfg.root}/ (${check.entries?.length ?? 0} items)` }
+    }
 
     if (meta.authType === 'token') {
       const token = String(body.token ?? '').trim()
@@ -103,6 +120,14 @@ export async function connectorRoutes(app: FastifyInstance) {
       if (!res.ok) return reply.code(502).send({ ok: false, error: `${meta.name} auth failed` })
       return { ok: true, detail: parseAccount(id, await res.json().catch(() => ({}))) || null }
     }
+    if (id === 'obsidian') {
+      const token = await getSecret(orgId, 'GITHUB_VAULT_TOKEN')
+      if (!token) return reply.code(400).send({ ok: false, error: 'not connected' })
+      const cfg = parseVaultConfig(await getSecret(orgId, 'VAULT_CONFIG'))
+      const r = await vaultList(token, cfg, cfg.root)
+      if (!r.ok) return reply.code(502).send({ ok: false, error: `GitHub ${r.status}` })
+      return { ok: true, detail: `${cfg.repo} · ${cfg.root}/ (${r.entries?.length ?? 0} items)` }
+    }
     if (id === 'jira') {
       const cfg = await getJiraCfg(orgId)
       if (!cfg) return reply.code(400).send({ ok: false, error: 'not connected' })
@@ -126,6 +151,9 @@ export async function connectorRoutes(app: FastifyInstance) {
       if (meta.accountKey) await delSecret(orgId, meta.accountKey)
     } else if (id === 'jira') {
       await clearJiraCfg(orgId)
+    } else if (id === 'obsidian') {
+      await delSecret(orgId, 'VAULT_CONFIG')
+      await delSecret(orgId, 'GITHUB_VAULT_TOKEN')
     } else if (meta.authType === 'oauth') {
       await db.delete(schema.oauthTokens).where(and(eq(schema.oauthTokens.orgId, orgId), eq(schema.oauthTokens.provider, 'google')))
     }

--- a/backend/src/services/connectors.ts
+++ b/backend/src/services/connectors.ts
@@ -7,7 +7,7 @@ export type AuthType = 'token' | 'basic' | 'oauth'
 export interface ConnectorMeta {
   id: string
   name: string
-  category: 'Dev' | 'Google' | 'Project' | 'AI'
+  category: 'Dev' | 'Google' | 'Project' | 'AI' | 'Memory'
   authType: AuthType
   icon: string
   docsUrl: string
@@ -31,6 +31,8 @@ export const CONNECTORS: ConnectorMeta[] = [
     docsUrl: 'https://drive.google.com', provider: 'google' },
   { id: 'huggingface', name: 'Hugging Face', category: 'AI', authType: 'token', icon: '🤗',
     docsUrl: 'https://huggingface.co/settings/tokens', secretKey: 'HUGGINGFACE_TOKEN', accountKey: 'HUGGINGFACE_ACCOUNT' },
+  { id: 'obsidian', name: 'Obsidian Vault (shared memory)', category: 'Memory', authType: 'basic', icon: '🪨',
+    docsUrl: 'https://github.com/settings/tokens', fields: ['repo', 'root', 'branch', 'token'] },
 ]
 
 export const GOOGLE_MEMBERS = CONNECTORS.filter(c => c.provider === 'google').map(c => c.id)
@@ -57,7 +59,7 @@ export function parseAccount(id: string, json: any): string {
 
 export interface ConnectorStatus {
   id: string; name: string; category: string; authType: AuthType; icon: string; docsUrl: string
-  connected: boolean; detail: string | null
+  fields: string[]; connected: boolean; detail: string | null
 }
 
 // Compose a status row from resolved inputs (pure — no IO).
@@ -67,7 +69,7 @@ export function buildStatus(
 ): ConnectorStatus {
   return {
     id: meta.id, name: meta.name, category: meta.category, authType: meta.authType,
-    icon: meta.icon, docsUrl: meta.docsUrl,
+    icon: meta.icon, docsUrl: meta.docsUrl, fields: meta.fields ?? [],
     connected: opts.connected, detail: opts.detail ?? null,
   }
 }

--- a/backend/src/services/google-auth.ts
+++ b/backend/src/services/google-auth.ts
@@ -1,6 +1,19 @@
 const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
-const SCOPES = 'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/drive.file'
+// One Google connection powers Gmail, Calendar, and Drive in the Connectors tab.
+// NOTE: gmail.* and calendar.events are sensitive/restricted scopes — the Google
+// Cloud OAuth consent screen must list them (and, for production/verified apps,
+// pass Google verification). In "testing" consent mode they work for listed test users.
+export const SCOPES = [
+  'openid',
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/userinfo.profile',
+  'https://www.googleapis.com/auth/drive.readonly',
+  'https://www.googleapis.com/auth/drive.file',
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.send',
+  'https://www.googleapis.com/auth/calendar.events',
+].join(' ')
 
 export function buildAuthUrl(orgId: string): string {
   const params = new URLSearchParams({
@@ -9,6 +22,7 @@ export function buildAuthUrl(orgId: string): string {
     response_type: 'code',
     scope: SCOPES,
     access_type: 'offline',
+    include_granted_scopes: 'true',
     prompt: 'consent',
     state: orgId,
   })

--- a/backend/src/services/vault-connector.ts
+++ b/backend/src/services/vault-connector.ts
@@ -1,22 +1,45 @@
-// Obsidian vault connector (Memory tab). The deployed backend can't reach a
-// local Obsidian vault, so it reads the shared vault's markdown from its private
-// GitHub repo via the Contents API, using a stored GitHub token. Pure helpers
-// here; the route wires the token + fetch.
+// Obsidian vault connector — shared agent memory. The deployed backend can't
+// reach a local Obsidian vault, so it reads/writes the shared vault's markdown
+// through its Git host (GitHub Contents API) using a stored token. The vault is
+// per-org configurable (repo/root/branch) via the Connectors tab's Obsidian card.
 
 export const VAULT_REPO = process.env.VAULT_REPO ?? 'Arturito7ei/7Ei-MC_TARCO'
 export const VAULT_ROOT = process.env.VAULT_ROOT ?? 'vault'
+export const VAULT_BRANCH = process.env.VAULT_BRANCH ?? 'main'
 
-/** Guard against path traversal; only allow the vault root subtree. */
-export function isSafeVaultPath(path: string): boolean {
-  const p = String(path ?? '').replace(/^\/+/, '')
-  if (p.includes('..') || p.includes('\\')) return false
-  return p === VAULT_ROOT || p.startsWith(VAULT_ROOT + '/') || p === '' 
+export interface VaultConfig { repo: string; root: string; branch: string }
+
+export function defaultVaultConfig(): VaultConfig {
+  return { repo: VAULT_REPO, root: VAULT_ROOT, branch: VAULT_BRANCH }
 }
 
-/** GitHub Contents API URL for a path in the vault repo. */
-export function ghContentsUrl(path: string, repo = VAULT_REPO): string {
+/** Merge a stored VAULT_CONFIG JSON blob with defaults. */
+export function parseVaultConfig(json: string | null | undefined): VaultConfig {
+  const d = defaultVaultConfig()
+  if (!json) return d
+  try {
+    const o = JSON.parse(json)
+    return { repo: o.repo || d.repo, root: (o.root ?? d.root) || d.root, branch: o.branch || d.branch }
+  } catch { return d }
+}
+
+/** Guard against path traversal; only allow the configured vault-root subtree. */
+export function isSafeVaultPath(path: string, root: string = VAULT_ROOT): boolean {
+  const p = String(path ?? '').replace(/^\/+/, '')
+  if (p.includes('..') || p.includes('\\')) return false
+  const r = String(root ?? '').replace(/^\/+|\/+$/g, '')
+  return p === r || p.startsWith(r + '/') || p === ''
+}
+
+export function isMarkdownPath(path: string): boolean {
+  return /\.(md|markdown|txt)$/i.test(String(path ?? ''))
+}
+
+/** GitHub Contents API URL for a path in a repo (optionally at a ref/branch). */
+export function ghContentsUrl(path: string, repo: string = VAULT_REPO, ref?: string): string {
   const clean = String(path ?? '').replace(/^\/+/, '')
-  return `https://api.github.com/repos/${repo}/contents/${encodeURI(clean)}`
+  const base = `https://api.github.com/repos/${repo}/contents/${encodeURI(clean)}`
+  return ref ? `${base}?ref=${encodeURIComponent(ref)}` : base
 }
 
 export interface VaultEntry { name: string; path: string; type: 'dir' | 'file' }
@@ -34,4 +57,45 @@ export function parseDirEntries(arr: any[]): VaultEntry[] {
 export function decodeFileContent(obj: any): string {
   if (!obj || typeof obj.content !== 'string') return ''
   return Buffer.from(obj.content, (obj.encoding as BufferEncoding) || 'base64').toString('utf8')
+}
+
+/** Build the PUT body for a Contents API write (create or update). */
+export function ghPutBody(markdown: string, message: string, branch: string, sha?: string, committer?: { name: string; email: string }): Record<string, any> {
+  const body: Record<string, any> = { message, content: Buffer.from(markdown ?? '', 'utf8').toString('base64'), branch }
+  if (sha) body.sha = sha
+  if (committer) body.committer = committer
+  return body
+}
+
+// ─── Thin IO helpers (token = GitHub PAT with repo access) ──────────────────
+const ghHeaders = (token: string) => ({ Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'User-Agent': '7ei-mc' })
+
+export async function vaultList(token: string, cfg: VaultConfig, path: string): Promise<{ ok: boolean; status: number; entries?: VaultEntry[] }> {
+  const res = await fetch(ghContentsUrl(path || cfg.root, cfg.repo, cfg.branch), { headers: ghHeaders(token) })
+  if (!res.ok) return { ok: false, status: res.status }
+  return { ok: true, status: 200, entries: parseDirEntries(await res.json() as any) }
+}
+
+export async function vaultRead(token: string, cfg: VaultConfig, path: string): Promise<{ ok: boolean; status: number; markdown?: string }> {
+  const res = await fetch(ghContentsUrl(path, cfg.repo, cfg.branch), { headers: ghHeaders(token) })
+  if (!res.ok) return { ok: false, status: res.status }
+  return { ok: true, status: 200, markdown: decodeFileContent(await res.json() as any) }
+}
+
+export async function vaultWrite(
+  token: string, cfg: VaultConfig, path: string, markdown: string, message: string,
+  committer?: { name: string; email: string },
+): Promise<{ ok: boolean; status: number; commit?: string; error?: string }> {
+  const clean = String(path ?? '').replace(/^\/+/, '')
+  // Look up existing sha (required to update an existing file).
+  let sha: string | undefined
+  const head = await fetch(ghContentsUrl(clean, cfg.repo, cfg.branch), { headers: ghHeaders(token) })
+  if (head.ok) { try { sha = (await head.json() as any).sha } catch {} }
+  const res = await fetch(`https://api.github.com/repos/${cfg.repo}/contents/${encodeURI(clean)}`, {
+    method: 'PUT', headers: { ...ghHeaders(token), 'Content-Type': 'application/json' },
+    body: JSON.stringify(ghPutBody(markdown, message, cfg.branch, sha, committer)),
+  })
+  if (!res.ok) return { ok: false, status: res.status, error: `GitHub ${res.status}` }
+  const j = await res.json().catch(() => ({})) as any
+  return { ok: true, status: res.status, commit: j?.commit?.sha }
 }

--- a/backend/src/tests/connectors.test.ts
+++ b/backend/src/tests/connectors.test.ts
@@ -2,10 +2,17 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { CONNECTORS, GOOGLE_MEMBERS, getConnector, tokenTestRequest, parseAccount, buildStatus } from '../services/connectors'
 
-test('registry has the six expected connectors, unique ids', () => {
+test('registry has the expected connectors, unique ids', () => {
   const ids = CONNECTORS.map(c => c.id)
-  assert.deepEqual(ids.sort(), ['gcal', 'gdrive', 'github', 'gmail', 'huggingface', 'jira'])
+  assert.deepEqual(ids.sort(), ['gcal', 'gdrive', 'github', 'gmail', 'huggingface', 'jira', 'obsidian'])
   assert.equal(new Set(ids).size, ids.length)
+})
+
+test('obsidian is a basic connector with vault fields', () => {
+  const o = getConnector('obsidian')!
+  assert.equal(o.authType, 'basic')
+  assert.deepEqual(o.fields, ['repo', 'root', 'branch', 'token'])
+  assert.equal(o.category, 'Memory')
 })
 
 test('google members are the three google connectors', () => {

--- a/backend/src/tests/google-scopes.test.ts
+++ b/backend/src/tests/google-scopes.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { SCOPES, buildAuthUrl } from '../services/google-auth'
+
+test('Google OAuth scopes cover Drive, Gmail, Calendar, and identity', () => {
+  for (const s of [
+    'drive.readonly', 'drive.file',
+    'gmail.readonly', 'gmail.send',
+    'calendar.events',
+    'userinfo.email',
+  ]) assert.ok(SCOPES.includes(s), `missing scope: ${s}`)
+})
+
+test('buildAuthUrl requests offline access + incremental scopes', () => {
+  process.env.GOOGLE_CLIENT_ID = 'test-client'
+  process.env.PUBLIC_URL = 'https://api.example.com'
+  const url = buildAuthUrl('org-1')
+  assert.match(url, /access_type=offline/)
+  assert.match(url, /include_granted_scopes=true/)
+  assert.match(url, /state=org-1/)
+  assert.match(url, /gmail\.send/)
+})

--- a/backend/src/tests/vault-config.test.ts
+++ b/backend/src/tests/vault-config.test.ts
@@ -1,0 +1,42 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseVaultConfig, defaultVaultConfig, isSafeVaultPath, isMarkdownPath, ghContentsUrl, ghPutBody } from '../services/vault-connector'
+
+test('parseVaultConfig merges with defaults and tolerates junk', () => {
+  const d = defaultVaultConfig()
+  assert.deepEqual(parseVaultConfig(null), d)
+  assert.deepEqual(parseVaultConfig('not json'), d)
+  assert.deepEqual(parseVaultConfig('{"repo":"o/r","root":"notes","branch":"dev"}'), { repo: 'o/r', root: 'notes', branch: 'dev' })
+  // partial → fill from defaults
+  assert.equal(parseVaultConfig('{"repo":"o/r"}').branch, d.branch)
+})
+
+test('isSafeVaultPath honours a custom root and blocks traversal', () => {
+  assert.ok(isSafeVaultPath('notes/a.md', 'notes'))
+  assert.ok(isSafeVaultPath('notes', 'notes'))
+  assert.ok(isSafeVaultPath('', 'notes'))
+  assert.equal(isSafeVaultPath('other/a.md', 'notes'), false)
+  assert.equal(isSafeVaultPath('notes/../secret', 'notes'), false)
+  assert.equal(isSafeVaultPath('notes\\a.md', 'notes'), false)
+})
+
+test('isMarkdownPath matches md/markdown/txt only', () => {
+  assert.ok(isMarkdownPath('vault/x.md'))
+  assert.ok(isMarkdownPath('a.markdown'))
+  assert.ok(isMarkdownPath('a.txt'))
+  assert.equal(isMarkdownPath('a.png'), false)
+})
+
+test('ghContentsUrl appends ref when given a branch', () => {
+  assert.equal(ghContentsUrl('vault/a.md', 'o/r'), 'https://api.github.com/repos/o/r/contents/vault/a.md')
+  assert.match(ghContentsUrl('vault/a.md', 'o/r', 'main'), /\?ref=main$/)
+})
+
+test('ghPutBody base64-encodes content and includes sha on update', () => {
+  const create = ghPutBody('hello', 'msg', 'main')
+  assert.equal(create.branch, 'main')
+  assert.equal(Buffer.from(create.content, 'base64').toString('utf8'), 'hello')
+  assert.equal(create.sha, undefined)
+  const update = ghPutBody('hi', 'msg', 'main', 'abc123')
+  assert.equal(update.sha, 'abc123')
+})

--- a/web/app/dashboard/ConnectorsPanel.tsx
+++ b/web/app/dashboard/ConnectorsPanel.tsx
@@ -19,13 +19,18 @@ async function call<T>(path: string, token: string | null, opts?: RequestInit): 
   return j as T
 }
 
-type Row = { id: string; name: string; category: string; authType: 'token' | 'basic' | 'oauth'; icon: string; docsUrl: string; connected: boolean; detail: string | null }
+type Row = { id: string; name: string; category: string; authType: 'token' | 'basic' | 'oauth'; icon: string; docsUrl: string; fields: string[]; connected: boolean; detail: string | null }
 type JiraIssue = { id: string; key: string; summary: string; status?: string; priority?: string; assignee?: string }
 
-const CATEGORY_ORDER = ['Project', 'Dev', 'Google', 'AI']
+const CATEGORY_ORDER = ['Memory', 'Project', 'Dev', 'Google', 'AI']
 const HINT: Record<string, string> = {
   github: 'Personal access token (Contents/Repo read).',
   huggingface: 'Access token from huggingface.co/settings/tokens.',
+  obsidian: 'Point at your Obsidian vault’s Git repo — every agent reads & writes this one shared memory. Token needs repo read+write.',
+}
+const FIELD_LABEL: Record<string, string> = {
+  domain: 'domain (e.g. 7ei → 7ei.atlassian.net)', email: 'email', apiToken: 'API token', defaultProjectKey: 'default project key (O7MC)',
+  repo: 'owner/repo (e.g. Arturito7ei/7Ei-MC_TARCO)', root: 'root folder (vault)', branch: 'branch (main)', token: 'GitHub token (repo scope)',
 }
 
 export default function ConnectorsPanel({ orgId, getToken }: { orgId: string; getToken: Getter }) {
@@ -123,12 +128,13 @@ export default function ConnectorsPanel({ orgId, getToken }: { orgId: string; ge
                     {row.authType === 'token' ? (
                       <input style={s.input} type="password" placeholder="Paste token" value={form[row.id]?.token ?? ''} onChange={e => setF(row.id, 'token', e.target.value)} />
                     ) : (
-                      <>
-                        <input style={s.input} placeholder="domain (e.g. 7ei → 7ei.atlassian.net)" value={form[row.id]?.domain ?? ''} onChange={e => setF(row.id, 'domain', e.target.value)} />
-                        <input style={s.input} placeholder="email" value={form[row.id]?.email ?? ''} onChange={e => setF(row.id, 'email', e.target.value)} />
-                        <input style={s.input} type="password" placeholder="API token" value={form[row.id]?.apiToken ?? ''} onChange={e => setF(row.id, 'apiToken', e.target.value)} />
-                        <input style={s.input} placeholder="default project key (O7MC)" value={form[row.id]?.defaultProjectKey ?? ''} onChange={e => setF(row.id, 'defaultProjectKey', e.target.value)} />
-                      </>
+                      row.fields.map(f => (
+                        <input key={f} style={s.input}
+                          type={/token|secret|apitoken/i.test(f) ? 'password' : 'text'}
+                          placeholder={FIELD_LABEL[f] ?? f}
+                          value={form[row.id]?.[f] ?? ''}
+                          onChange={e => setF(row.id, f, e.target.value)} />
+                      ))
                     )}
                     {HINT[row.id] && <p style={s.hint}>{HINT[row.id]} <a style={s.link} href={row.docsUrl} target="_blank" rel="noreferrer">Get one ↗</a></p>}
                     <div style={s.actions}>


### PR DESCRIPTION
Turns the shared Obsidian vault into a **configurable connector** and gives **every agent read+write** access — a true shared memory.

- **Vault selector**: Connectors → *Obsidian Vault (shared memory)* card — enter repo (owner/name), root folder, branch, and a GitHub token; validated by listing the vault root. Stored encrypted (D4).
- **Per-org vault**: repo/root/branch no longer hardcoded — Memory tab + all endpoints read the configured vault.
- **Agent shared memory**: `GET/PUT /api/agent/memory/*` — agents read the vault and commit notes (as themselves) that other agents can read. Writes allowed anywhere in the vault subtree.
- **UI write**: `PUT /api/orgs/:id/memory/file`.

Path-traversal guarded, markdown-only writes. Backend 400+ tests (3 new suites), boot regression green, web tsc+build clean.