### PR TITLE
feat(MCA-ADAPT): http executor + adapter presets + 7ei-mc CLI

### DIFF
--- a/adapters/openclaw/mc.env.example
+++ b/adapters/openclaw/mc.env.example
@@ -8,8 +8,12 @@ MC_WORKDIR=/Users/artutito/7Ei-MC_TARCO        # canonical vault repo
 MC_ALLOW_SHELL=1
 MC_POLL_SECONDS=20
 
-# Executor: auto (llm if MC_LLM_API_KEY set, else shell) | shell | llm
+# Executor: auto (llm if MC_LLM_API_KEY set, else shell) | shell | llm | http
+# See ../presets/ for ready-made mc.env files (Codex, Gemini, NVIDIA-MiniMax, shell, http).
 MC_EXECUTOR=auto
+# MC_EXECUTOR=http forwards the task to your own bot:
+# MC_HTTP_URL=https://your-bot.example.com/mc
+# MC_HTTP_HEADER=Authorization: Bearer <your-bot-key>
 MC_MAX_STEPS=4
 # LLM brain (OpenAI-compatible). MiniMax shown; works with any compatible host.
 MC_LLM_BASE_URL=https://api.minimax.io/v1

--- a/adapters/openclaw/mc_adapter.py
+++ b/adapters/openclaw/mc_adapter.py
@@ -36,6 +36,8 @@ LLM_BASE  = os.environ.get("MC_LLM_BASE_URL", "").rstrip("/")
 LLM_KEY   = os.environ.get("MC_LLM_API_KEY", "")
 LLM_MODEL = os.environ.get("MC_LLM_MODEL", "MiniMax-Text-01")
 LLM_MAX_TOKENS = int(os.environ.get("MC_LLM_MAX_TOKENS", "1024"))  # some hosts (e.g. NVIDIA NIM minimax-m3) return empty choices without this
+HTTP_URL   = os.environ.get("MC_HTTP_URL", "")        # MC_EXECUTOR=http → POST tasks here
+HTTP_HEADER = os.environ.get("MC_HTTP_HEADER", "")    # optional "Name: value" auth header for the webhook
 TG_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN", "")
 TG_CHAT  = os.environ.get("TELEGRAM_CHAT_ID", "")
 
@@ -170,11 +172,38 @@ def llm_execute(task):
         return "failed", f"llm executor error: {e}"
 
 
+def http_execute(task):
+    """Forward the task to a bring-your-own HTTP bot and use its reply as the result.
+    POSTs {id,title,input} to MC_HTTP_URL. Accepts a JSON {output,status?} reply or plain text."""
+    if not HTTP_URL:
+        return "failed", "MC_HTTP_URL not configured"
+    headers = {"Content-Type": "application/json"}
+    if HTTP_HEADER and ":" in HTTP_HEADER:
+        k, v = HTTP_HEADER.split(":", 1)
+        headers[k.strip()] = v.strip()
+    payload = {"id": task.get("id"), "title": task.get("title"), "input": task.get("input") or ""}
+    req = urllib.request.Request(HTTP_URL, data=json.dumps(payload).encode(), headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            raw = r.read().decode()
+    except Exception as e:
+        return "failed", f"http executor error: {e}"
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return (data.get("status") or "done"), str(data.get("output") or data.get("result") or raw)
+    except Exception:
+        pass
+    return "done", raw
+
+
 def choose_executor():
     if EXECUTOR == "shell":
         return shell_execute
     if EXECUTOR == "llm":
         return llm_execute
+    if EXECUTOR == "http":
+        return http_execute
     # auto
     return llm_execute if LLM_KEY else shell_execute
 
@@ -224,7 +253,8 @@ def load_secrets():
 def main():
     if not TOKEN:
         print("MC_AGENT_TOKEN is required", file=sys.stderr); sys.exit(2)
-    mode = "llm" if choose_executor() is llm_execute else "shell"
+    _ex = choose_executor()
+    mode = {id(llm_execute): "llm", id(shell_execute): "shell", id(http_execute): "http"}.get(id(_ex), "auto")
     print(f"7Ei MC adapter → {BASE}  (executor={mode}, shell={'on' if ALLOW_SHELL else 'off'}, workdir={WORKDIR})")
     heartbeat("green")
     load_secrets()

--- a/adapters/presets/README.md
+++ b/adapters/presets/README.md
@@ -1,0 +1,33 @@
+# Adapter presets (MCA-ADAPT S2.2)
+
+Drop-in `mc.env` presets for the 7Ei Mission Control adapter (`adapters/openclaw/mc_adapter.py`).
+Every LLM preset reuses the same OpenAI-compatible `llm` executor — only the base URL + model differ.
+**"If it can receive a heartbeat, it's hired."**
+
+Copy a preset to `~/.openclaw/mc-adapter/mc.env`, then fill `MC_AGENT_TOKEN` (mint in Cockpit → agent card)
+and the provider key.
+
+| Preset | Runtime | Executor | Notes |
+|---|---|---|---|
+| `codex.env` | OpenAI (Codex/GPT) | `llm` | `MC_LLM_API_KEY` = OpenAI key |
+| `gemini.env` | Google Gemini | `llm` | Google's OpenAI-compatible endpoint |
+| `nvidia-minimax.env` | MiniMax-M3 @ NVIDIA NIM | `llm` | needs `MC_LLM_MAX_TOKENS` (NIM quirk) |
+| `shell.env` | Deterministic shell | `shell` | runs `task.input` as a command (gated) |
+| `http.env` | Bring-your-own HTTP bot | `http` | POSTs the task to your webhook |
+
+Common to all: `MC_BASE_URL=https://7ei-backend.fly.dev`, `MC_AGENT_TOKEN=<paste>`, `MC_POLL_SECONDS=20`.
+
+## shell.env
+```
+MC_EXECUTOR=shell
+MC_ALLOW_SHELL=1
+MC_WORKDIR=/Users/artutito/7Ei-MC_TARCO
+```
+
+## http.env  (generic webhook / HTTP bot)
+```
+MC_EXECUTOR=http
+MC_HTTP_URL=https://your-bot.example.com/mc
+MC_HTTP_HEADER=Authorization: Bearer <your-bot-key>
+```
+The adapter POSTs `{id,title,input}` to `MC_HTTP_URL`; reply with JSON `{"output":"...","status":"done"}` or plain text.

--- a/adapters/presets/codex.env
+++ b/adapters/presets/codex.env
@@ -1,0 +1,12 @@
+# 7Ei MC adapter — Codex / OpenAI (GPT) brain. Copy to ~/.openclaw/mc-adapter/mc.env
+MC_BASE_URL=https://7ei-backend.fly.dev
+MC_AGENT_TOKEN=<paste-agent-token>
+MC_WORKDIR=/Users/artutito/7Ei-MC_TARCO
+MC_ALLOW_SHELL=0
+MC_POLL_SECONDS=20
+
+MC_EXECUTOR=llm
+MC_MAX_STEPS=4
+MC_LLM_BASE_URL=https://api.openai.com/v1
+MC_LLM_API_KEY=<openai-api-key>
+MC_LLM_MODEL=gpt-4o-mini

--- a/adapters/presets/gemini.env
+++ b/adapters/presets/gemini.env
@@ -1,0 +1,12 @@
+# 7Ei MC adapter — Google Gemini brain (OpenAI-compatible endpoint). Copy to mc.env
+MC_BASE_URL=https://7ei-backend.fly.dev
+MC_AGENT_TOKEN=<paste-agent-token>
+MC_WORKDIR=/Users/artutito/7Ei-MC_TARCO
+MC_ALLOW_SHELL=0
+MC_POLL_SECONDS=20
+
+MC_EXECUTOR=llm
+MC_MAX_STEPS=4
+MC_LLM_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai
+MC_LLM_API_KEY=<google-ai-studio-key>
+MC_LLM_MODEL=gemini-2.0-flash

--- a/adapters/presets/nvidia-minimax.env
+++ b/adapters/presets/nvidia-minimax.env
@@ -1,0 +1,13 @@
+# 7Ei MC adapter — MiniMax-M3 via NVIDIA NIM (OpenAI-compatible). Copy to mc.env
+MC_BASE_URL=https://7ei-backend.fly.dev
+MC_AGENT_TOKEN=<paste-agent-token>
+MC_WORKDIR=/Users/artutito/7Ei-MC_TARCO
+MC_ALLOW_SHELL=0
+MC_POLL_SECONDS=20
+
+MC_EXECUTOR=llm
+MC_MAX_STEPS=4
+MC_LLM_BASE_URL=https://integrate.api.nvidia.com/v1
+MC_LLM_API_KEY=<nvidia-nvapi-key>
+MC_LLM_MODEL=minimaxai/minimax-m3
+MC_LLM_MAX_TOKENS=1024

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,19 @@
+# 7ei-mc — operator CLI (MCA-ADAPT S2.3)
+
+Zero-dependency Node (18+) CLI that wraps the 7Ei Mission Control **agent API**. Drive an agent, tail work,
+and read/write the shared memory vault from a terminal.
+
+```bash
+export MC_BASE_URL=https://7ei-backend.fly.dev
+export MC_AGENT_TOKEN=mca_...        # mint in Cockpit → agent card
+
+node cli/mc.mjs me
+node cli/mc.mjs tasks assigned
+node cli/mc.mjs claim <taskId>        # → { runId, sessionState }
+node cli/mc.mjs runlog <runId> "did X"
+node cli/mc.mjs result <taskId> done "finished"
+node cli/mc.mjs mem tree vault/Protocols
+node cli/mc.mjs mem write vault/Memory/agents/note.md "shared memory line"
+```
+
+Install as a command: `npm i -g ./cli` then `7ei-mc me`. Tests: `cd cli && npm test`.

--- a/cli/lib.mjs
+++ b/cli/lib.mjs
@@ -1,0 +1,49 @@
+// Pure request-builder for the 7ei-mc CLI (MCA-ADAPT S2.3).
+// Maps argv → { method, path, body? } against the agent API. No IO here → unit-testable.
+
+function need(v, name) { if (!v) throw new Error(`missing ${name}`) }
+const q = (p) => encodeURIComponent(p ?? '')
+
+export function buildRequest(args) {
+  const [cmd, ...rest] = args
+  switch (cmd) {
+    case 'me':
+      return { method: 'GET', path: '/api/agent/me' }
+    case 'tasks':
+      return { method: 'GET', path: `/api/agent/tasks?state=${q(rest[0] || 'assigned')}` }
+    case 'claim':
+      need(rest[0], 'taskId'); return { method: 'POST', path: `/api/agent/tasks/${rest[0]}/claim` }
+    case 'result':
+      need(rest[0], 'taskId')
+      return { method: 'POST', path: `/api/agent/tasks/${rest[0]}/result`, body: { status: rest[1] || 'done', output: rest.slice(2).join(' ') } }
+    case 'comment':
+      need(rest[0], 'taskId'); return { method: 'POST', path: `/api/agent/tasks/${rest[0]}/comment`, body: { body: rest.slice(1).join(' ') } }
+    case 'heartbeat':
+      return { method: 'POST', path: '/api/agent/heartbeat', body: { status: rest[0] || 'green' } }
+    case 'runlog':
+      need(rest[0], 'runId'); return { method: 'POST', path: `/api/agent/runs/${rest[0]}/log`, body: { log: rest.slice(1).join(' ') } }
+    case 'mem': {
+      const sub = rest[0]
+      if (sub === 'tree') return { method: 'GET', path: `/api/agent/memory/tree?path=${q(rest[1] || 'vault')}` }
+      if (sub === 'read') { need(rest[1], 'path'); return { method: 'GET', path: `/api/agent/memory/file?path=${q(rest[1])}` } }
+      if (sub === 'write') { need(rest[1], 'path'); return { method: 'PUT', path: '/api/agent/memory/file', body: { path: rest[1], markdown: rest.slice(2).join(' ') } } }
+      throw new Error('mem <tree|read|write>')
+    }
+    default:
+      throw new Error(`unknown command: ${cmd ?? '(none)'}`)
+  }
+}
+
+export const HELP = `7ei-mc — operator CLI for the 7Ei Mission Control agent API
+env: MC_BASE_URL (default https://7ei-backend.fly.dev), MC_AGENT_TOKEN (required)
+
+  me                                     who am I
+  tasks [assigned|in_progress|open|all]  my queue
+  claim <taskId>                         atomic checkout (returns runId + sessionState)
+  result <taskId> <done|failed> <text>   report a result
+  comment <taskId> <text...>             comment on a ticket
+  heartbeat [green|amber|stale]          liveness
+  runlog <runId> <msg...>                append a run log line
+  mem tree [path]                        list the shared vault
+  mem read <path>                        read a note
+  mem write <path> <markdown...>         write a note (commits to the vault)`

--- a/cli/mc.mjs
+++ b/cli/mc.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// 7ei-mc — thin operator CLI over the agent API. Zero dependencies (Node 18+ global fetch).
+import { buildRequest, HELP } from './lib.mjs'
+
+const args = process.argv.slice(2)
+if (!args.length || args[0] === 'help' || args[0] === '-h' || args[0] === '--help') { console.log(HELP); process.exit(0) }
+
+const BASE = process.env.MC_BASE_URL || 'https://7ei-backend.fly.dev'
+const TOKEN = process.env.MC_AGENT_TOKEN
+if (!TOKEN) { console.error('MC_AGENT_TOKEN is required (mint one in Cockpit → agent card)'); process.exit(2) }
+
+let req
+try { req = buildRequest(args) } catch (e) { console.error('✗', e.message, '\n\n' + HELP); process.exit(2) }
+
+const res = await fetch(BASE + req.path, {
+  method: req.method,
+  headers: { Authorization: `Bearer ${TOKEN}`, ...(req.body ? { 'Content-Type': 'application/json' } : {}) },
+  body: req.body ? JSON.stringify(req.body) : undefined,
+})
+const text = await res.text()
+let out = text; try { out = JSON.stringify(JSON.parse(text), null, 2) } catch {}
+console.log(out)
+process.exit(res.ok ? 0 : 1)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@7ei/mc",
+  "version": "0.1.0",
+  "description": "7ei-mc — operator CLI for the 7Ei Mission Control agent API",
+  "type": "module",
+  "bin": { "7ei-mc": "./mc.mjs" },
+  "scripts": { "test": "node --test" },
+  "engines": { "node": ">=18" },
+  "license": "MIT"
+}

--- a/cli/test/lib.test.mjs
+++ b/cli/test/lib.test.mjs
@@ -1,0 +1,26 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildRequest } from '../lib.mjs'
+
+test('routes commands to method + path + body', () => {
+  assert.deepEqual(buildRequest(['me']), { method: 'GET', path: '/api/agent/me' })
+  assert.equal(buildRequest(['tasks']).path, '/api/agent/tasks?state=assigned')
+  assert.equal(buildRequest(['tasks', 'all']).path, '/api/agent/tasks?state=all')
+  assert.deepEqual(buildRequest(['claim', 'T1']), { method: 'POST', path: '/api/agent/tasks/T1/claim' })
+  const r = buildRequest(['result', 'T1', 'done', 'all', 'good'])
+  assert.equal(r.path, '/api/agent/tasks/T1/result')
+  assert.deepEqual(r.body, { status: 'done', output: 'all good' })
+  assert.equal(buildRequest(['mem', 'tree']).path, '/api/agent/memory/tree?path=vault')
+  assert.equal(buildRequest(['mem', 'read', 'vault/a b.md']).path, '/api/agent/memory/file?path=vault%2Fa%20b.md')
+  const w = buildRequest(['mem', 'write', 'vault/Memory/x.md', 'hi', 'there'])
+  assert.equal(w.method, 'PUT')
+  assert.deepEqual(w.body, { path: 'vault/Memory/x.md', markdown: 'hi there' })
+  assert.deepEqual(buildRequest(['heartbeat']).body, { status: 'green' })
+  assert.equal(buildRequest(['runlog', 'R1', 'step', '2']).body.log, 'step 2')
+})
+
+test('errors on missing args + unknown command', () => {
+  assert.throws(() => buildRequest(['claim']), /missing taskId/)
+  assert.throws(() => buildRequest(['nope']), /unknown command/)
+  assert.throws(() => buildRequest(['mem', 'read']), /missing path/)
+})


### PR DESCRIPTION
Phase 2 (epic MCA-52: MCA-53/54/55). Widens bring-your-own-agent and adds an operator CLI.

- **S2.1 HTTP executor** — `MC_EXECUTOR=http` forwards the task to your webhook and uses the reply as the result (config-only HTTP bot).
- **S2.2 Presets** — `adapters/presets/` for Codex/OpenAI, Gemini, NVIDIA-MiniMax, shell, http — all reuse the OpenAI-compatible `llm` loop.
- **S2.3 `7ei-mc` CLI** — zero-dep Node CLI over the agent API (me/tasks/claim/result/comment/heartbeat/runlog/mem). Pure router + unit tests; verified live against prod (OpenClaw `me` + vault `mem tree`).