### PR TITLE
feat(MCA-WORK): attachments/work-products, ticket timeline, preview URLs

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -106,8 +106,26 @@ export const tasks = sqliteTable('tasks', {
   lockToken: text('lock_token'),                      // MCA-EXEC S1.1: atomic checkout lock owner
   lockedAt: integer('locked_at', { mode: 'timestamp' }),
   blockedBy: text('blocked_by'),                      // MCA-EXEC S1.4: JSON array of blocker task ids
+  labels: text('labels'),                             // MCA-WORK S3.2: JSON array of label strings
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   completedAt: integer('completed_at', { mode: 'timestamp' }),
+})
+
+// MCA-WORK S3.1: attachments + work products on a task. kind = link | file | work_product.
+// Agent work-products commit to the shared vault; url points at the vault path (or an external link).
+export const taskAttachments = sqliteTable('task_attachments', {
+  id: text('id').primaryKey(),
+  orgId: text('org_id').notNull(),
+  taskId: text('task_id').notNull(),
+  kind: text('kind').notNull().default('link'),       // link | file | work_product
+  name: text('name').notNull(),
+  url: text('url'),
+  contentType: text('content_type'),
+  sizeBytes: integer('size_bytes'),
+  sha: text('sha'),
+  createdByAgentId: text('created_by_agent_id'),
+  createdByUser: text('created_by_user'),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 
 // MCA-EXEC S1.2: one row per agent execution — structured logs, cost, and
@@ -156,6 +174,8 @@ export const workspaces = sqliteTable('workspaces', {
   repoUrl: text('repo_url'),
   baseBranch: text('base_branch').default('main'),
   previewUrl: text('preview_url'),
+  runtimeStatus: text('runtime_status'),              // MCA-WORK S3.3: stopped | starting | running
+  devUrl: text('dev_url'),                             // running dev-server URL reported by the agent
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -97,6 +97,12 @@ export async function setupDatabase() {
     `CREATE INDEX IF NOT EXISTS idx_agent_runs_agent ON agent_runs(agent_id, status)`,
     `CREATE TABLE IF NOT EXISTS task_comments (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, task_id TEXT NOT NULL, author_agent_id TEXT, author_user TEXT, body TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE INDEX IF NOT EXISTS idx_task_comments_task ON task_comments(task_id)`,
+    // MCA-WORK (Phase 3): attachments/work-products, labels, workspace runtime
+    `ALTER TABLE tasks ADD COLUMN labels TEXT`,
+    `ALTER TABLE workspaces ADD COLUMN runtime_status TEXT`,
+    `ALTER TABLE workspaces ADD COLUMN dev_url TEXT`,
+    `CREATE TABLE IF NOT EXISTS task_attachments (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, task_id TEXT NOT NULL, kind TEXT NOT NULL DEFAULT 'link', name TEXT NOT NULL, url TEXT, content_type TEXT, size_bytes INTEGER, sha TEXT, created_by_agent_id TEXT, created_by_user TEXT, created_at INTEGER NOT NULL)`,
+    `CREATE INDEX IF NOT EXISTS idx_task_attachments_task ON task_attachments(task_id)`,
   ]
   for (const sql of alterStatements) {
     try { await dbClient.execute(sql) } catch { /* column already exists */ }

--- a/backend/src/routes/agent-api.ts
+++ b/backend/src/routes/agent-api.ts
@@ -131,6 +131,45 @@ export async function agentApiRoutes(app: FastifyInstance) {
     return { ok: true, comment: row }
   })
 
+  // MCA-WORK S3.1 — attach a work product (markdown → committed to the vault) or a link.
+  app.post('/api/agent/tasks/:taskId/attachment', async (req, reply) => {
+    const agent = (req as any).agent
+    const { taskId } = req.params as any
+    const b = (req.body ?? {}) as any
+    const task = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+    if (!task || task.orgId !== agent.orgId) return reply.code(404).send({ error: 'Task not found' })
+    let kind = 'link', url: string | null = b.url ?? null, name = b.name ?? 'attachment', sha: string | null = null
+    if (typeof b.markdown === 'string') {
+      const { token, cfg } = await resolveVault(agent.orgId)
+      if (!token) return reply.code(400).send({ error: 'vault not connected (required for work products)' })
+      const safeName = String(b.name || `work-product-${Date.now()}.md`).replace(/[^A-Za-z0-9._-]/g, '-')
+      const path = `${cfg.root}/07-Agents/work-products/${taskId}/${safeName}`
+      if (!isMarkdownPath(path)) return reply.code(400).send({ error: 'work product name must end .md/.markdown/.txt' })
+      const w = await vaultWrite(token, cfg, path, b.markdown, `mc(${agent.name}): work product for ${taskId}`, { name: `${agent.name} (7Ei agent)`, email: 'agents@7ei.ai' })
+      if (!w.ok) return reply.code(w.status).send({ error: w.error ?? `GitHub ${w.status}` })
+      kind = 'work_product'; url = `vault:${path}`; name = safeName; sha = w.commit ?? null
+    } else if (!url) {
+      return reply.code(400).send({ error: 'provide markdown (work product) or url (link)' })
+    }
+    const row = { id: randomUUID(), orgId: agent.orgId, taskId, kind, name: String(name).slice(0, 300), url, contentType: b.contentType ?? (kind === 'work_product' ? 'text/markdown' : null), sizeBytes: null, sha, createdByAgentId: agent.id, createdByUser: null, createdAt: new Date() }
+    await db.insert(schema.taskAttachments).values(row)
+    return { ok: true, attachment: row }
+  })
+
+  // MCA-WORK S3.3 — report a running dev server + preview URL for a workspace.
+  app.post('/api/agent/workspaces/:id/runtime', async (req, reply) => {
+    const agent = (req as any).agent
+    const { id } = req.params as any
+    const b = (req.body ?? {}) as any
+    const ws = await db.query.workspaces.findFirst({ where: eq(schema.workspaces.id, id) })
+    if (!ws || ws.orgId !== agent.orgId) return reply.code(404).send({ error: 'Workspace not found' })
+    const patch: any = { runtimeStatus: b.status ?? 'running' }
+    if (typeof b.previewUrl === 'string') patch.previewUrl = b.previewUrl
+    if (typeof b.devUrl === 'string') patch.devUrl = b.devUrl
+    await db.update(schema.workspaces).set(patch).where(eq(schema.workspaces.id, id))
+    return { ok: true, workspaceId: id, runtimeStatus: patch.runtimeStatus }
+  })
+
   // Liveness/heartbeat — also returns who the runtime is authenticated as.
   app.post('/api/agent/heartbeat', async (req) => {
     const agent = (req as any).agent

--- a/backend/src/routes/all.ts
+++ b/backend/src/routes/all.ts
@@ -19,6 +19,7 @@ import { spendForScope, evaluatePolicy } from '../services/budget'
 import { buildExport, remapImport } from '../services/portability'
 import { encrypt, decrypt, maskValue } from '../services/secrets'
 import { isSafeVaultPath, isMarkdownPath, parseVaultConfig, vaultList, vaultRead, vaultWrite } from '../services/vault-connector'
+import { normalizeAttachmentKind, buildTimeline } from '../services/tickets'
 import { validateManifest, grantedCapabilities, exposedTools } from '../services/plugins'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
@@ -671,6 +672,17 @@ export async function taskRoutes(app: FastifyInstance) {
     await db.insert(schema.workspaces).values(ws)
     reply.code(201); return { workspace: ws }
   })
+  // MCA-WORK S3.3 — set a workspace's preview URL / dev-server runtime status.
+  app.patch('/api/workspaces/:id', async (req) => {
+    const { id } = req.params as any
+    const b = (req.body ?? {}) as any
+    const patch: any = {}
+    if (typeof b.previewUrl === 'string') patch.previewUrl = b.previewUrl
+    if (typeof b.devUrl === 'string') patch.devUrl = b.devUrl
+    if (typeof b.runtimeStatus === 'string') patch.runtimeStatus = b.runtimeStatus
+    if (Object.keys(patch).length) await db.update(schema.workspaces).set(patch).where(eq(schema.workspaces.id, id))
+    return { ok: true }
+  })
   app.delete('/api/workspaces/:id', async (req, reply) => {
     await db.delete(schema.workspaces).where(eq(schema.workspaces.id, (req.params as any).id))
     reply.code(204)
@@ -811,6 +823,51 @@ export async function taskRoutes(app: FastifyInstance) {
     const { taskId } = req.params as any
     const runs = await db.select().from(schema.agentRuns).where(eq(schema.agentRuns.taskId, taskId)).orderBy(desc(schema.agentRuns.startedAt)).limit(20)
     return { runs }
+  })
+
+  // MCA-WORK S3.1 — attachments + work products.
+  app.get('/api/tasks/:taskId/attachments', async (req) => {
+    const { taskId } = req.params as any
+    const attachments = await db.select().from(schema.taskAttachments).where(eq(schema.taskAttachments.taskId, taskId)).orderBy(desc(schema.taskAttachments.createdAt))
+    return { attachments }
+  })
+  app.post('/api/tasks/:taskId/attachments', async (req, reply) => {
+    const { taskId } = req.params as any
+    const b = (req.body ?? {}) as any
+    if (!b.name || !b.url) return reply.code(400).send({ error: 'name and url required' })
+    const task = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+    if (!task) return reply.code(404).send({ error: 'Task not found' })
+    const row = { id: randomUUID(), orgId: task.orgId, taskId, kind: normalizeAttachmentKind(b.kind), name: String(b.name).slice(0, 300), url: String(b.url).slice(0, 2000), contentType: b.contentType ?? null, sizeBytes: b.sizeBytes ?? null, sha: null, createdByAgentId: null, createdByUser: (req as any).userId ?? null, createdAt: new Date() }
+    await db.insert(schema.taskAttachments).values(row); reply.code(201); return { attachment: row }
+  })
+  app.delete('/api/attachments/:id', async (req, reply) => {
+    const { id } = req.params as any
+    await db.delete(schema.taskAttachments).where(eq(schema.taskAttachments.id, id)); reply.code(204)
+  })
+
+  // MCA-WORK S3.2 — labels, subtasks, unified ticket timeline.
+  app.patch('/api/tasks/:taskId/labels', async (req) => {
+    const { taskId } = req.params as any
+    const b = (req.body ?? {}) as any
+    const labels = Array.isArray(b.labels) ? b.labels.map(String) : []
+    await db.update(schema.tasks).set({ labels: JSON.stringify(labels) }).where(eq(schema.tasks.id, taskId))
+    return { ok: true, labels }
+  })
+  app.get('/api/tasks/:taskId/subtasks', async (req) => {
+    const { taskId } = req.params as any
+    const subtasks = await db.select().from(schema.tasks).where(eq(schema.tasks.parentTaskId, taskId)).orderBy(schema.tasks.createdAt)
+    return { subtasks }
+  })
+  app.get('/api/tasks/:taskId/timeline', async (req, reply) => {
+    const { taskId } = req.params as any
+    const task = await db.query.tasks.findFirst({ where: eq(schema.tasks.id, taskId) })
+    if (!task) return reply.code(404).send({ error: 'Task not found' })
+    const [comments, runs, attachments] = await Promise.all([
+      db.select().from(schema.taskComments).where(eq(schema.taskComments.taskId, taskId)),
+      db.select().from(schema.agentRuns).where(eq(schema.agentRuns.taskId, taskId)),
+      db.select().from(schema.taskAttachments).where(eq(schema.taskAttachments.taskId, taskId)),
+    ])
+    return { timeline: buildTimeline({ task, comments, runs, attachments }) }
   })
 
   app.patch('/api/tasks/:taskId', async (req) => {

--- a/backend/src/services/tickets.ts
+++ b/backend/src/services/tickets.ts
@@ -1,0 +1,37 @@
+// MCA-WORK Phase 3 — pure helpers for labels, attachment kinds, and the unified
+// ticket timeline (comments + runs + attachments + lifecycle → one sorted feed).
+
+export function parseLabels(json: string | null | undefined): string[] {
+  if (!json) return []
+  try { const a = JSON.parse(json); return Array.isArray(a) ? a.filter((x) => typeof x === 'string') : [] }
+  catch { return [] }
+}
+
+const KINDS = ['link', 'file', 'work_product']
+export function normalizeAttachmentKind(kind: string | null | undefined): string {
+  const k = String(kind ?? 'link')
+  return KINDS.includes(k) ? k : 'link'
+}
+
+const ms = (d: any): number =>
+  d instanceof Date ? d.getTime() : (typeof d === 'number' ? d : (Date.parse(d) || 0))
+
+export interface TimelineItem { kind: string; at: number; by?: string | null; text?: string; ref?: string }
+
+export function buildTimeline(input: {
+  task?: { createdAt?: any; completedAt?: any; status?: string } | null
+  comments?: Array<{ body: string; authorAgentId?: string | null; authorUser?: string | null; createdAt: any }>
+  runs?: Array<{ id: string; status: string; startedAt: any; endedAt?: any; agentId?: string | null }>
+  attachments?: Array<{ name: string; kind: string; url?: string | null; createdAt: any }>
+}): TimelineItem[] {
+  const items: TimelineItem[] = []
+  if (input.task?.createdAt) items.push({ kind: 'created', at: ms(input.task.createdAt), text: 'task created' })
+  for (const c of input.comments ?? []) items.push({ kind: 'comment', at: ms(c.createdAt), by: c.authorAgentId ?? c.authorUser ?? null, text: c.body })
+  for (const r of input.runs ?? []) {
+    items.push({ kind: 'run_started', at: ms(r.startedAt), by: r.agentId ?? null, ref: r.id })
+    if (r.endedAt) items.push({ kind: `run_${r.status}`, at: ms(r.endedAt), by: r.agentId ?? null, ref: r.id })
+  }
+  for (const a of input.attachments ?? []) items.push({ kind: `attach_${a.kind}`, at: ms(a.createdAt), text: a.name, ref: a.url ?? undefined })
+  if (input.task?.completedAt) items.push({ kind: input.task.status === 'done' ? 'completed' : 'closed', at: ms(input.task.completedAt) })
+  return items.sort((x, y) => x.at - y.at)
+}

--- a/backend/src/tests/tickets.test.ts
+++ b/backend/src/tests/tickets.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseLabels, normalizeAttachmentKind, buildTimeline } from '../services/tickets'
+
+test('parseLabels tolerates junk', () => {
+  assert.deepEqual(parseLabels('["a","b"]'), ['a', 'b'])
+  assert.deepEqual(parseLabels(null), [])
+  assert.deepEqual(parseLabels('{"x":1}'), [])
+  assert.deepEqual(parseLabels('[1,"a"]'), ['a'])
+})
+
+test('normalizeAttachmentKind clamps to known kinds', () => {
+  assert.equal(normalizeAttachmentKind('work_product'), 'work_product')
+  assert.equal(normalizeAttachmentKind('file'), 'file')
+  assert.equal(normalizeAttachmentKind('weird'), 'link')
+  assert.equal(normalizeAttachmentKind(null), 'link')
+})
+
+test('buildTimeline merges + sorts events ascending', () => {
+  const tl = buildTimeline({
+    task: { createdAt: 100, completedAt: 500, status: 'done' },
+    comments: [{ body: 'hi', authorAgentId: 'a1', createdAt: 300 }],
+    runs: [{ id: 'r1', status: 'done', startedAt: 200, endedAt: 400, agentId: 'a1' }],
+    attachments: [{ name: 'report.md', kind: 'work_product', url: 'vault/x.md', createdAt: 350 }],
+  })
+  assert.deepEqual(tl.map(i => i.kind), ['created', 'run_started', 'comment', 'attach_work_product', 'run_done', 'completed'])
+  assert.deepEqual(tl.map(i => i.at), [100, 200, 300, 350, 400, 500])
+  assert.equal(tl.find(i => i.kind === 'comment')!.by, 'a1')
+})
+
+test('buildTimeline handles empty input', () => {
+  assert.deepEqual(buildTimeline({}), [])
+})


### PR DESCRIPTION
Phase 3 (epic MCA-56: MCA-57/58/59). Matches Paperclip task/workspace depth.

- **S3.1 attachments + work products** — agent work-products **commit to the shared vault**; link attachments store a URL. `task_attachments` + add/list/delete.
- **S3.2 labels + subtasks + timeline** — `tasks.labels`, `GET /tasks/:id/subtasks`, and `GET /tasks/:id/timeline` (comments+runs+attachments+lifecycle, sorted). Pure builder + tests.
- **S3.3 workspace runtime** — `runtime_status`+`dev_url`; `PATCH /workspaces/:id`; agent `POST /agent/workspaces/:id/runtime` reports a dev server + **preview URL**.

tsc clean · boot regression green · full suite (4 new tests).