### PR TITLE
feat(ops): adapter secret-store LLM key + Mac-mini bundle + go-live runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ coverage/
 # Misc
 .cache/
 tmp/
+adapters/openclaw/__pycache__/

--- a/GO-LIVE.md
+++ b/GO-LIVE.md
@@ -1,0 +1,159 @@
+# Mission Control — Go-Live Runbook
+
+Operational steps to take Mission Control from "works for the founder in dev
+mode" to a hardened production setup. Each item is a **user action** in a vendor
+console (Clerk, Google Cloud, NVIDIA, GitHub, the Mac mini) — the engineering to
+make each a one-step change is already shipped; this doc gives the exact steps,
+env-var names, and where they're consumed.
+
+Owner: Arturito · Last updated: 2026-07-02
+
+| # | Item | Risk if skipped | Effort |
+|---|------|-----------------|--------|
+| 1 | Clerk **production** instance | Dev keys rate-limit + show a dev banner; anyone can sign up | ~20 min |
+| 2 | Google consent screen: Gmail/Calendar scopes | Gmail/Calendar connectors can't read data | ~15 min |
+| 3 | Rotate exposed tokens (NVIDIA key, vault PAT) | Leaked creds usable by anyone who saw them | ~15 min |
+| 4 | Move OpenClaw to the Mac mini | Agent dies when the laptop sleeps/closes | ~10 min |
+
+---
+
+## 1. Clerk production instance
+
+The web app (`app.7ei.ai`, Vercel) currently runs on a Clerk **development**
+instance. Production needs its own instance + keys.
+
+**Steps (Clerk dashboard → your app):**
+1. Create a **Production** instance (or "Deploy to production").
+2. Add `app.7ei.ai` as the production domain; complete the DNS records Clerk
+   shows (CNAMEs for `clerk.`, `accounts.`, etc.).
+3. Configure the production sign-in/up methods and (optionally) restrict sign-ups
+   to the `7ei.ai` domain.
+4. Copy the **production** keys.
+
+**Set on Vercel (Project → Settings → Environment Variables, Production):**
+
+| var | value |
+|-----|-------|
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | `pk_live_…` |
+| `CLERK_SECRET_KEY` | `sk_live_…` |
+
+Keep `NEXT_PUBLIC_CLERK_SIGN_IN_URL` / `NEXT_PUBLIC_API_URL` as-is. Redeploy the
+web project so the new env is baked in. Verify: sign out, sign back in on
+`app.7ei.ai` — the dev banner is gone and the URL is your Clerk prod domain.
+
+> Prohibited for the assistant: creating the Clerk account/instance and entering
+> keys must be done by you. I can't create accounts or enter credentials.
+
+---
+
+## 2. Google OAuth consent screen — Gmail + Calendar scopes
+
+The Google connector already **requests** the full scope set (see
+`backend/src/services/google-auth.ts`):
+
+```
+openid
+.../auth/userinfo.email
+.../auth/userinfo.profile
+.../auth/drive.readonly
+.../auth/drive.file
+.../auth/gmail.readonly     ← sensitive
+.../auth/gmail.send         ← sensitive
+.../auth/calendar.events    ← sensitive
+```
+
+Google won't grant the sensitive ones until they're listed on the OAuth consent
+screen and (for an External/published app) the app passes verification.
+
+**Steps (Google Cloud Console → the project holding `GOOGLE_CLIENT_ID`):**
+1. **APIs & Services → Enabled APIs**: enable **Gmail API** and **Google
+   Calendar API** (Drive already enabled).
+2. **OAuth consent screen → Data access / Scopes → Add or remove scopes**: add
+   `gmail.readonly`, `gmail.send`, `calendar.events` (Drive scopes already there).
+3. Fastest path for a small team: keep the app in **Testing** mode and add each
+   user (e.g. `arturito@7ei.ai`) under **Test users** — sensitive scopes work
+   immediately for listed testers, no Google verification needed.
+   - To go fully public later, **Publish** the app and complete Google's
+     sensitive-scope verification (privacy policy URL, demo video, etc.).
+4. Confirm the **Authorized redirect URI** matches
+   `${PUBLIC_URL}/api/auth/google/callback` — i.e.
+   `https://7ei-backend.fly.dev/api/auth/google/callback` (or your custom API
+   domain if `PUBLIC_URL` differs).
+
+**Backend env (Fly `7ei-backend` — already set, confirm values):**
+`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `PUBLIC_URL`.
+
+Verify: **Connectors → Google → Connect**, approve the consent screen, then hit
+**Test** on Gmail and Calendar — both should return data.
+
+---
+
+## 3. Rotate exposed tokens
+
+Two secrets were handled in plaintext during setup and should be rotated. **I
+can't rotate these for you** (that means authenticating to vendor consoles and
+minting credentials) — do the rotate in each console, then paste the new value
+into the app's encrypted store or Fly secrets as noted.
+
+### 3a. NVIDIA NIM API key (the MiniMax brain)
+- Rotate: **NVIDIA NGC / build.nvidia.com → API keys → revoke the old key →
+  generate a new one** (`nvapi-…`).
+- Store it **once**, encrypted, in the app: **Cockpit → Secrets → set
+  `MC_LLM_API_KEY`** to the new key. The adapter pulls it at boot via
+  `GET /api/agent/secrets` and injects it into its env — so **no plaintext key
+  needs to live in `mc.env`** on any adapter host (this is the hardening in
+  `adapters/openclaw/mc_adapter.py`: `llm_chat()` and the `auto` executor read
+  `MC_LLM_API_KEY` from the environment at call time).
+- Remove any lingering `MC_LLM_API_KEY=nvapi-…` line from
+  `~/.openclaw/mc-adapter/mc.env` on every host, then restart the adapter.
+
+### 3b. Vault GitHub PAT (agent shared-memory writes)
+- Rotate: **GitHub → Settings → Developer settings → Personal access tokens →
+  regenerate** the token used for `Arturito7ei/7Ei-MC_TARCO`. Give it **repo
+  write** scope (fine-grained: Contents read/write on that repo) so agents can
+  commit memory.
+- Store it in the app: **Connectors → Obsidian Vault** (or the secret store key
+  `GITHUB_VAULT_TOKEN`, part of `VAULT_CONFIG`). Test the connector — the tree
+  should list and a write should commit.
+
+> After rotating, the old values in any chat scrollback or local file are dead.
+> Don't paste live secrets into chat again — set them directly in the console /
+> the app's Secrets UI.
+
+---
+
+## 4. Move OpenClaw to the Mac mini
+
+Run the always-on adapter on the Mac mini instead of the laptop.
+
+1. On the Mac mini, check out the repo (or copy the `adapters/` folder).
+2. Mint a fresh agent token: **app → Cockpit → the OpenClaw agent → rotate
+   token** (`POST /api/agents/:id/rotate-token`). This also invalidates the
+   laptop's token.
+3. Install in one command:
+   ```bash
+   cd 7Ei-Mission_Control_App/adapters/mac-mini
+   MC_AGENT_TOKEN=mca_xxx ./setup.sh --preset nvidia-minimax --yes
+   ```
+   It installs `mc_adapter.py`, writes `~/.openclaw/mc-adapter/mc.env`
+   (chmod 600, **no LLM key** — pulled from the secret store per §3a), renders +
+   loads the launchd keep-alive, and runs a one-pass smoke test.
+4. On the **laptop**, stop the old service so two hosts don't double-claim:
+   ```bash
+   launchctl unload ~/Library/LaunchAgents/com.7ei.mc-adapter.plist
+   ```
+5. Verify on the Mac mini: `tail -f ~/.openclaw/mc-adapter/adapter.log` and watch
+   a heartbeat go green in the app's Cockpit. Assign a test task and confirm it
+   reaches **done**.
+
+See `adapters/mac-mini/README.md` for flags and operations.
+
+---
+
+## Assistant boundaries (why some steps are yours)
+
+Per the operating rules, I don't create accounts, enter passwords/keys, complete
+OAuth consent, change account settings, or rotate/enter credentials on your
+behalf. Everything I *can* automate — the adapter hardening, the one-command
+installer, this runbook — is done; the four items above are the console actions
+that only you can perform.

--- a/adapters/mac-mini/README.md
+++ b/adapters/mac-mini/README.md
@@ -1,0 +1,60 @@
+# Mac-mini adapter bundle
+
+One-command install of the 7Ei Mission Control external-agent adapter on a
+dedicated Mac mini (or any always-on Mac). Wraps `../openclaw/mc_adapter.py` +
+`../presets/` with an installer that also sets up a launchd keep-alive service.
+
+## Install
+
+```bash
+# on the Mac mini, from a checkout of this repo:
+cd 7Ei-Mission_Control_App/adapters/mac-mini
+./setup.sh
+```
+
+Interactive prompts: `MC_BASE_URL`, `MC_WORKDIR`, executor preset, and the agent
+token. Or run non-interactively:
+
+```bash
+MC_AGENT_TOKEN=mca_xxx ./setup.sh --preset nvidia-minimax --yes
+```
+
+### Flags
+
+| flag | effect |
+|------|--------|
+| `--preset <name>` | `codex` \| `gemini` \| `nvidia-minimax` \| `shell` \| `http` (default `shell`) |
+| `--no-shell` | force `MC_ALLOW_SHELL=0` (adapter won't run shell commands) |
+| `--yes` | non-interactive; loads launchd at the end |
+| `--no-launchd` | install + smoke test only |
+
+## What it does
+
+1. Copies `mc_adapter.py` to `~/.openclaw/mc-adapter/`.
+2. Writes `~/.openclaw/mc-adapter/mc.env` (chmod 600) from the chosen preset,
+   overlaid with your `MC_BASE_URL` / token / workdir.
+3. Renders `~/Library/LaunchAgents/com.7ei.mc-adapter.plist` for the current
+   user (sources `mc.env` then execs the adapter; `KeepAlive` restarts on crash).
+4. Runs one `--once` poll pass as a smoke test.
+5. Optionally `launchctl load -w` the service (survives reboot).
+
+## The LLM key is not stored on disk
+
+`mc.env` intentionally leaves `MC_LLM_API_KEY` **empty**. At boot the adapter
+calls `GET /api/agent/secrets` and injects the org's scoped secrets into its
+environment — so set `MC_LLM_API_KEY` once in the app (**Cockpit → Secrets**,
+encrypted at rest) and every adapter host picks it up. `llm_chat()` and the
+`auto` executor read the key from the environment at call time, so the injected
+value is used and no plaintext key ever lands in `mc.env`.
+
+## Operate
+
+```bash
+tail -f ~/.openclaw/mc-adapter/adapter.log        # live logs
+launchctl unload ~/Library/LaunchAgents/com.7ei.mc-adapter.plist   # stop
+launchctl load -w ~/Library/LaunchAgents/com.7ei.mc-adapter.plist  # start
+```
+
+To upgrade the adapter, re-run `./setup.sh` (it overwrites `mc_adapter.py` and
+reloads the service). See `../openclaw/README.md` for the execution model and
+`../../GO-LIVE.md` for the full production runbook.

--- a/adapters/mac-mini/setup.sh
+++ b/adapters/mac-mini/setup.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# 7Ei Mission Control — one-command Mac-mini adapter installer.
+#
+# Installs mc_adapter.py + a chosen executor preset into ~/.openclaw/mc-adapter,
+# renders the launchd keep-alive plist for the current user, runs a one-shot
+# smoke test, and (optionally) loads the service so it survives reboots.
+#
+# Usage:
+#   ./setup.sh                       # interactive
+#   MC_AGENT_TOKEN=mca_... ./setup.sh --preset nvidia-minimax --yes
+#
+# Flags:
+#   --preset <name>   codex | gemini | nvidia-minimax | shell | http  (default: shell)
+#   --no-shell        force MC_ALLOW_SHELL=0 (safer; shell executor disabled)
+#   --yes             non-interactive; don't prompt, load launchd at the end
+#   --no-launchd      install + smoke test only; skip launchctl load
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+# ── locate the bundle (this dir) and the adapter/presets in the repo ──────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ADAPTER_SRC="$SCRIPT_DIR/../openclaw/mc_adapter.py"
+PRESET_DIR="$SCRIPT_DIR/../presets"
+DEST="$HOME/.openclaw/mc-adapter"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.7ei.mc-adapter.plist"
+
+PRESET="shell"
+ALLOW_SHELL="1"
+ASSUME_YES="0"
+DO_LAUNCHD="1"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --preset)    PRESET="$2"; shift 2;;
+    --no-shell)  ALLOW_SHELL="0"; shift;;
+    --yes)       ASSUME_YES="1"; shift;;
+    --no-launchd) DO_LAUNCHD="0"; shift;;
+    *) echo "unknown flag: $1" >&2; exit 2;;
+  esac
+done
+
+say() { printf '\033[1;33m▸\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+[ -f "$ADAPTER_SRC" ] || die "adapter not found at $ADAPTER_SRC (run from the repo checkout)"
+command -v python3 >/dev/null || die "python3 not found — install the Xcode command line tools"
+
+# ── config values ─────────────────────────────────────────────────────────────
+MC_BASE_URL="${MC_BASE_URL:-https://7ei-backend.fly.dev}"
+MC_WORKDIR="${MC_WORKDIR:-$HOME/7Ei-MC_TARCO}"
+MC_AGENT_TOKEN="${MC_AGENT_TOKEN:-}"
+
+if [ "$ASSUME_YES" = "0" ]; then
+  read -r -p "MC_BASE_URL   [$MC_BASE_URL]: " _v; MC_BASE_URL="${_v:-$MC_BASE_URL}"
+  read -r -p "MC_WORKDIR    [$MC_WORKDIR]: " _v; MC_WORKDIR="${_v:-$MC_WORKDIR}"
+  read -r -p "Executor preset (codex|gemini|nvidia-minimax|shell|http) [$PRESET]: " _v; PRESET="${_v:-$PRESET}"
+fi
+
+if [ -z "$MC_AGENT_TOKEN" ]; then
+  if [ "$ASSUME_YES" = "1" ]; then die "MC_AGENT_TOKEN not set (mint one in the app -> Cockpit -> rotate token)"; fi
+  read -r -p "MC_AGENT_TOKEN (mca_...): " MC_AGENT_TOKEN
+fi
+[ -n "$MC_AGENT_TOKEN" ] || die "a token is required"
+
+# ── install files ─────────────────────────────────────────────────────────────
+say "Installing to $DEST"
+mkdir -p "$DEST" "$(dirname "$PLIST_DEST")"
+cp "$ADAPTER_SRC" "$DEST/mc_adapter.py"
+chmod +x "$DEST/mc_adapter.py"
+
+# base env from preset (if any) then overlay the resolved values
+ENV_FILE="$DEST/mc.env"
+if [ "$PRESET" != "shell" ] && [ -f "$PRESET_DIR/$PRESET.env" ]; then
+  cp "$PRESET_DIR/$PRESET.env" "$ENV_FILE"
+  say "Seeded mc.env from preset '$PRESET'"
+else
+  : > "$ENV_FILE"
+  [ "$PRESET" = "shell" ] || say "no preset file for '$PRESET'; writing minimal mc.env"
+fi
+
+# strip any keys we are about to (re)write, then append the resolved config
+_tmp="$(mktemp)"
+grep -vE '^(MC_BASE_URL|MC_AGENT_TOKEN|MC_WORKDIR|MC_ALLOW_SHELL|MC_EXECUTOR)=' "$ENV_FILE" > "$_tmp" 2>/dev/null || true
+mv "$_tmp" "$ENV_FILE"
+{
+  echo "MC_BASE_URL=$MC_BASE_URL"
+  echo "MC_AGENT_TOKEN=$MC_AGENT_TOKEN"
+  echo "MC_WORKDIR=$MC_WORKDIR"
+  echo "MC_ALLOW_SHELL=$ALLOW_SHELL"
+  # 'shell' preset -> force shell executor; otherwise leave preset/auto in place
+  [ "$PRESET" = "shell" ] && echo "MC_EXECUTOR=shell"
+} >> "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+say "Wrote $ENV_FILE (chmod 600)"
+say "Note: leave MC_LLM_API_KEY empty here — the adapter pulls it from the encrypted"
+say "      secret store at boot (Cockpit -> Secrets -> MC_LLM_API_KEY). No plaintext key on disk."
+
+# ── render the launchd plist for THIS user ────────────────────────────────────
+cat > "$PLIST_DEST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>            <string>com.7ei.mc-adapter</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>set -a; source "$ENV_FILE"; set +a; exec /usr/bin/python3 "$DEST/mc_adapter.py"</string>
+  </array>
+  <key>RunAtLoad</key>        <true/>
+  <key>KeepAlive</key>        <true/>
+  <key>ThrottleInterval</key> <integer>10</integer>
+  <key>StandardOutPath</key>  <string>$DEST/adapter.log</string>
+  <key>StandardErrorPath</key><string>$DEST/adapter.err</string>
+</dict>
+</plist>
+PLIST
+say "Rendered $PLIST_DEST"
+
+# ── smoke test (one pass) ─────────────────────────────────────────────────────
+say "Smoke test: one poll pass..."
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"; set +a
+if python3 "$DEST/mc_adapter.py" --once; then
+  say "Smoke test OK"
+else
+  die "smoke test failed — check the token / MC_BASE_URL and re-run"
+fi
+
+# ── load launchd ──────────────────────────────────────────────────────────────
+if [ "$DO_LAUNCHD" = "1" ] && [ "$ASSUME_YES" = "0" ]; then
+  read -r -p "Load the keep-alive service now (survives reboot)? [y/N]: " _v
+  { [ "${_v:-N}" = "y" ] || [ "${_v:-N}" = "Y" ]; } || DO_LAUNCHD="0"
+fi
+if [ "$DO_LAUNCHD" = "1" ]; then
+  launchctl unload "$PLIST_DEST" 2>/dev/null || true
+  launchctl load -w "$PLIST_DEST"
+  say "launchd service loaded. Logs: tail -f $DEST/adapter.log"
+else
+  say "Skipped launchd. Start manually:  launchctl load -w $PLIST_DEST"
+fi
+
+say "Done. Agent will poll $MC_BASE_URL every few seconds."

--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -26,11 +26,22 @@ curl -sX POST "$MC_BASE_URL/api/orgs/$ORG_ID/agents/external" \
 
 ## 2. Install on the Mac mini
 
+One command (recommended — installs adapter + preset + launchd keep-alive, runs a
+smoke test): see [`../mac-mini/`](../mac-mini/README.md).
+
+```bash
+cd adapters/mac-mini
+MC_AGENT_TOKEN=mca_xxx ./setup.sh --preset nvidia-minimax --yes
+```
+
+Or by hand:
+
 ```bash
 mkdir -p ~/.openclaw/mc-adapter
 cp mc_adapter.py mc.env.example ~/.openclaw/mc-adapter/
 cp ~/.openclaw/mc-adapter/mc.env.example ~/.openclaw/mc-adapter/mc.env
 # edit mc.env → paste MC_AGENT_TOKEN, set MC_BASE_URL + MC_WORKDIR
+# leave MC_LLM_API_KEY empty — it's injected from the encrypted secret store at boot
 ```
 
 ## 3. Run

--- a/adapters/openclaw/mc_adapter.py
+++ b/adapters/openclaw/mc_adapter.py
@@ -122,13 +122,25 @@ def _extract_bash(text):
 
 
 def llm_chat(messages):
-    """OpenAI-compatible chat completion → assistant content string."""
-    if not (LLM_BASE and LLM_KEY):
+    """OpenAI-compatible chat completion → assistant content string.
+
+    Credentials are read from os.environ at call time (not import time) so a key
+    injected by load_secrets() from the encrypted D4 secret store is picked up —
+    no plaintext MC_LLM_API_KEY needs to live in mc.env on disk.
+    """
+    base = os.environ.get("MC_LLM_BASE_URL", LLM_BASE).rstrip("/")
+    key = os.environ.get("MC_LLM_API_KEY", LLM_KEY)
+    model = os.environ.get("MC_LLM_MODEL", LLM_MODEL)
+    try:
+        max_tokens = int(os.environ.get("MC_LLM_MAX_TOKENS", str(LLM_MAX_TOKENS)))
+    except ValueError:
+        max_tokens = LLM_MAX_TOKENS
+    if not (base and key):
         raise RuntimeError("MC_LLM_BASE_URL / MC_LLM_API_KEY not configured")
     req = urllib.request.Request(
-        LLM_BASE + "/chat/completions",
-        data=json.dumps({"model": LLM_MODEL, "messages": messages, "temperature": 0.2, "max_tokens": LLM_MAX_TOKENS}).encode(),
-        headers={"Authorization": "Bearer " + LLM_KEY, "Content-Type": "application/json"},
+        base + "/chat/completions",
+        data=json.dumps({"model": model, "messages": messages, "temperature": 0.2, "max_tokens": max_tokens}).encode(),
+        headers={"Authorization": "Bearer " + key, "Content-Type": "application/json"},
         method="POST")
     with urllib.request.urlopen(req, timeout=120) as r:
         data = json.loads(r.read().decode())
@@ -204,8 +216,9 @@ def choose_executor():
         return llm_execute
     if EXECUTOR == "http":
         return http_execute
-    # auto
-    return llm_execute if LLM_KEY else shell_execute
+    # auto — read the key from env at call time so a secret injected by
+    # load_secrets() counts (falls back to the import-time module global)
+    return llm_execute if os.environ.get("MC_LLM_API_KEY", LLM_KEY) else shell_execute
 
 
 def execute(task):
@@ -253,11 +266,12 @@ def load_secrets():
 def main():
     if not TOKEN:
         print("MC_AGENT_TOKEN is required", file=sys.stderr); sys.exit(2)
+    # Load scoped secrets first so an injected MC_LLM_API_KEY influences auto-executor selection.
+    heartbeat("green")
+    load_secrets()
     _ex = choose_executor()
     mode = {id(llm_execute): "llm", id(shell_execute): "shell", id(http_execute): "http"}.get(id(_ex), "auto")
     print(f"7Ei MC adapter → {BASE}  (executor={mode}, shell={'on' if ALLOW_SHELL else 'off'}, workdir={WORKDIR})")
-    heartbeat("green")
-    load_secrets()
     if "--once" in sys.argv:
         n = poll_once(); print(f"processed {n} task(s)"); return
     while True:


### PR DESCRIPTION
Closes the operational hardening open items.

**Adapter hardening** — `mc_adapter.py` now reads the LLM base/key/model/max-tokens from `os.environ` at call time (not import), and `load_secrets()` runs before `choose_executor()` in `main()`. Effect: the NVIDIA key can live only in the encrypted D4 secret store (`MC_LLM_API_KEY`, injected at boot) — no plaintext key on any adapter host. Backward compatible (falls back to import-time globals). Verified: `py_compile` + auto-executor picks `llm` only when the key is present in env.

**Mac-mini bundle** — `adapters/mac-mini/setup.sh` installs the adapter + a chosen preset, writes a chmod-600 `mc.env` with **no** LLM key, renders + loads the launchd keep-alive, and runs a one-pass smoke test. `bash -n` clean.

**Go-live runbook** — `GO-LIVE.md`: exact console steps + env-var names for the four user-only actions (Clerk production instance, Google sensitive scopes for Gmail/Calendar, NVIDIA + vault token rotation, moving OpenClaw to the Mac mini).