### PR TITLE
feat(MCA-75): agent memory bus — session summaries, shared-memory injection, nightly KV export

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -34,6 +34,9 @@ Remaining **user-only** console actions (assistant can't create accounts / enter
 3. Rotate NVIDIA key → set as `MC_LLM_API_KEY` secret; rotate vault GitHub PAT.
 4. Run `adapters/mac-mini/setup.sh` on the Mac mini; unload the laptop's launchd service.
 
+## Shared-memory bus (vault proposal R3)
+- **MCA-75** (2026-07-02): `POST /api/agent/memory/session-summary` (namespaced append to `Memory/agents/<slug>/recent.md`, same capability/policy gates as memory writes); `buildSystemPrompt()` now injects org + agent long-term vault memory (TTL-cached, truncated, non-critical on failure); nightly scheduler job exports each agent's DB memory KVs to `Memory/agents/<slug>/kv.md`. New `services/agent-memory.ts` + 19 tests (434 total).
+
 ## Refactors
 - **MCA-74** (2026-07-02): `routes/all.ts` (1,383 lines) split into domain modules (orgs/agents/tasks/projects/costs/skills/auth/credentials), `all.ts` kept as barrel; `sendPushNotification` + token map extracted to `services/push.ts` (fixes the routes→services inversion). No behavior change; 415 tests + 11/11 evals green.
 

--- a/backend/src/routes/agent-api.ts
+++ b/backend/src/routes/agent-api.ts
@@ -8,6 +8,7 @@ import { decrypt, resolveSecretsForAgent } from '../services/secrets'
 import { workspaceRuntime } from '../services/workspaces'
 import { parseVaultConfig, isSafeVaultPath, isMarkdownPath, vaultList, vaultRead, vaultWrite } from '../services/vault-connector'
 import { parseBlockedBy, blockersSatisfied, isClaimable, appendLog } from '../services/runs'
+import { agentRecentPath, appendSection, formatSessionSummary } from '../services/agent-memory'
 import { parseCapabilities, isCapabilityAllowed, signRunToken, requiresApproval } from '../services/governance2'
 
 const RUNTIME_BRANCH: Record<string, string> = { openclaw: 'claw', cursor: 'cursor', claude_code: 'cc' }
@@ -22,6 +23,14 @@ const RUNTIME_BRANCH: Record<string, string> = { openclaw: 'claw', cursor: 'curs
 const HeartbeatSchema = z.object({
   status: z.enum(['green', 'amber', 'stale']).default('green'),
   note: z.string().max(500).optional(),
+})
+
+const SessionSummarySchema = z.object({
+  focus: z.string().min(1).max(2000),
+  completed: z.string().max(4000).optional(),
+  blockers: z.string().max(2000).optional(),
+  next: z.string().max(2000).optional(),
+  date: z.string().optional(),
 })
 
 const ResultSchema = z.object({
@@ -105,6 +114,33 @@ export async function agentApiRoutes(app: FastifyInstance) {
     if (!isSafeVaultPath(path, cfg.root) || !isMarkdownPath(path)) return reply.code(400).send({ error: 'path must be a .md/.markdown/.txt file inside the vault root' })
     const committer = { name: `${agent.name} (7Ei agent)`, email: 'agents@7ei.ai' }
     const r = await vaultWrite(token, cfg, path, String(body.markdown ?? ''), body.message || `mc(${agent.name}): update ${path}`, committer)
+    if (!r.ok) return reply.code(r.status).send({ error: r.error ?? `GitHub ${r.status}` })
+    return { ok: true, path, commit: r.commit }
+  })
+
+  // MCA-75 — append a session-continuity summary to the agent's OWN recent.md.
+  // The path is derived from the agent's name; the agent cannot choose it.
+  app.post('/api/agent/memory/session-summary', async (req, reply) => {
+    const agent = (req as any).agent
+    // S4.2 capability gate + S4.1 execution policy gate (same action as memory/file).
+    if (!isCapabilityAllowed(parseCapabilities(agent.permissions), 'memory:write')) return reply.code(403).send({ error: 'agent lacks capability memory:write' })
+    const pols = await db.select().from(schema.executionPolicies).where(and(eq(schema.executionPolicies.orgId, agent.orgId), eq(schema.executionPolicies.action, 'memory.write')))
+    if (requiresApproval(pols as any, 'memory.write')) {
+      await db.insert(schema.approvalRequests).values({ id: randomUUID(), orgId: agent.orgId, type: 'memory.write', summary: `${agent.name} → session summary`, payload: { agentId: agent.id }, status: 'pending', requestedByAgentId: agent.id, decidedBy: null, decidedAt: null, createdAt: new Date() } as any)
+      return reply.code(202).send({ pending: true, error: 'requires human approval (policy: memory.write)' })
+    }
+    const { token, cfg } = await resolveVault(agent.orgId)
+    if (!token) return reply.code(400).send({ error: 'vault not connected' })
+    const body = SessionSummarySchema.parse(req.body ?? {})
+    const date = body.date || new Date().toISOString().slice(0, 10)
+    const path = agentRecentPath(agent.name, cfg.root)
+    const existing = await vaultRead(token, cfg, path)
+    const markdown = appendSection(
+      existing.ok ? existing.markdown : undefined,
+      formatSessionSummary({ date, focus: body.focus, completed: body.completed, blockers: body.blockers, next: body.next, agentName: agent.name }),
+    )
+    const committer = { name: `${agent.name} (7Ei agent)`, email: 'agents@7ei.ai' }
+    const r = await vaultWrite(token, cfg, path, markdown, `mc(${agent.name}): session summary ${date}`, committer)
     if (!r.ok) return reply.code(r.status).send({ error: r.error ?? `GitHub ${r.status}` })
     return { ok: true, path, commit: r.commit }
   })

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -13,6 +13,7 @@ import { isExternalAgent, notifyExternalAgent } from './agent-runtime'
 import { goalAncestry, formatGoalContext } from './goals'
 import { canAgentRun } from './governance'
 import { enforceAgentBudget } from './budget'
+import { resolveVaultForOrg, fetchSharedMemory } from './agent-memory'
 
 export interface ExecuteResult {
   output: string; tokensUsed: number; costUsd: number; durationMs: number
@@ -131,6 +132,18 @@ export async function executeAgentTask(opts: {
       console.warn('Drive context fetch failed (non-critical):', err)
     }
 
+    // Shared memory bus (MCA-75): org + agent long-term vault notes into the prompt.
+    let sharedMemory = ''
+    try {
+      const vault = await resolveVaultForOrg(agent.orgId)
+      if (vault.token) {
+        const { block } = await fetchSharedMemory(vault.token, vault.cfg, agent.name)
+        sharedMemory = block
+      }
+    } catch (err) {
+      console.warn('Shared memory fetch failed (non-critical):', err)
+    }
+
     // Org chart context (MCA-PC A1): manager + direct reports for the reporting line.
     const hierAgents = await db.select({ id: schema.agents.id, name: schema.agents.name, reportsTo: schema.agents.reportsTo })
       .from(schema.agents).where(eq(schema.agents.orgId, agent.orgId))
@@ -150,7 +163,7 @@ export async function executeAgentTask(opts: {
       }
     } catch { /* non-critical */ }
 
-    const systemPrompt = buildSystemPrompt(agent, memoryBlock, isOrchestrator, org, ragContext, driveContext, availableAgents, hierarchy, goalContext)
+    const systemPrompt = buildSystemPrompt(agent, memoryBlock, isOrchestrator, org, ragContext, driveContext, availableAgents, hierarchy, goalContext, sharedMemory)
     const model    = agent.llmModel    ?? 'claude-sonnet-4-20250514'
     const provider = agent.llmProvider ?? 'anthropic'
     const orgApiKey = org?.deployConfig?.[`${provider}_api_key`] as string | undefined
@@ -252,6 +265,7 @@ export function buildSystemPrompt(
   availableAgents?: Array<{ name: string; role: string }>,
   hierarchy?: { title?: string | null; manager?: string | null; reports?: string[] },
   goalContext?: string,
+  sharedMemory?: string,
 ): string {
   const lines: string[] = []
 
@@ -270,6 +284,9 @@ export function buildSystemPrompt(
   }
   if (goalContext) {
     lines.push(goalContext, '')
+  }
+  if (sharedMemory) {
+    lines.push(sharedMemory, '')
   }
 
   if (agent.agentType === 'advisor' && agent.advisorPersona) {

--- a/backend/src/services/agent-memory.ts
+++ b/backend/src/services/agent-memory.ts
@@ -1,0 +1,141 @@
+// Agent memory bus (MCA-75) — per-agent vault memory under Memory/agents/<slug>/.
+// Pure formatting/path helpers + one fetch wrapper that pulls the org + agent
+// long-term notes from the shared vault into a system-prompt block. Paths follow
+// the same convention as PUT /api/agent/memory/file: root-prefixed, so they pass
+// isSafeVaultPath(path, cfg.root) (e.g. `vault/Memory/agents/arturito/recent.md`).
+
+import { db, schema } from '../db/client'
+import { eq, and } from 'drizzle-orm'
+import { decrypt } from './secrets'
+import { VaultConfig, parseVaultConfig, vaultRead } from './vault-connector'
+
+/** Kebab-case an agent name for vault paths: "Arturito R2D2" → "arturito-r2d2". */
+export function slugifyAgentName(name: string): string {
+  return String(name ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+}
+
+/** Root-relative memory directory for an agent: `Memory/agents/<slug>`. */
+export function agentMemoryDir(name: string): string {
+  return `Memory/agents/${slugifyAgentName(name)}`
+}
+
+const withRoot = (root: string, rel: string): string => {
+  const r = String(root ?? '').replace(/^\/+|\/+$/g, '')
+  return r ? `${r}/${rel}` : rel
+}
+
+/** Session-continuity log: `<root>/Memory/agents/<slug>/recent.md`. */
+export function agentRecentPath(name: string, root: string): string {
+  return withRoot(root, `${agentMemoryDir(name)}/recent.md`)
+}
+
+/** Curated agent notes: `<root>/Memory/agents/<slug>/long-term.md`. */
+export function agentLongTermPath(name: string, root: string): string {
+  return withRoot(root, `${agentMemoryDir(name)}/long-term.md`)
+}
+
+/** Nightly DB-memory mirror: `<root>/Memory/agents/<slug>/kv.md`. */
+export function agentKvPath(name: string, root: string): string {
+  return withRoot(root, `${agentMemoryDir(name)}/kv.md`)
+}
+
+/** Org-wide shared notes: `<root>/Memory/long-term.md`. */
+export function orgLongTermPath(root: string): string {
+  return withRoot(root, 'Memory/long-term.md')
+}
+
+/** Session-continuity block appended to recent.md — empty optional lines are omitted. */
+export function formatSessionSummary(input: {
+  date: string; focus: string; completed?: string; blockers?: string; next?: string; agentName: string
+}): string {
+  const lines = [`## Session: ${input.date} — ${input.agentName}`, `- **Focus:** ${input.focus}`]
+  if (input.completed) lines.push(`- **Completed:** ${input.completed}`)
+  if (input.blockers)  lines.push(`- **Blockers:** ${input.blockers}`)
+  if (input.next)      lines.push(`- **Next:** ${input.next}`)
+  return lines.join('\n')
+}
+
+/** Append a block with exactly one blank line separator; missing/empty file → block as-is. */
+export function appendSection(existing: string | undefined, block: string): string {
+  const prev = String(existing ?? '').replace(/\s+$/, '')
+  return prev ? `${prev}\n\n${block}` : block
+}
+
+/** Deterministic markdown mirror of an agent's DB memory (sorted by key, no frontmatter). */
+export function formatKvExport(
+  agentName: string,
+  kvs: Array<{ key: string; value: string; updatedAt?: Date | null }>,
+  generatedAt: Date = new Date(),
+): string {
+  const sorted = [...kvs].sort((a, b) => a.key.localeCompare(b.key))
+  const lines = [`# Memory KV export — ${agentName}`, '']
+  for (const kv of sorted) {
+    const updated = kv.updatedAt ? ` _(updated ${kv.updatedAt.toISOString().slice(0, 10)})_` : ''
+    lines.push(`- **${kv.key}:** ${kv.value}${updated}`)
+  }
+  lines.push('', `_Generated: ${generatedAt.toISOString()}_`)
+  return lines.join('\n')
+}
+
+/** Build the SHARED MEMORY system-prompt block; '' when both inputs are empty. */
+export function sharedMemoryBlock(orgLongTerm: string | null, agentLongTerm: string | null, maxChars = 4000): string {
+  const truncate = (s: string) => s.length > maxChars ? s.slice(0, maxChars) + '\n[truncated]' : s
+  const org = String(orgLongTerm ?? '').trim()
+  const agent = String(agentLongTerm ?? '').trim()
+  if (!org && !agent) return ''
+  const parts: string[] = []
+  if (org)   parts.push('=== SHARED MEMORY (org long-term) ===', truncate(org))
+  if (agent) parts.push('=== AGENT LONG-TERM MEMORY ===', truncate(agent))
+  parts.push('=== END SHARED MEMORY ===')
+  return parts.join('\n')
+}
+
+// ─ Shared-memory TTL cache — one vault round-trip per agent per 5 minutes ────
+const SHARED_MEMORY_TTL_MS = 5 * 60_000
+const sharedMemoryCache = new Map<string, { block: string; fetchedAt: number }>()
+
+export function sharedMemoryCacheKey(cfg: VaultConfig, agentName: string): string {
+  return `${cfg.repo}:${agentName}`
+}
+
+export function getCachedSharedMemory(key: string, now: number = Date.now()): string | null {
+  const hit = sharedMemoryCache.get(key)
+  if (!hit) return null
+  if (now - hit.fetchedAt > SHARED_MEMORY_TTL_MS) { sharedMemoryCache.delete(key); return null }
+  return hit.block
+}
+
+export function setCachedSharedMemory(key: string, block: string, fetchedAt: number = Date.now()): void {
+  sharedMemoryCache.set(key, { block, fetchedAt })
+}
+
+export function clearSharedMemoryCache(): void {
+  sharedMemoryCache.clear()
+}
+
+/** Read org + agent long-term notes from the vault and build the prompt block.
+ *  404s (file not created yet) are tolerated as null; results are TTL-cached. */
+export async function fetchSharedMemory(token: string, cfg: VaultConfig, agentName: string): Promise<{ block: string }> {
+  const key = sharedMemoryCacheKey(cfg, agentName)
+  const cached = getCachedSharedMemory(key)
+  if (cached !== null) return { block: cached }
+  const readOrNull = async (path: string): Promise<string | null> => {
+    const r = await vaultRead(token, cfg, path)
+    return r.ok ? (r.markdown ?? '') : null
+  }
+  const [org, agent] = await Promise.all([
+    readOrNull(orgLongTermPath(cfg.root)),
+    readOrNull(agentLongTermPath(agentName, cfg.root)),
+  ])
+  const block = sharedMemoryBlock(org, agent)
+  setCachedSharedMemory(key, block)
+  return { block }
+}
+
+/** Resolve an org's vault token + config (mirrors resolveVault in agent-api.ts,
+ *  which is route-local — services must not import from routes). */
+export async function resolveVaultForOrg(orgId: string): Promise<{ token: string | null; cfg: VaultConfig }> {
+  const rows = await db.select().from(schema.secrets).where(and(eq(schema.secrets.orgId, orgId), eq(schema.secrets.scope, 'company')))
+  const get = (k: string): string | null => { const r = rows.find(x => x.key === k); if (!r) return null; try { return decrypt(r.valueEncrypted) } catch { return null } }
+  return { token: process.env.VAULT_GH_TOKEN || get('GITHUB_VAULT_TOKEN'), cfg: parseVaultConfig(get('VAULT_CONFIG')) }
+}

--- a/backend/src/services/scheduler.ts
+++ b/backend/src/services/scheduler.ts
@@ -12,6 +12,9 @@ import { randomUUID } from 'crypto'
 import { executeAgentTask } from './agent-executor'
 import { sendPushNotification } from './push'
 import { runHeartbeatSweep } from './heartbeat-engine'
+import { resolveVaultForOrg, formatKvExport, agentKvPath } from './agent-memory'
+import { vaultWrite } from './vault-connector'
+import type { MemoryEntry } from './memory'
 
 const TICK_INTERVAL_MS = 60_000  // check every minute
 let schedulerTimer: NodeJS.Timeout | null = null
@@ -45,6 +48,8 @@ async function runDueTasks() {
     }
     // MCA-PC C1: heartbeat engine sweep (orphan recovery, status recompute, wakes).
     runHeartbeatSweep().catch(err => console.error('Heartbeat sweep error:', err))
+    // MCA-75: nightly memory KV export (once per day, on the 03:00 UTC tick).
+    maybeRunNightlyKvExport(now).catch(err => console.error('KV export error:', err))
   } catch (err) {
     console.error('Scheduler tick error:', err)
   }
@@ -52,6 +57,36 @@ async function runDueTasks() {
 
 async function runScheduledTask(scheduled: any, triggerTime: Date) {
   await fireRoutine(scheduled, triggerTime)
+}
+
+// MCA-75: nightly memory KV export — mirror each agent's DB memory (memoryLongTerm)
+// into the vault at Memory/agents/<slug>/kv.md. Runs on the first scheduler tick
+// at or after KV_EXPORT_HOUR_UTC, at most once per UTC day. Writes are
+// unconditional: the generated-at line changes nightly anyway, and vaultWrite
+// already does the sha-lookup read — a compare read would only double the GETs.
+const KV_EXPORT_HOUR_UTC = 3
+let lastKvExportDay: string | null = null
+
+export async function maybeRunNightlyKvExport(now: Date): Promise<void> {
+  const day = now.toISOString().slice(0, 10)
+  if (now.getUTCHours() !== KV_EXPORT_HOUR_UTC || lastKvExportDay === day) return
+  lastKvExportDay = day
+  const orgs = await db.select({ id: schema.organisations.id }).from(schema.organisations)
+  for (const org of orgs) {
+    const { token, cfg } = await resolveVaultForOrg(org.id)
+    if (!token) continue
+    const agents = await db.select().from(schema.agents).where(eq(schema.agents.orgId, org.id))
+    for (const agent of agents) {
+      const memory = (agent.memoryLongTerm ?? {}) as Record<string, MemoryEntry>
+      const entries = Object.values(memory)
+      if (entries.length === 0) continue
+      const kvs = entries.map(e => ({ key: e.key, value: e.value, updatedAt: e.updatedAt ? new Date(e.updatedAt) : null }))
+      // Fire-and-forget per agent — one bad write must not sink the sweep.
+      vaultWrite(token, cfg, agentKvPath(agent.name, cfg.root), formatKvExport(agent.name, kvs),
+        `mc(system): nightly memory KV export ${day}`, { name: 'Mission Control (7Ei system)', email: 'agents@7ei.ai' })
+        .catch(err => console.warn(`KV export failed for ${agent.name} (non-critical):`, err))
+    }
+  }
 }
 
 // MCA-PC C3: fire a routine from any trigger (cron, webhook, or API). Creates a

--- a/backend/src/tests/agent-memory.test.ts
+++ b/backend/src/tests/agent-memory.test.ts
@@ -1,0 +1,160 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  slugifyAgentName, agentMemoryDir, agentRecentPath, agentLongTermPath, agentKvPath, orgLongTermPath,
+  formatSessionSummary, appendSection, formatKvExport, sharedMemoryBlock,
+  sharedMemoryCacheKey, getCachedSharedMemory, setCachedSharedMemory, clearSharedMemoryCache,
+} from '../services/agent-memory.ts'
+import { isSafeVaultPath, isMarkdownPath } from '../services/vault-connector.ts'
+
+// ─ slugifyAgentName ──────────────────────────────────────────────────────────
+
+test('[MCA-75] slugify: spaces + caps', () => {
+  assert.equal(slugifyAgentName('Arturito R2D2'), 'arturito-r2d2')
+})
+
+test('[MCA-75] slugify: dots collapse to single dashes', () => {
+  assert.equal(slugifyAgentName('J.A.R.V.I.S.'), 'j-a-r-v-i-s')
+})
+
+test('[MCA-75] slugify: strips non-alphanumerics incl. unicode-ish chars', () => {
+  assert.equal(slugifyAgentName('Café Ünit №7'), 'caf-nit-7')
+})
+
+test('[MCA-75] slugify: trims leading/trailing separators + handles empty', () => {
+  assert.equal(slugifyAgentName('  Maya!  '), 'maya')
+  assert.equal(slugifyAgentName(''), '')
+})
+
+// ─ path helpers ──────────────────────────────────────────────────────────────
+
+test('[MCA-75] agentMemoryDir is root-relative', () => {
+  assert.equal(agentMemoryDir('Arturito R2D2'), 'Memory/agents/arturito-r2d2')
+})
+
+test('[MCA-75] path helpers prefix the vault root and stay safe + markdown', () => {
+  assert.equal(agentRecentPath('Arturito R2D2', 'vault'), 'vault/Memory/agents/arturito-r2d2/recent.md')
+  assert.equal(agentLongTermPath('Maya', 'vault'), 'vault/Memory/agents/maya/long-term.md')
+  assert.equal(agentKvPath('Maya', 'vault'), 'vault/Memory/agents/maya/kv.md')
+  assert.equal(orgLongTermPath('vault'), 'vault/Memory/long-term.md')
+  // Must pass the same guards PUT /api/agent/memory/file applies.
+  assert.equal(isSafeVaultPath(agentRecentPath('Maya', 'vault'), 'vault'), true)
+  assert.equal(isMarkdownPath(agentRecentPath('Maya', 'vault')), true)
+})
+
+// ─ formatSessionSummary ──────────────────────────────────────────────────────
+
+test('[MCA-75] formatSessionSummary with all optionals', () => {
+  const block = formatSessionSummary({
+    date: '2026-07-02', focus: 'Ship MCA-75', completed: 'Service + route',
+    blockers: 'None', next: 'Nightly export', agentName: 'Arturito R2D2',
+  })
+  assert.equal(block, [
+    '## Session: 2026-07-02 — Arturito R2D2',
+    '- **Focus:** Ship MCA-75',
+    '- **Completed:** Service + route',
+    '- **Blockers:** None',
+    '- **Next:** Nightly export',
+  ].join('\n'))
+})
+
+test('[MCA-75] formatSessionSummary omits empty optional lines', () => {
+  const block = formatSessionSummary({ date: '2026-07-02', focus: 'Ship it', agentName: 'Maya' })
+  assert.equal(block, '## Session: 2026-07-02 — Maya\n- **Focus:** Ship it')
+  assert.equal(block.includes('Completed'), false)
+  assert.equal(block.includes('Blockers'), false)
+  assert.equal(block.includes('Next'), false)
+})
+
+// ─ appendSection ─────────────────────────────────────────────────────────────
+
+test('[MCA-75] appendSection: missing/empty file returns block as-is', () => {
+  assert.equal(appendSection(undefined, '## Session: x'), '## Session: x')
+  assert.equal(appendSection('', '## Session: x'), '## Session: x')
+})
+
+test('[MCA-75] appendSection: exactly one blank line separator', () => {
+  assert.equal(appendSection('# Recent\nold', '## new'), '# Recent\nold\n\n## new')
+})
+
+test('[MCA-75] appendSection: no double blank lines on trailing whitespace', () => {
+  assert.equal(appendSection('# Recent\nold\n\n\n', '## new'), '# Recent\nold\n\n## new')
+})
+
+// ─ formatKvExport ────────────────────────────────────────────────────────────
+
+test('[MCA-75] formatKvExport is deterministic (sorted keys, fixed timestamp)', () => {
+  const at = new Date('2026-07-02T03:00:00.000Z')
+  const kvs = [
+    { key: 'b_key', value: 'two', updatedAt: new Date('2026-07-01T00:00:00.000Z') },
+    { key: 'a_key', value: 'one', updatedAt: null },
+  ]
+  const a = formatKvExport('Maya', kvs, at)
+  const b = formatKvExport('Maya', [...kvs].reverse(), at)
+  assert.equal(a, b)  // input order must not matter
+  assert.equal(a, [
+    '# Memory KV export — Maya',
+    '',
+    '- **a_key:** one',
+    '- **b_key:** two _(updated 2026-07-01)_',
+    '',
+    '_Generated: 2026-07-02T03:00:00.000Z_',
+  ].join('\n'))
+})
+
+// ─ sharedMemoryBlock ─────────────────────────────────────────────────────────
+
+test('[MCA-75] sharedMemoryBlock: empty when both parts are empty', () => {
+  assert.equal(sharedMemoryBlock(null, null), '')
+  assert.equal(sharedMemoryBlock('', '   '), '')
+})
+
+test('[MCA-75] sharedMemoryBlock: includes only non-empty parts', () => {
+  const block = sharedMemoryBlock(null, 'agent notes')
+  assert.equal(block, '=== AGENT LONG-TERM MEMORY ===\nagent notes\n=== END SHARED MEMORY ===')
+  assert.equal(block.includes('org long-term'), false)
+})
+
+test('[MCA-75] sharedMemoryBlock: both parts in order with end marker', () => {
+  const block = sharedMemoryBlock('org notes', 'agent notes')
+  assert.equal(block, [
+    '=== SHARED MEMORY (org long-term) ===', 'org notes',
+    '=== AGENT LONG-TERM MEMORY ===', 'agent notes',
+    '=== END SHARED MEMORY ===',
+  ].join('\n'))
+})
+
+test('[MCA-75] sharedMemoryBlock: truncates each part to maxChars with marker', () => {
+  const block = sharedMemoryBlock('x'.repeat(50), 'short', 10)
+  assert.equal(block.includes('x'.repeat(10) + '\n[truncated]'), true)
+  assert.equal(block.includes('x'.repeat(11)), false)
+  assert.equal(block.includes('short'), true)  // under the cap → untouched
+})
+
+// ─ shared-memory TTL cache ───────────────────────────────────────────────────
+
+test('[MCA-75] cache: fresh entries hit, key includes repo + agent', () => {
+  clearSharedMemoryCache()
+  const key = sharedMemoryCacheKey({ repo: 'org/vault', root: 'vault', branch: 'main' }, 'Maya')
+  assert.equal(key, 'org/vault:Maya')
+  assert.equal(getCachedSharedMemory(key), null)
+  setCachedSharedMemory(key, 'block-1')
+  assert.equal(getCachedSharedMemory(key), 'block-1')
+})
+
+test('[MCA-75] cache: entries expire after the 5-minute TTL', () => {
+  clearSharedMemoryCache()
+  const now = Date.now()
+  setCachedSharedMemory('k', 'stale', now - 6 * 60_000)
+  assert.equal(getCachedSharedMemory('k', now), null)
+  setCachedSharedMemory('k', 'fresh', now - 4 * 60_000)
+  assert.equal(getCachedSharedMemory('k', now), 'fresh')
+})
+
+test('[MCA-75] cache: clearSharedMemoryCache empties everything', () => {
+  setCachedSharedMemory('k1', 'v1')
+  setCachedSharedMemory('k2', 'v2')
+  clearSharedMemoryCache()
+  assert.equal(getCachedSharedMemory('k1'), null)
+  assert.equal(getCachedSharedMemory('k2'), null)
+})


### PR DESCRIPTION
Implements R3 of vault 02-Architecture/Shared-Memory-Upgrade-2026-07-02.md. Session-summary endpoint (namespaced, gated), org+agent long-term memory injected into every MC agent's system prompt (TTL-cached, fail-open), nightly KV export to the vault. Verified: typecheck clean, npm test 434/434, evals 11/11. Jira: MCA-75.