### PR TITLE
feat(arturita A3): intent classifier + two-phase destructive confirm

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -26,7 +26,9 @@ Full planning/tracking layer filed (docs-only, no code yet): **PRD** `docs/PRD-a
 | **A1** · Persona, sessions & `/panic` | `services/arturita-session.ts` (pure: session mint/verify/revoke + TTL/step-up freshness, single-operator binding, nonce guard, panic plan); `arturita_sessions`/`arturita_bindings`/`arturita_nonces` tables; owner-scoped Arturita persona seed; session/bind routes + **`POST panic`** (owner-authed via session token). | ✅ done | #174 |
 | **A2** · Dangerous approval types + step-up | `services/dangerous-approvals.ts` (pure: `file_destructive`/`wallet_tx`/`email_send`/`machine_exec` classification, **machine-rendered verbatim** action summaries + scam/danger warnings, step-up evaluation); `decideApproval` gains a step-up gate (approve a dangerous type ⇒ needs a fresh command session, else 403); approvals POST regenerates the summary from a structured `action` (ignores model prose). | in progress | PR pending |
 
-Safety gate: **A2 is the mechanical approval-type gate** every dangerous surface depends on — **no B/C/D/E dangerous surface merges before A2 is on `main`**. `machine_exec` (C3) + wallet signing (E2) are last + most-guarded.
+| **A3** · Intent classifier + two-phase confirm | `services/intent.ts` (pure: `classifyIntent` tiers safe/destructive/critical + maps to A2 approval types; `confirmationPhraseFor`; `isConfirmed` two-phase — bare "yes" rejected for the top tier, action-verb restatement or tap required; sub-threshold STT re-prompts, never guesses). Table-driven tests over a destructive/safe/ambiguous corpus. | in progress | PR pending |
+
+Safety gate: **A2 (on `main`) is the mechanical approval-type gate** every dangerous surface depends on. `machine_exec` (C3) + wallet signing (E2) are last + most-guarded and stay blocked on **S3/S6/S4** until CONFIRMED.
 
 ## Paperclip gap-bridge — 5 / 5 phases shipped
 | Epic | Phase | Status |

--- a/backend/src/services/intent.ts
+++ b/backend/src/services/intent.ts
@@ -1,0 +1,206 @@
+// Arturita A3 — intent classifier + two-phase destructive confirmation.
+//
+// STT is fallible and Arturita's blast radius is large; a misheard destructive
+// command must never execute silently (PRD §7.2). This module is the *pure*
+// gate between "what the operator said" and "what Arturita is allowed to do
+// without a second, explicit, distinct confirmation":
+//
+//  - `classifyIntent(transcript)` tags a transcript with its danger tier and the
+//    dangerous approval type it maps to (aligns with A2's dangerous types).
+//  - `confirmationPhraseFor(intent)` gives the exact phrase the operator must say
+//    (or the button they must tap) to confirm — never a bare "yes".
+//  - `isConfirmed(...)` is the two-phase check: a preview is shown, then an
+//    explicit distinct confirmation (phrase restating the action, or a tap) is
+//    required; a generic affirmative is rejected for the top tier, and a low
+//    STT-confidence confirmation is re-prompted, never guessed.
+//
+// Table-driven and IO-free so it's exhaustively testable over a corpus of
+// destructive / safe / ambiguous phrasings.
+
+// ─── Tiers & kinds ───────────────────────────────────────────────────────────
+
+/** safe = read-only / no side effects; destructive = reversible-ish outward or
+ *  file mutation (move/overwrite/send/exec); critical = irreversible or funds
+ *  (delete/wallet sign/transfer) — the "top tier" that a generic yes can't
+ *  confirm (PRD §7.2). */
+export type IntentTier = 'safe' | 'destructive' | 'critical'
+
+export type IntentKind =
+  | 'delete' | 'move' | 'overwrite'     // file ops
+  | 'send'                              // email/outbound
+  | 'sign' | 'transfer'                 // wallet
+  | 'exec'                             // machine command
+  | 'read'                             // safe/no-op
+
+/** The A2 dangerous approval type a kind maps to (undefined for safe). */
+export type ApprovalType = 'file_destructive' | 'wallet_tx' | 'email_send' | 'machine_exec'
+
+interface KindSpec {
+  kind: IntentKind
+  tier: IntentTier
+  approvalType?: ApprovalType
+  /** confirmation verb the operator must restate (distinct, not a bare "yes"). */
+  confirmVerb: string
+  re: RegExp
+}
+
+// Order matters: the highest-tier match wins, and within a tier the earliest
+// spec wins. Critical (irreversible / funds) is checked first.
+const KIND_SPECS: KindSpec[] = [
+  // ── critical (top tier) ──
+  { kind: 'delete',   tier: 'critical', approvalType: 'file_destructive', confirmVerb: 'delete',
+    re: /\b(delete|delet(?:e|ing)|remove|erase|wipe|purge|shred|rm)\b/i },
+  { kind: 'transfer', tier: 'critical', approvalType: 'wallet_tx', confirmVerb: 'transfer',
+    re: /\b(transfer|swap|withdraw|send\s+[\d.]+\s*(?:eth|btc|usdc|usdt|sol|matic|tokens?)|pay\s+[\d.]+)\b/i },
+  { kind: 'sign',     tier: 'critical', approvalType: 'wallet_tx', confirmVerb: 'sign',
+    re: /\b(sign|approve\s+the\s+(?:transaction|tx|swap)|authori[sz]e\s+the\s+(?:transaction|tx|payment))\b/i },
+  // ── destructive ──
+  { kind: 'overwrite', tier: 'destructive', approvalType: 'file_destructive', confirmVerb: 'overwrite',
+    re: /\b(overwrite|replace|clobber|truncate)\b/i },
+  { kind: 'move',      tier: 'destructive', approvalType: 'file_destructive', confirmVerb: 'move',
+    re: /\b(move|archive|relocate|rename|mv)\b/i },
+  { kind: 'send',      tier: 'destructive', approvalType: 'email_send', confirmVerb: 'send',
+    re: /\b(send|email|e-mail|reply[- ]?all|forward)\b/i },
+  { kind: 'exec',      tier: 'destructive', approvalType: 'machine_exec', confirmVerb: 'run',
+    re: /\b(run|execute|exec|launch|invoke)\b/i },
+]
+
+export interface IntentClassification {
+  transcript: string
+  tier: IntentTier
+  kinds: IntentKind[]
+  /** The primary (highest-tier, earliest) kind — drives the confirmation phrase. */
+  primary: IntentKind
+  destructive: boolean
+  approvalType?: ApprovalType
+}
+
+const TIER_RANK: Record<IntentTier, number> = { safe: 0, destructive: 1, critical: 2 }
+
+/** Classify a transcript into a danger tier + the kinds it triggers. A blank or
+ *  read-only transcript is `safe`. Matching several kinds keeps them all but the
+ *  highest-tier / earliest one is primary. */
+export function classifyIntent(transcript: string | null | undefined): IntentClassification {
+  const text = String(transcript ?? '')
+  const matched = KIND_SPECS.filter(s => s.re.test(text))
+  if (matched.length === 0) {
+    return { transcript: text, tier: 'safe', kinds: ['read'], primary: 'read', destructive: false }
+  }
+  // Primary = highest tier, then earliest in KIND_SPECS order (spec order encodes
+  // priority within a tier).
+  const primarySpec = [...matched].sort((a, b) =>
+    TIER_RANK[b.tier] - TIER_RANK[a.tier] || KIND_SPECS.indexOf(a) - KIND_SPECS.indexOf(b))[0]
+  const tier = primarySpec.tier
+  return {
+    transcript: text,
+    tier,
+    kinds: matched.map(s => s.kind),
+    primary: primarySpec.kind,
+    destructive: true,
+    approvalType: primarySpec.approvalType,
+  }
+}
+
+/** The confirmation phrase the operator must say to confirm this intent — always
+ *  restates the action ("confirm delete"), never a bare "yes". */
+export function confirmationPhraseFor(intent: IntentClassification | IntentKind): string {
+  const kind = typeof intent === 'string' ? intent : intent.primary
+  const spec = KIND_SPECS.find(s => s.kind === kind)
+  const verb = spec?.confirmVerb ?? 'proceed'
+  return `confirm ${verb}`
+}
+
+// ─── STT confidence gate ─────────────────────────────────────────────────────
+
+/** Below this STT confidence, a transcript is too uncertain to act on — the
+ *  caller re-prompts instead of guessing (PRD §7.2, §8). */
+export const MIN_STT_CONFIDENCE = 0.6
+
+/** Should the caller re-prompt because the transcript was too uncertain?
+ *  Undefined/absent confidence is treated as unknown → do NOT force a reprompt
+ *  (some providers don't return confidence); a provided low score does. */
+export function shouldReprompt(confidence: number | null | undefined, threshold: number = MIN_STT_CONFIDENCE): boolean {
+  if (confidence == null) return false
+  return confidence < threshold
+}
+
+// ─── Generic-affirmative detection ───────────────────────────────────────────
+
+// Bare affirmatives that are NEVER sufficient to confirm a destructive action.
+const GENERIC_AFFIRMATIVES = new Set([
+  'yes', 'yeah', 'yep', 'yup', 'ya', 'ok', 'okay', 'sure', 'fine', 'go', 'go ahead',
+  'do it', 'confirm', 'confirmed', 'proceed', 'affirmative', 'uh huh', 'mhm', 'yes please',
+])
+
+function normalize(s: string): string {
+  return String(s ?? '').toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+/** Is this utterance a bare generic affirmative (insufficient for confirmation)? */
+export function isGenericAffirmative(utterance: string | null | undefined): boolean {
+  return GENERIC_AFFIRMATIVES.has(normalize(utterance ?? ''))
+}
+
+// ─── Two-phase confirmation ──────────────────────────────────────────────────
+
+export interface ConfirmResult {
+  ok: boolean
+  /** true when the confirmation was too uncertain and the caller should re-prompt. */
+  reprompt?: boolean
+  reason?: string
+}
+
+/**
+ * Decide whether a destructive intent is confirmed. Two-phase: a preview has been
+ * shown; this evaluates the operator's *second* action.
+ *  - A safe intent needs no confirmation (ok).
+ *  - An explicit tap (Cockpit/Telegram button) always confirms (distinct + explicit).
+ *  - A spoken confirmation must (a) clear the STT-confidence threshold — else
+ *    re-prompt, never guess — and (b) restate the action verb (contain the
+ *    confirmation verb / phrase). A bare generic affirmative is rejected,
+ *    especially for the critical top tier.
+ * Fail-closed: anything ambiguous → not ok.
+ */
+export function isConfirmed(input: {
+  intent: IntentClassification
+  utterance?: string | null
+  tapped?: boolean
+  confidence?: number | null
+}): ConfirmResult {
+  const { intent } = input
+  if (!intent.destructive) return { ok: true }
+
+  // Explicit tap is always an acceptable distinct confirmation.
+  if (input.tapped) return { ok: true }
+
+  const utter = input.utterance ?? ''
+  if (!normalize(utter)) {
+    return { ok: false, reason: 'no confirmation given — preview shown, awaiting explicit confirm' }
+  }
+
+  // Low-confidence spoken confirmation → re-prompt, never guess.
+  if (shouldReprompt(input.confidence)) {
+    return { ok: false, reprompt: true, reason: 'confirmation transcript below STT-confidence threshold — re-prompting' }
+  }
+
+  // A bare generic affirmative is never enough for a destructive action.
+  if (isGenericAffirmative(utter)) {
+    return {
+      ok: false,
+      reason: `a generic "${normalize(utter)}" is not a valid confirmation — say "${confirmationPhraseFor(intent)}" or tap Approve`,
+    }
+  }
+
+  // Must restate the action verb (distinct confirmation). Accept the explicit
+  // phrase ("confirm delete") or any utterance containing the confirmation verb
+  // ("yes, delete them").
+  const spec = KIND_SPECS.find(s => s.kind === intent.primary)
+  const verb = spec?.confirmVerb ?? 'proceed'
+  const n = normalize(utter)
+  if (n.includes(verb)) return { ok: true }
+
+  return {
+    ok: false,
+    reason: `confirmation must restate the action — say "${confirmationPhraseFor(intent)}" or tap Approve`,
+  }
+}

--- a/backend/src/tests/intent.test.ts
+++ b/backend/src/tests/intent.test.ts
@@ -1,0 +1,120 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  classifyIntent, confirmationPhraseFor, isConfirmed, isGenericAffirmative,
+  shouldReprompt, MIN_STT_CONFIDENCE,
+} from '../services/intent'
+
+// ─── classifyIntent: tier + approval-type mapping ────────────────────────────
+
+const CASES: Array<{ t: string; tier: string; primary: string; approvalType?: string }> = [
+  // critical (top tier)
+  { t: 'delete last week\'s downloads', tier: 'critical', primary: 'delete', approvalType: 'file_destructive' },
+  { t: 'permanently remove these files', tier: 'critical', primary: 'delete', approvalType: 'file_destructive' },
+  { t: 'transfer 0.5 ETH to Alice', tier: 'critical', primary: 'transfer', approvalType: 'wallet_tx' },
+  { t: 'swap 100 USDC for ETH', tier: 'critical', primary: 'transfer', approvalType: 'wallet_tx' },
+  { t: 'sign the transaction', tier: 'critical', primary: 'sign', approvalType: 'wallet_tx' },
+  // destructive
+  { t: 'move the screenshots into the Q3 folder', tier: 'destructive', primary: 'move', approvalType: 'file_destructive' },
+  { t: 'archive last month\'s invoices', tier: 'destructive', primary: 'move', approvalType: 'file_destructive' },
+  { t: 'overwrite the config file', tier: 'destructive', primary: 'overwrite', approvalType: 'file_destructive' },
+  { t: 'send that reply to the Fly invoice', tier: 'destructive', primary: 'send', approvalType: 'email_send' },
+  { t: 'run the deploy script', tier: 'destructive', primary: 'exec', approvalType: 'machine_exec' },
+  // safe / read-only
+  { t: 'what\'s on my calendar Thursday', tier: 'safe', primary: 'read' },
+  { t: 'what is my ETH balance and gas price', tier: 'safe', primary: 'read' },
+  { t: 'summarize this PDF', tier: 'safe', primary: 'read' },
+  { t: '', tier: 'safe', primary: 'read' },
+]
+
+for (const c of CASES) {
+  test(`[A3] classifyIntent: "${c.t.slice(0, 40)}" → ${c.tier}/${c.primary}`, () => {
+    const r = classifyIntent(c.t)
+    assert.equal(r.tier, c.tier, `tier for "${c.t}"`)
+    assert.equal(r.primary, c.primary, `primary for "${c.t}"`)
+    assert.equal(r.approvalType, c.approvalType, `approvalType for "${c.t}"`)
+    assert.equal(r.destructive, c.tier !== 'safe')
+  })
+}
+
+test('[A3] critical outranks destructive when both present (delete + move)', () => {
+  const r = classifyIntent('move these to trash then delete the originals')
+  assert.equal(r.tier, 'critical')
+  assert.equal(r.primary, 'delete')
+  assert.ok(r.kinds.includes('move'))
+  assert.ok(r.kinds.includes('delete'))
+})
+
+// ─── confirmationPhraseFor ───────────────────────────────────────────────────
+
+test('[A3] confirmation phrase restates the action, never a bare yes', () => {
+  assert.equal(confirmationPhraseFor(classifyIntent('delete the files')), 'confirm delete')
+  assert.equal(confirmationPhraseFor(classifyIntent('move them')), 'confirm move')
+  assert.equal(confirmationPhraseFor(classifyIntent('send the email')), 'confirm send')
+  assert.equal(confirmationPhraseFor(classifyIntent('transfer 1 ETH')), 'confirm transfer')
+  assert.equal(confirmationPhraseFor('sign'), 'confirm sign')
+})
+
+// ─── generic-affirmative detection ───────────────────────────────────────────
+
+test('[A3] generic affirmatives are recognized (and rejected as confirmations)', () => {
+  for (const y of ['yes', 'yeah', 'yep', 'ok', 'okay', 'sure', 'confirm', 'Confirmed!', 'do it', 'go ahead', 'yes please']) {
+    assert.equal(isGenericAffirmative(y), true, `"${y}" should be generic`)
+  }
+  assert.equal(isGenericAffirmative('confirm delete'), false)
+  assert.equal(isGenericAffirmative('yes delete them'), false)
+})
+
+// ─── STT-confidence reprompt ─────────────────────────────────────────────────
+
+test('[A3] shouldReprompt fires below threshold; unknown confidence does not', () => {
+  assert.equal(shouldReprompt(MIN_STT_CONFIDENCE - 0.01), true)
+  assert.equal(shouldReprompt(MIN_STT_CONFIDENCE), false)
+  assert.equal(shouldReprompt(0.95), false)
+  assert.equal(shouldReprompt(null), false)      // provider gave no score → don't force reprompt
+  assert.equal(shouldReprompt(undefined), false)
+})
+
+// ─── two-phase confirmation ──────────────────────────────────────────────────
+
+test('[A3] safe intents need no confirmation', () => {
+  assert.equal(isConfirmed({ intent: classifyIntent('what is on my calendar') }).ok, true)
+})
+
+test('[A3] a tap always confirms a destructive action', () => {
+  assert.equal(isConfirmed({ intent: classifyIntent('delete the files'), tapped: true }).ok, true)
+})
+
+test('[A3] a bare generic yes never confirms the top tier', () => {
+  const del = classifyIntent('delete the files')
+  const r = isConfirmed({ intent: del, utterance: 'yes', confidence: 0.99 })
+  assert.equal(r.ok, false)
+  assert.match(r.reason!, /confirm delete/)
+})
+
+test('[A3] restating the action verb confirms; unrelated speech does not', () => {
+  const del = classifyIntent('delete the files')
+  assert.equal(isConfirmed({ intent: del, utterance: 'confirm delete', confidence: 0.9 }).ok, true)
+  assert.equal(isConfirmed({ intent: del, utterance: 'yes, delete them', confidence: 0.9 }).ok, true)
+  assert.equal(isConfirmed({ intent: del, utterance: 'actually never mind', confidence: 0.9 }).ok, false)
+})
+
+test('[A3] low-confidence confirmation re-prompts, never guesses', () => {
+  const send = classifyIntent('send the reply')
+  const r = isConfirmed({ intent: send, utterance: 'confirm send', confidence: 0.3 })
+  assert.equal(r.ok, false)
+  assert.equal(r.reprompt, true)
+})
+
+test('[A3] empty confirmation is not ok (preview shown, awaiting confirm)', () => {
+  const mv = classifyIntent('move the files')
+  const r = isConfirmed({ intent: mv, utterance: '', confidence: 0.9 })
+  assert.equal(r.ok, false)
+  assert.equal(r.reprompt, undefined)
+})
+
+test('[A3] wallet transfer needs the transfer verb restated', () => {
+  const tx = classifyIntent('transfer 0.5 ETH to Bob')
+  assert.equal(isConfirmed({ intent: tx, utterance: 'yes', confidence: 0.99 }).ok, false)
+  assert.equal(isConfirmed({ intent: tx, utterance: 'confirm transfer', confidence: 0.99 }).ok, true)
+})

--- a/docs/PLAN-arturita.md
+++ b/docs/PLAN-arturita.md
@@ -17,8 +17,8 @@ This table is the source of truth for per-story status. Update the **Status** + 
 | Story | Title | Status | PR | Gating decision |
 |---|---|---|---|---|
 | **A1** | Persona, sessions & `/panic` kill switch | `done` | [#174](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/174) | — |
-| **A2** | Dangerous-action approval types + step-up | `in-progress` | PR pending | — |
-| **A3** | Intent classifier + two-phase destructive confirm | `todo` | — | — |
+| **A2** | Dangerous-action approval types + step-up | `done` | [#175](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/175) | — |
+| **A3** | Intent classifier + two-phase destructive confirm | `in-progress` | PR pending | — |
 | **B1** | Voice Gateway (STT/TTS) | `todo` | — | S1 |
 | **B2** | Cockpit voice panel | `todo` | — | S5 |
 | **B3** | Ask-vs-execute routing from voice | `todo` | — | — |

--- a/docs/REQUIREMENTS-arturita.md
+++ b/docs/REQUIREMENTS-arturita.md
@@ -71,7 +71,7 @@
 | FR-33 | Arturita exists as an owner-scoped agent persona per org. | A1 | `[x]` (A1: `agentType='arturita'`, idempotently ensured per org) |
 | FR-34 | Remote control is bound to the single operator (Telegram chat id + Cockpit identity) via a one-time Cockpit code. | A1 | `[~]` (A1: begin/confirm/revoke binding + one-time hashed code with TTL, single-use; primary Telegram-driven confirm path lands in D1) |
 | FR-35 | Command sessions are short-lived and individually revocable; dangerous actions require a fresh session / step-up. | A1, A2 | `[x]` (A1: short-lived + individually revocable sessions + `isFresh`/`needsStepUp`; A2: `POST /api/approvals/:id/decide` refuses to *approve* a dangerous type without a fresh command session — 403) |
-| FR-36 | Destructive intents are classified and always produce a preview + explicit distinct confirmation (two-phase). | A3 | `[ ]` |
+| FR-36 | Destructive intents are classified and always produce a preview + explicit distinct confirmation (two-phase). | A3 | `[~]` (A3: `classifyIntent`/`confirmationPhraseFor`/`isConfirmed` pure two-phase logic done — generic yes rejected for the top tier, low STT-confidence re-prompts; wired to the voice loop in B1/B3) |
 | FR-37 | New endpoints are self-described via `/api/openapi.json`; CLI `7ei-mc` gains `arturita bind|panic|host-status`. | G1 | `[ ]` |
 
 ---
@@ -84,7 +84,7 @@
 | NFR-1 | **100%** of destructive file ops, wallet txs, and email sends pass through an approval before execution. | A2 + C2/E2/A2 | `[~]` (A2: the gate exists — dangerous types + machine-rendered verbatim summary + step-up on approve; per-surface *execution* wiring enforced in C2/E2/D2) |
 | NFR-2 | **Zero** private keys / seed phrases ever touch Arturita's process — enforced by design invariant + CI secret-scan. | E1 | `[ ]` |
 | NFR-3 | No dangerous surface (B/C/D/E) merges before A2 (the approval-type gate) is on `main`. | sequencing | `[ ]` |
-| NFR-4 | Destructive voice commands are never one-shot: ≥99% require an explicit confirmation utterance/tap; ambiguous/low-confidence → reject + re-prompt. | A3, B1 | `[ ]` |
+| NFR-4 | Destructive voice commands are never one-shot: ≥99% require an explicit confirmation utterance/tap; ambiguous/low-confidence → reject + re-prompt. | A3, B1 | `[~]` (A3: two-phase confirm logic — bare affirmative rejected, action-verb restatement or tap required, sub-threshold STT re-prompts; end-to-end voice wiring in B1) |
 | NFR-5 | Voice never authorizes an address or amount alone — entities echoed visually before wallet/email approval. | A3, E2 | `[ ]` |
 | NFR-6 | Machine ops cannot escape the allowlist root (canonicalize + prefix check; no `..`/symlink escape); denylist hard-refused for read + write. | C1 | `[ ]` |
 | NFR-7 | Blast-radius caps: over-cap ops require approval; over hard-ceiling refused outright. | C1, C2 | `[ ]` |


### PR DESCRIPTION
## Epic A · Story A3 — completes the safety spine

The **pure gate** between "what the operator said" and "what Arturita may do without a second, explicit, distinct confirmation" (PRD §7.2). STT is fallible and Arturita's blast radius is large; a misheard destructive command must never execute silently. Table-driven and IO-free.

### What shipped — `services/intent.ts`
- **`classifyIntent(transcript)`** — tags a transcript `safe | destructive | critical` and maps it to the **A2 dangerous approval type**: delete/transfer/sign → `critical` (top tier), move/overwrite/send/exec → `destructive`, read-only → `safe`. Highest-tier match wins; all matched kinds kept.
- **`confirmationPhraseFor(intent)`** — the exact phrase that **restates the action** (`confirm delete`) — never a bare "yes".
- **`isConfirmed()`** — two-phase confirm: a **tap** always confirms; a **spoken** confirmation must (a) clear the STT-confidence threshold — else **re-prompt, never guess** — and (b) **restate the action verb**. A generic affirmative (`yes`/`yeah`/`ok`/`confirm`) is **rejected**, especially for the critical top tier. Fail-closed on ambiguity.
- Helpers: `shouldReprompt`, `isGenericAffirmative`, `MIN_STT_CONFIDENCE`.

### Safety
Directly encodes PRD §7.2 (voice misrecognition on destructive commands): two-phase, distinct confirmation, homophone/entity safety via action-verb restatement, low-confidence re-prompt. Wires into the voice loop in B1/B3; this PR is the tested logic.

### Verification
**646 backend tests** (25 new, table-driven over a destructive/safe/ambiguous corpus) · **11/11 evals** · web build via CI (no web changes) · `npm audit` known non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)