### PR TITLE
feat(arturita F1): LLM fallback chain + circuit breaker (pure decision layer)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -28,6 +28,8 @@ Full planning/tracking layer filed (docs-only, no code yet): **PRD** `docs/PRD-a
 
 | **A3** · Intent classifier + two-phase confirm | `services/intent.ts` (pure: `classifyIntent` tiers safe/destructive/critical + maps to A2 approval types; `confirmationPhraseFor`; `isConfirmed` two-phase — bare "yes" rejected for the top tier, action-verb restatement or tap required; sub-threshold STT re-prompts, never guesses). Table-driven tests over a destructive/safe/ambiguous corpus. | in progress | PR pending |
 
+| **F1** · LLM fallback chain + circuit breaker | `services/llm-fallback.ts` (pure: `parseFallbackChain` from deployConfig; `classifyLlmError` → 6 failure classes + failover/breaker guidance; circuit breaker `recordFailure`/`isProviderHealthy` with window + cooldown/re-probe; `planFallback` walks the chain, skips open breakers, drops hops over the preflight per-wake cap, parks with a plain-language reason when exhausted). **Pure decision layer only** — live wiring into the `agent-executor`/`streamLLM` retry loop is a deliberate follow-up (kept off the LLM hot path in the overnight session). | in progress | PR pending |
+
 Safety gate: **A2 (on `main`) is the mechanical approval-type gate** every dangerous surface depends on. `machine_exec` (C3) + wallet signing (E2) are last + most-guarded and stay blocked on **S3/S6/S4** until CONFIRMED.
 
 ## Paperclip gap-bridge — 5 / 5 phases shipped

--- a/backend/src/services/llm-fallback.ts
+++ b/backend/src/services/llm-fallback.ts
@@ -1,0 +1,230 @@
+// Arturita F1 — ordered LLM fallback chain + circuit breaker (pure).
+//
+// Arturita must keep working when a provider degrades (PRD §6). This module is
+// the pure decision layer on top of the existing `llm-router.ts`: it does NOT
+// call any provider — it decides, given a chain and live breaker state, which
+// provider to try next, whether to try at all, and when to give up. The executor
+// wires it around `streamLLM`, re-running the existing preflight per-wake cap on
+// every hop so failover can never blow the budget.
+//
+// Design (all pure, unit-tested):
+//  - parseFallbackChain(): read an ordered chain from org.deployConfig.
+//  - classifyLlmError(): map a thrown error / status to a failure class and
+//    whether it's worth failing over.
+//  - Circuit breaker: recordFailure / recordSuccess / isProviderHealthy over a
+//    caller-held state map (N failures in a window → cooldown → re-probe).
+//  - planFallback(): the next hop — skip unhealthy providers, stop at the
+//    per-wake cost cap, surface a plain-language reason when exhausted.
+
+import { estimateWakeCost } from './preflight'
+
+// ─── Chain config ────────────────────────────────────────────────────────────
+
+export interface ChainLink {
+  /** provider id understood by llm-router (anthropic|openai|google|deepseek|…|ollama). */
+  provider: string
+  /** model id (must have a COST_RATES entry to be cost-bounded). */
+  model: string
+}
+
+/** Split a "provider/model" token. A bare model (no slash) infers the provider
+ *  from a small known map, else defaults to 'custom'. */
+export function parseChainLink(token: string): ChainLink | null {
+  const t = String(token ?? '').trim()
+  if (!t) return null
+  const slash = t.indexOf('/')
+  if (slash > 0) return { provider: t.slice(0, slash).trim(), model: t.slice(slash + 1).trim() }
+  // bare model → infer provider
+  if (/^claude/i.test(t)) return { provider: 'anthropic', model: t }
+  if (/^gpt/i.test(t)) return { provider: 'openai', model: t }
+  if (/^gemini/i.test(t)) return { provider: 'google', model: t }
+  if (/^deepseek/i.test(t)) return { provider: 'deepseek', model: t }
+  return { provider: 'custom', model: t }
+}
+
+/** Read the ordered fallback chain for an agent from deployConfig. Prefers a
+ *  per-agent key (`arturita_fallback_chain:<id>`) over the org default
+ *  (`arturita_fallback_chain`). Accepts a JSON array or a comma/space list.
+ *  Returns [] when unset (caller falls back to the agent's single configured
+ *  model). */
+export function parseFallbackChain(
+  deployConfig: Record<string, string> | null | undefined,
+  agentId?: string | null,
+): ChainLink[] {
+  const cfg = deployConfig ?? {}
+  const raw = (agentId && cfg[`arturita_fallback_chain:${agentId}`]) || cfg.arturita_fallback_chain
+  if (!raw || !String(raw).trim()) return []
+  let tokens: string[] = []
+  const s = String(raw).trim()
+  if (s.startsWith('[')) {
+    try { const arr = JSON.parse(s); if (Array.isArray(arr)) tokens = arr.map(String) } catch { tokens = [] }
+  }
+  if (tokens.length === 0) tokens = s.split(/[,\s]+/)
+  return tokens.map(parseChainLink).filter((l): l is ChainLink => l !== null)
+}
+
+// ─── Error classification ────────────────────────────────────────────────────
+
+export type FailureClass =
+  | 'timeout' | 'server_error' | 'rate_limit' | 'auth' | 'context_overflow' | 'content_filter' | 'unknown'
+
+export interface ErrorClassification {
+  class: FailureClass
+  /** worth trying the next provider? (auth = skip this provider but do fail over.) */
+  failover: boolean
+  /** should this provider be marked unhealthy (tripping the breaker)? */
+  tripBreaker: boolean
+}
+
+/** Classify a thrown LLM error (or an explicit status code) into a failure class
+ *  + failover/breaker guidance. llm-router throws `Error("<provider> error <status>")`
+ *  and native fetch/timeout errors; we parse either. */
+export function classifyLlmError(err: unknown, statusHint?: number): ErrorClassification {
+  const msg = (err instanceof Error ? err.message : String(err ?? '')).toLowerCase()
+  const status = statusHint ?? (msg.match(/error\s+(\d{3})/)?.[1] ? Number(msg.match(/error\s+(\d{3})/)![1]) : undefined)
+
+  if (status === 429 || /rate.?limit|too many requests/.test(msg)) {
+    return { class: 'rate_limit', failover: true, tripBreaker: true }
+  }
+  if (status === 401 || status === 403 || /unauthor|invalid api key|no api key|forbidden/.test(msg)) {
+    // Bad/rotated key: skip THIS provider (breaker) but do fail over + alert.
+    return { class: 'auth', failover: true, tripBreaker: true }
+  }
+  if ((status != null && status >= 500) || /server error|bad gateway|unavailable|overloaded/.test(msg)) {
+    return { class: 'server_error', failover: true, tripBreaker: true }
+  }
+  if (/tim2?e?d?\s?out|timeout|etimedout|econnreset|network|fetch failed|socket hang up/.test(msg)) {
+    return { class: 'timeout', failover: true, tripBreaker: true }
+  }
+  if (/context length|maximum context|too long|token limit|context_length_exceeded/.test(msg)) {
+    // Not the provider's fault — fail over to a larger-context model, don't trip.
+    return { class: 'context_overflow', failover: true, tripBreaker: false }
+  }
+  if (/content|refus|safety|filter|blocked/.test(msg)) {
+    // Retry once on the next provider; don't blame this one's health.
+    return { class: 'content_filter', failover: true, tripBreaker: false }
+  }
+  return { class: 'unknown', failover: true, tripBreaker: false }
+}
+
+// ─── Circuit breaker ─────────────────────────────────────────────────────────
+
+export interface BreakerState {
+  failures: number
+  /** ms epoch of the first failure in the current window. */
+  windowStart: number | null
+  /** ms epoch until which the provider is considered open (skipped). */
+  openUntil: number | null
+}
+
+export interface BreakerConfig {
+  /** failures within the window that trip the breaker. */
+  threshold: number
+  /** window length (ms) over which failures accumulate. */
+  windowMs: number
+  /** cooldown (ms) the breaker stays open before a re-probe. */
+  cooldownMs: number
+}
+
+export const DEFAULT_BREAKER: BreakerConfig = { threshold: 3, windowMs: 60_000, cooldownMs: 120_000 }
+
+export function newBreakerState(): BreakerState {
+  return { failures: 0, windowStart: null, openUntil: null }
+}
+
+/** Is the provider healthy (breaker closed) right now? Open until `openUntil`. */
+export function isProviderHealthy(state: BreakerState | null | undefined, now: number): boolean {
+  if (!state) return true
+  return !(state.openUntil != null && now < state.openUntil)
+}
+
+/** Record a failure. Accumulates within the window; on reaching the threshold the
+ *  breaker opens for the cooldown. Returns the new state (pure). */
+export function recordFailure(
+  state: BreakerState | null | undefined,
+  now: number,
+  cfg: BreakerConfig = DEFAULT_BREAKER,
+): BreakerState {
+  const s = state ? { ...state } : newBreakerState()
+  // reset the window if it elapsed
+  if (s.windowStart == null || now - s.windowStart > cfg.windowMs) {
+    s.windowStart = now
+    s.failures = 0
+  }
+  s.failures += 1
+  if (s.failures >= cfg.threshold) {
+    s.openUntil = now + cfg.cooldownMs
+    // start a fresh window after tripping so post-cooldown probes get a clean slate
+    s.failures = 0
+    s.windowStart = null
+  }
+  return s
+}
+
+/** Record a success — closes the breaker and clears the failure window. */
+export function recordSuccess(_state?: BreakerState | null): BreakerState {
+  return newBreakerState()
+}
+
+// ─── Fallback planning ───────────────────────────────────────────────────────
+
+export interface FallbackHop {
+  link: ChainLink
+  index: number
+  estimateUsd: number | null
+}
+
+export interface FallbackPlan {
+  /** ordered hops to attempt (healthy + under the per-wake cap), in chain order. */
+  hops: FallbackHop[]
+  /** providers skipped because their breaker is open. */
+  skippedUnhealthy: ChainLink[]
+  /** providers skipped because their worst-case wake cost exceeds the cap. */
+  skippedOverCap: ChainLink[]
+  /** true when NO hop is attemptable — the caller parks the task with `reason`. */
+  exhausted: boolean
+  reason?: string
+}
+
+/** Plan the fallback attempt order for one wake: walk the chain, skip providers
+ *  whose breaker is open, and drop any hop whose worst-case wake cost exceeds the
+ *  per-wake cap (failover must stay within budget — PRD §6, D-g). Pure over a
+ *  snapshot of breaker states. */
+export function planFallback(input: {
+  chain: ChainLink[]
+  breakers: Record<string, BreakerState>   // keyed by provider (or provider/model)
+  now: number
+  inputTokens: number
+  maxOutputTokens?: number
+  capUsd: number | null
+}): FallbackPlan {
+  const hops: FallbackHop[] = []
+  const skippedUnhealthy: ChainLink[] = []
+  const skippedOverCap: ChainLink[] = []
+
+  input.chain.forEach((link, index) => {
+    const key = `${link.provider}/${link.model}`
+    const state = input.breakers[key] ?? input.breakers[link.provider]
+    if (!isProviderHealthy(state, input.now)) { skippedUnhealthy.push(link); return }
+    const estimateUsd = estimateWakeCost(link.model, { inputTokens: input.inputTokens, maxOutputTokens: input.maxOutputTokens })
+    // Over the per-wake cap → skip (only when the cap is set AND the cost is known
+    // and above it; unknown-priced models are allowed but flagged null, matching
+    // preflightWake's philosophy).
+    if (input.capUsd != null && input.capUsd > 0 && estimateUsd != null && estimateUsd > input.capUsd) {
+      skippedOverCap.push(link); return
+    }
+    hops.push({ link, index, estimateUsd })
+  })
+
+  if (hops.length === 0) {
+    const parts: string[] = []
+    if (skippedUnhealthy.length) parts.push(`${skippedUnhealthy.length} provider(s) in cooldown`)
+    if (skippedOverCap.length) parts.push(`${skippedOverCap.length} over the per-wake cost cap`)
+    const why = parts.length ? ` (${parts.join('; ')})` : ''
+    return {
+      hops, skippedUnhealthy, skippedOverCap, exhausted: true,
+      reason: `No LLM provider available for this wake${why}. Task parked — check provider health / raise the per-wake cap, or wait for cooldown.`,
+    }
+  }
+  return { hops, skippedUnhealthy, skippedOverCap, exhausted: false }
+}

--- a/backend/src/tests/llm-fallback.test.ts
+++ b/backend/src/tests/llm-fallback.test.ts
@@ -1,0 +1,131 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parseChainLink, parseFallbackChain, classifyLlmError,
+  newBreakerState, isProviderHealthy, recordFailure, recordSuccess,
+  planFallback, DEFAULT_BREAKER, type BreakerState,
+} from '../services/llm-fallback'
+
+// ─── Chain parsing ───────────────────────────────────────────────────────────
+
+test('[F1] parseChainLink splits provider/model and infers bare models', () => {
+  assert.deepEqual(parseChainLink('anthropic/claude-sonnet-4-20250514'), { provider: 'anthropic', model: 'claude-sonnet-4-20250514' })
+  assert.deepEqual(parseChainLink('ollama/llama3.3'), { provider: 'ollama', model: 'llama3.3' })
+  assert.deepEqual(parseChainLink('claude-opus-4-6'), { provider: 'anthropic', model: 'claude-opus-4-6' })
+  assert.deepEqual(parseChainLink('gpt-4o'), { provider: 'openai', model: 'gpt-4o' })
+  assert.deepEqual(parseChainLink('gemini-2.0-flash'), { provider: 'google', model: 'gemini-2.0-flash' })
+  assert.equal(parseChainLink(''), null)
+})
+
+test('[F1] parseFallbackChain reads JSON array or list, per-agent overrides org', () => {
+  const cfg = {
+    arturita_fallback_chain: '["claude-sonnet-4-20250514", "gpt-4o", "ollama/llama3.3"]',
+    'arturita_fallback_chain:agent_x': 'gemini-2.0-flash, deepseek-chat',
+  }
+  const org = parseFallbackChain(cfg)
+  assert.equal(org.length, 3)
+  assert.equal(org[0].model, 'claude-sonnet-4-20250514')
+  assert.equal(org[2].provider, 'ollama')
+
+  const agent = parseFallbackChain(cfg, 'agent_x')
+  assert.equal(agent.length, 2)
+  assert.equal(agent[0].provider, 'google')
+  assert.equal(agent[1].provider, 'deepseek')
+
+  assert.deepEqual(parseFallbackChain(null), [])
+  assert.deepEqual(parseFallbackChain({}), [])
+})
+
+// ─── Error classification ────────────────────────────────────────────────────
+
+test('[F1] classifyLlmError maps failure classes + failover/breaker guidance', () => {
+  assert.deepEqual(classifyLlmError(new Error('openai error 429')), { class: 'rate_limit', failover: true, tripBreaker: true })
+  assert.deepEqual(classifyLlmError(new Error('anthropic error 503')), { class: 'server_error', failover: true, tripBreaker: true })
+  assert.deepEqual(classifyLlmError(new Error('No API key configured for provider "deepseek"')), { class: 'auth', failover: true, tripBreaker: true })
+  assert.deepEqual(classifyLlmError(new Error('fetch failed')), { class: 'timeout', failover: true, tripBreaker: true })
+  // context overflow + content filter fail over but DON'T blame the provider
+  assert.equal(classifyLlmError(new Error('maximum context length exceeded')).class, 'context_overflow')
+  assert.equal(classifyLlmError(new Error('maximum context length exceeded')).tripBreaker, false)
+  assert.equal(classifyLlmError(new Error('content policy refusal')).tripBreaker, false)
+  // explicit status hint wins
+  assert.equal(classifyLlmError(new Error('weird'), 429).class, 'rate_limit')
+  assert.equal(classifyLlmError(new Error('mystery')).class, 'unknown')
+})
+
+// ─── Circuit breaker ─────────────────────────────────────────────────────────
+
+test('[F1] breaker trips after threshold failures in the window, then cools down', () => {
+  const cfg = DEFAULT_BREAKER
+  let s: BreakerState = newBreakerState()
+  const t0 = 1_000_000
+  assert.equal(isProviderHealthy(s, t0), true)
+
+  s = recordFailure(s, t0, cfg)
+  s = recordFailure(s, t0 + 1000, cfg)
+  assert.equal(isProviderHealthy(s, t0 + 1000), true, 'still healthy below threshold')
+
+  s = recordFailure(s, t0 + 2000, cfg) // 3rd failure → trip
+  assert.equal(isProviderHealthy(s, t0 + 2000), false, 'breaker open after threshold')
+  // still open just before cooldown ends
+  assert.equal(isProviderHealthy(s, t0 + 2000 + cfg.cooldownMs - 1), false)
+  // healthy again after cooldown (re-probe)
+  assert.equal(isProviderHealthy(s, t0 + 2000 + cfg.cooldownMs + 1), true)
+})
+
+test('[F1] failures outside the window do not accumulate', () => {
+  const cfg = DEFAULT_BREAKER
+  let s = newBreakerState()
+  s = recordFailure(s, 0, cfg)
+  s = recordFailure(s, cfg.windowMs + 1, cfg) // window reset → count is 1, not 2
+  assert.equal(isProviderHealthy(s, cfg.windowMs + 1), true)
+})
+
+test('[F1] recordSuccess closes the breaker', () => {
+  const cfg = DEFAULT_BREAKER
+  let s = newBreakerState()
+  s = recordFailure(s, 0, cfg)
+  s = recordFailure(s, 1, cfg)
+  s = recordSuccess(s)
+  assert.deepEqual(s, newBreakerState())
+})
+
+// ─── Fallback planning ───────────────────────────────────────────────────────
+
+const CHAIN = parseFallbackChain({ arturita_fallback_chain: 'claude-sonnet-4-20250514, gpt-4o, ollama/llama3.3' })
+
+test('[F1] planFallback returns healthy hops in order under the cap', () => {
+  const plan = planFallback({
+    chain: CHAIN, breakers: {}, now: 1000, inputTokens: 1000, maxOutputTokens: 1000, capUsd: null,
+  })
+  assert.equal(plan.exhausted, false)
+  assert.equal(plan.hops.length, 3)
+  assert.equal(plan.hops[0].link.model, 'claude-sonnet-4-20250514')
+})
+
+test('[F1] planFallback skips providers whose breaker is open', () => {
+  const openState: BreakerState = { failures: 0, windowStart: null, openUntil: 5000 }
+  const plan = planFallback({
+    chain: CHAIN, breakers: { 'anthropic/claude-sonnet-4-20250514': openState }, now: 1000,
+    inputTokens: 1000, maxOutputTokens: 1000, capUsd: null,
+  })
+  assert.equal(plan.skippedUnhealthy.length, 1)
+  assert.equal(plan.hops[0].link.provider, 'openai')
+})
+
+test('[F1] planFallback drops hops over the per-wake cost cap', () => {
+  // A tiny cap excludes the priced cloud models but keeps the $0 local model.
+  const plan = planFallback({
+    chain: CHAIN, breakers: {}, now: 1000, inputTokens: 100_000, maxOutputTokens: 4096, capUsd: 0.001,
+  })
+  assert.ok(plan.skippedOverCap.length >= 1, 'expensive models dropped')
+  assert.ok(plan.hops.some(h => h.link.provider === 'ollama'), 'free local model kept')
+})
+
+test('[F1] planFallback is exhausted (parks the task) when nothing is attemptable', () => {
+  const open: BreakerState = { failures: 0, windowStart: null, openUntil: 9999 }
+  const breakers: Record<string, BreakerState> = {}
+  for (const l of CHAIN) breakers[`${l.provider}/${l.model}`] = open
+  const plan = planFallback({ chain: CHAIN, breakers, now: 1000, inputTokens: 1000, capUsd: null })
+  assert.equal(plan.exhausted, true)
+  assert.match(plan.reason!, /parked/i)
+})

--- a/docs/PLAN-arturita.md
+++ b/docs/PLAN-arturita.md
@@ -29,7 +29,7 @@ This table is the source of truth for per-story status. Update the **Status** + 
 | **D2** | Telegram files + inline approvals + voice replies | `todo` | — | S2 |
 | **E1** | Wallet read + prepare + simulate | `todo` | — | — |
 | **E2** | Wallet approval card + WalletConnect handoff | `todo` | — | **S4** |
-| **F1** | LLM fallback chain + circuit breaker | `todo` | — | — |
+| **F1** | LLM fallback chain + circuit breaker | `in-progress` | PR pending (pure layer; executor wiring follow-up) | — |
 | **F2** | Degraded/offline + watchdogs | `todo` | — | — |
 | **G1** | Self-description + CLI | `todo` | — | — |
 | **G2** | Go-live gates + runbook | `todo` | — | — |

--- a/docs/QUESTIONS-arturita-overnight.md
+++ b/docs/QUESTIONS-arturita-overnight.md
@@ -29,7 +29,9 @@ _(appended as the session progresses)_
 
 ## Deferred / smaller questions
 
-_(appended as the session progresses)_
+- **F1 executor wiring (follow-up, not a blocker).** F1 shipped the full pure decision layer (fallback chain + circuit breaker + cost-bounded planning) with tests, but I deliberately did **not** wire it into the live `agent-executor`/`streamLLM` retry loop overnight — that changes the LLM hot path and I'd want you to validate real failover behavior (and confirm the fallback-chain values in `deployConfig`) before it goes live. Follow-up story: catch `streamLLM` errors → `classifyLlmError` → `planFallback` → retry, holding a module-level breaker registry, plus surface breaker health on `/health` + Cockpit. **Q:** confirm the desired default `arturita_fallback_chain` (e.g. `claude-sonnet-4-20250514, gpt-4o, gemini-2.0-flash, deepseek-chat, ollama/llama3.3`).
+- **A1 panic auth model.** `/panic` is public-scope but owner-authed via a valid command-session token. The Cockpit panic button therefore needs a live session token to call it. **Q:** OK that the button mints/uses a command session, or do you want a Clerk-only panic variant too? (Telegram-driven panic lands in D1 via the HMAC receiver.)
+- **A1 bind confirm path.** A1 exposes `POST …/arturita/bind/confirm` in the Clerk scope so you can confirm a binding from the Cockpit. In D1 the *primary* confirm path moves to the HMAC Telegram receiver (operator types the code in Telegram). Confirm that's the intended UX.
 
 ---
 

--- a/docs/REQUIREMENTS-arturita.md
+++ b/docs/REQUIREMENTS-arturita.md
@@ -60,8 +60,8 @@
 ### Resilience & LLM
 | ID | Requirement | Story | Status |
 |---|---|---|---|
-| FR-29 | Arturita swaps LLM providers per task and fails over across an ordered fallback chain on provider failure. | F1 | `[ ]` |
-| FR-30 | Failover handles 5xx/timeout/429/auth/context-overflow/refusal; a circuit breaker skips unhealthy providers. | F1 | `[ ]` |
+| FR-29 | Arturita swaps LLM providers per task and fails over across an ordered fallback chain on provider failure. | F1 | `[~]` (F1: `parseFallbackChain` + `planFallback` pure ordered-chain logic done; wiring into the live `agent-executor`/`streamLLM` retry loop is a follow-up — kept off the LLM hot path overnight) |
+| FR-30 | Failover handles 5xx/timeout/429/auth/context-overflow/refusal; a circuit breaker skips unhealthy providers. | F1 | `[~]` (F1: `classifyLlmError` covers all six classes + `recordFailure`/`isProviderHealthy` circuit breaker with cooldown/re-probe, all tested; live wiring is the follow-up) |
 | FR-31 | Offline/degraded: local LLM + local STT/TTS keep Arturita conversational; cloud-dependent actions queue and replay idempotently on reconnect. | F2 | `[ ]` |
 | FR-32 | Provider/model health is visible on `/health` + the Cockpit. | F1 | `[ ]` |
 
@@ -102,7 +102,7 @@
 | ID | Requirement | Story | Status |
 |---|---|---|---|
 | NFR-13 | LLM failover completes the task on a fallback in ≥95% of primary-provider outages, within the per-wake cost cap. | F1 | `[ ]` |
-| NFR-14 | Failover retries are cost-bounded — cannot exceed the preflight per-wake cap; exhausted chain parks the task with a plain-language `system_notice`. | F1 | `[ ]` |
+| NFR-14 | Failover retries are cost-bounded — cannot exceed the preflight per-wake cap; exhausted chain parks the task with a plain-language `system_notice`. | F1 | `[~]` (F1: `planFallback` drops hops over the per-wake cap (reuses `estimateWakeCost`) and emits a plain-language park reason when exhausted; posting the `system_notice` wires with the executor follow-up) |
 | NFR-15 | Desk voice → first action ≤ 3s p50; Telegram voice note → acknowledged ≤ 5s p50. | B1/B2/D1 | `[ ]` |
 | NFR-16 | Long/expensive Arturita runs carry watchdogs (runtime/cost/no_activity), edge-triggered (fire once on transition). | F2 | `[ ]` |
 


### PR DESCRIPTION
## Epic F · Story F1 — resilience (no dangerous surface)

Arturita must keep working when a provider degrades (PRD §6). The **pure decision layer** on top of the existing `llm-router.ts`: it does not call any provider — it decides which to try next, whether to try at all, and when to give up, **cost-bounded by the existing preflight per-wake cap** so failover can never blow the budget (D-g).

### What shipped — `services/llm-fallback.ts`
- **`parseFallbackChain()`** — ordered chain from `org.deployConfig` (`arturita_fallback_chain[:agentId]`), JSON array or comma/space list; provider inferred from bare model ids; per-agent override beats org default.
- **`classifyLlmError()`** — maps a thrown error / status into six failure classes (5xx / timeout / 429 / auth / context-overflow / content-filter) with failover + breaker guidance (auth skips the provider but still fails over + alerts; context/filter fail over without blaming provider health).
- **Circuit breaker** — `recordFailure` / `recordSuccess` / `isProviderHealthy` over a caller-held state map: N failures in a window → cooldown → re-probe.
- **`planFallback()`** — walks the chain, skips open breakers, **drops hops whose worst-case wake cost exceeds the per-wake cap** (reuses `estimateWakeCost`), and **parks with a plain-language reason** when nothing is attemptable.

### Scope note
Shipped as the pure layer + tests. Wiring it into the live `agent-executor`/`streamLLM` retry loop and the `/health` breaker surface is a **deliberate follow-up** — it changes the LLM hot path, so I kept it off during the unattended overnight session and logged it (with a question about the default chain) in `docs/QUESTIONS-arturita-overnight.md`.

### Verification
**656 backend tests** (10 new) · **11/11 evals** · web build via CI · `npm audit` known non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)