### PR TITLE
feat(arturita C1 planner): host safety logic — fail-closed, no execution (S3-gated)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -32,7 +32,9 @@ Full planning/tracking layer filed (docs-only, no code yet): **PRD** `docs/PRD-a
 
 | **E1** · Wallet read + prepare + simulate | `services/wallet.ts` (pure: `buildUnsignedTx` key-free assembly; `decodeCalldata` ABI-layout decode of a curated selector table; `summarizeSimulation` gas/revert; `checkCaps` per-tx/per-day/allowlist; `detectScamSignals` new-address/setApprovalForAll/unlimited/drain/unknown-contract; `weiToEth`/`weiToGwei`; **`assertNoKeyMaterial` no-key-custody invariant**). `wallet_intents` table (no key material). Routes `POST …/wallet/prepare` + `…/:id/simulate` + `GET …/wallet/intents` — **no signing endpoint by design**. | in progress | PR pending |
 
-Safety gate: **A2 (on `main`) is the mechanical approval-type gate** every dangerous surface depends on. `machine_exec` (C3) + wallet signing handoff (E2) are last + most-guarded and stay blocked on **S3/S6/S4** until CONFIRMED. **Arturita never signs; no key custody, ever.**
+| **C1** (pure planner) · Host safety logic | `services/host-planner.ts` (pure, **fail-closed**: `HOST_EXECUTION_ENABLED=false` + `assertExecutionEnabled()` throw until S3; `canonicalizePath`/`isWithinRoot` no-escape prefix check; `hitsDenylist` catastrophic-target hard-deny; `classifyBlastRadius` auto-safe/needs-approval/refuse with destructive-never-auto-safe; `decideAccess`; `planHostOp` combined plan → `file_destructive` approval; undo-journal `buildUndoEntry`/`isReversible`). **No daemon, no routes, NO filesystem execution** — the write/destructive path stays blocked on **S3**. | in progress | PR pending |
+
+Safety gate: **A2 (on `main`) is the mechanical approval-type gate** every dangerous surface depends on. `machine_exec` (C3) + wallet signing handoff (E2) + host filesystem writes (C1/C2 daemon) stay blocked on **S3/S6/S4** until CONFIRMED. **Arturita never signs; no key custody; no real destructive machine op ships until S3.**
 
 ## Paperclip gap-bridge — 5 / 5 phases shipped
 | Epic | Phase | Status |

--- a/backend/src/services/host-planner.ts
+++ b/backend/src/services/host-planner.ts
@@ -1,0 +1,278 @@
+// Arturita C1 (safe subset) — Local Host SAFETY PLANNER (pure, fail-closed).
+//
+// ⚠️ This module is the *decision logic* for the future Arturita Local Host
+// daemon (`adapters/arturita-host/`), NOT the daemon itself. It performs NO
+// filesystem I/O and NO command execution. It exists so the allowlist-root /
+// denylist / blast-radius / path-canonicalization / undo-journal RULES are
+// written, owned, and exhaustively tested in the backend — behind a FAIL-CLOSED
+// default — before any real host write path ships.
+//
+// The real write/destructive path stays BLOCKED until decision S3 (adapter
+// approach + allowlist root/denylist) is CONFIRMED in docs/DECISIONS-arturita.md.
+// `HOST_EXECUTION_ENABLED = false` here is the fail-closed guard: every planner
+// returns a decision, but a decision to *allow* is meaningless until the daemon
+// exists AND S3 is confirmed. `assertExecutionEnabled()` throws so no caller can
+// accidentally treat a plan as permission to act.
+
+// ─── Fail-closed master switch ───────────────────────────────────────────────
+
+/** Master switch for REAL host execution. Stays false until S3 is CONFIRMED and
+ *  the daemon ships. Pure planners run regardless (they only decide); nothing may
+ *  actually touch the filesystem while this is false. */
+export const HOST_EXECUTION_ENABLED = false as boolean
+
+/** Throw unless real host execution has been enabled. The daemon/route calls this
+ *  at the top of any would-be execution path so a plan can never be mistaken for
+ *  permission. */
+export function assertExecutionEnabled(): void {
+  if (!HOST_EXECUTION_ENABLED) {
+    throw new Error(
+      'Arturita host execution is DISABLED (fail-closed): S3 (mac-control adapter + allowlist root/denylist) ' +
+      'is not CONFIRMED and the host daemon is not shipped. Planning only — no real filesystem action.',
+    )
+  }
+}
+
+// ─── Path canonicalization + allowlist root ──────────────────────────────────
+
+/** Canonicalize a POSIX-ish path lexically (no filesystem access): resolve `.`
+ *  and `..`, collapse duplicate slashes, strip a trailing slash. This is the
+ *  pure prefix-check basis; the daemon additionally resolves symlinks on the
+ *  real FS before applying the same prefix check (defense in depth). */
+export function canonicalizePath(input: string): string {
+  let p = String(input ?? '').trim()
+  if (!p) return ''
+  // Expand a leading ~ to a placeholder the caller substitutes with the real
+  // home; we keep it symbolic so this stays pure.
+  const parts = p.split('/')
+  const out: string[] = []
+  const absolute = p.startsWith('/')
+  for (const seg of parts) {
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') {
+      if (out.length && out[out.length - 1] !== '..') out.pop()
+      else if (!absolute) out.push('..')
+      // at root, `..` is a no-op (can't escape above /)
+    } else {
+      out.push(seg)
+    }
+  }
+  return (absolute ? '/' : '') + out.join('/')
+}
+
+/** Is `child` at or under `root` after canonicalization? The core no-escape
+ *  check. Both are canonicalized; a child equal to root is allowed. */
+export function isWithinRoot(child: string, root: string): boolean {
+  const c = canonicalizePath(child)
+  const r = canonicalizePath(root)
+  if (!c || !r) return false
+  if (c === r) return true
+  return c.startsWith(r.endsWith('/') ? r : r + '/')
+}
+
+// ─── Denylist ────────────────────────────────────────────────────────────────
+
+// Catastrophic targets — hard-denied for read AND write regardless of the
+// allowlist root (PRD §7.3). Matched against any path segment / suffix so a
+// nested `.ssh` or `.env` is caught too.
+export const DEFAULT_DENYLIST = [
+  '.ssh',
+  '.aws',
+  '.gnupg',
+  '.config/gcloud',
+  'Library/Keychains',
+  'Keychains',
+  '.env',
+  '.env.local',
+  'id_rsa',
+  'id_ed25519',
+  'wallet.dat',
+  'keystore',
+  'UTC--',                // geth keystore file prefix
+  '.metamask',
+  'Ethereum',             // wallet vaults
+  '.arturita-host',       // the host's own config
+] as const
+
+/** Does a path hit the denylist (catastrophic target)? Case-insensitive; matches
+ *  a full segment, a dotfile, or a known filename prefix anywhere in the path.
+ *  Fail-closed: a blank path is denied. */
+export function hitsDenylist(path: string, denylist: readonly string[] = DEFAULT_DENYLIST): boolean {
+  const c = canonicalizePath(path).toLowerCase()
+  if (!c) return true
+  const segments = c.split('/')
+  for (const d of denylist) {
+    const dl = d.toLowerCase()
+    if (segments.includes(dl)) return true
+    // filename prefix (e.g. UTC-- keystore files) or dotfile match on the last seg
+    const last = segments[segments.length - 1] ?? ''
+    if (last === dl || last.startsWith(dl)) return true
+    // nested path fragment (e.g. "library/keychains")
+    if (dl.includes('/') && c.includes(dl)) return true
+  }
+  return false
+}
+
+// ─── Access decision (read/write) ────────────────────────────────────────────
+
+export type HostOp = 'list' | 'read' | 'write' | 'move' | 'delete'
+
+export interface AccessDecision {
+  allowed: boolean
+  reason: string
+}
+
+/** Decide whether an op on a path is permitted by the root + denylist rules
+ *  ALONE (blast-radius is a separate gate). Fail-closed: outside root, in the
+ *  denylist, blank, or on a symlink-escape flag → denied. */
+export function decideAccess(input: {
+  op: HostOp
+  path: string
+  root: string
+  denylist?: readonly string[]
+  symlinkEscapes?: boolean   // the daemon sets this after real symlink resolution
+}): AccessDecision {
+  const path = String(input.path ?? '')
+  if (!canonicalizePath(path)) return { allowed: false, reason: 'blank/invalid path' }
+  if (input.symlinkEscapes) return { allowed: false, reason: 'symlink resolves outside the allowlist root' }
+  if (!isWithinRoot(path, input.root)) return { allowed: false, reason: 'outside the allowlist root' }
+  if (hitsDenylist(path, input.denylist)) return { allowed: false, reason: 'denylisted (catastrophic target) — refused for read + write' }
+  return { allowed: true, reason: 'within root, not denylisted' }
+}
+
+// ─── Blast-radius caps ───────────────────────────────────────────────────────
+
+export interface BlastRadius {
+  fileCount: number
+  totalBytes: number
+  recursive?: boolean
+}
+
+export interface BlastCaps {
+  /** at/below this, an in-root op is auto-safe (no approval). */
+  autoSafeMaxFiles: number
+  autoSafeMaxBytes: number
+  /** above the hard ceiling, refuse outright and ask the operator to narrow. */
+  hardMaxFiles: number
+  hardMaxBytes: number
+}
+
+export const DEFAULT_BLAST_CAPS: BlastCaps = {
+  autoSafeMaxFiles: 10,
+  autoSafeMaxBytes: 50 * 1024 * 1024,       // 50 MB
+  hardMaxFiles: 5000,
+  hardMaxBytes: 20 * 1024 * 1024 * 1024,    // 20 GB
+}
+
+export type BlastVerdict = 'auto_safe' | 'needs_approval' | 'refuse'
+
+export interface BlastDecision {
+  verdict: BlastVerdict
+  reason: string
+}
+
+/** Classify an op by blast radius: auto-safe (small, in-root), needs-approval
+ *  (over the auto-safe threshold or recursive), or refuse (over the hard
+ *  ceiling). Destructive ops (move/delete) are NEVER auto-safe — they always need
+ *  at least approval. Pure. */
+export function classifyBlastRadius(input: {
+  op: HostOp
+  radius: BlastRadius
+  caps?: BlastCaps
+}): BlastDecision {
+  const caps = input.caps ?? DEFAULT_BLAST_CAPS
+  const { fileCount, totalBytes, recursive } = input.radius
+  if (fileCount > caps.hardMaxFiles || totalBytes > caps.hardMaxBytes) {
+    return { verdict: 'refuse', reason: `over the hard ceiling (${caps.hardMaxFiles} files / ${caps.hardMaxBytes} bytes) — narrow the request` }
+  }
+  const destructive = input.op === 'move' || input.op === 'delete'
+  const overAutoSafe = fileCount > caps.autoSafeMaxFiles || totalBytes > caps.autoSafeMaxBytes || !!recursive
+  if (destructive || overAutoSafe) {
+    return { verdict: 'needs_approval', reason: destructive ? 'destructive op — approval required' : 'over the auto-safe threshold — approval required' }
+  }
+  return { verdict: 'auto_safe', reason: 'in-root, under threshold, non-destructive' }
+}
+
+// ─── Combined plan ───────────────────────────────────────────────────────────
+
+export interface HostPlan {
+  op: HostOp
+  path: string
+  access: AccessDecision
+  blast: BlastDecision | null
+  /** overall: 'refused' | 'auto_safe' | 'needs_approval'. */
+  outcome: 'refused' | 'auto_safe' | 'needs_approval'
+  /** the A2 approval type to raise when outcome === 'needs_approval'. */
+  approvalType: 'file_destructive' | null
+  /** always false in this build — real execution is gated on S3 + the daemon. */
+  executable: boolean
+  reason: string
+}
+
+/** Produce a full host-op plan combining access + blast-radius. NEVER executable
+ *  in this build (fail-closed): `executable` is `HOST_EXECUTION_ENABLED`, which
+ *  stays false until S3 is confirmed and the daemon ships. */
+export function planHostOp(input: {
+  op: HostOp
+  path: string
+  root: string
+  radius?: BlastRadius
+  caps?: BlastCaps
+  denylist?: readonly string[]
+  symlinkEscapes?: boolean
+}): HostPlan {
+  const access = decideAccess({ op: input.op, path: input.path, root: input.root, denylist: input.denylist, symlinkEscapes: input.symlinkEscapes })
+  if (!access.allowed) {
+    return { op: input.op, path: input.path, access, blast: null, outcome: 'refused', approvalType: null, executable: false, reason: access.reason }
+  }
+  const radius = input.radius ?? { fileCount: 1, totalBytes: 0 }
+  const blast = classifyBlastRadius({ op: input.op, radius, caps: input.caps })
+  if (blast.verdict === 'refuse') {
+    return { op: input.op, path: input.path, access, blast, outcome: 'refused', approvalType: null, executable: false, reason: blast.reason }
+  }
+  const outcome = blast.verdict === 'auto_safe' ? 'auto_safe' : 'needs_approval'
+  return {
+    op: input.op, path: input.path, access, blast, outcome,
+    approvalType: outcome === 'needs_approval' ? 'file_destructive' : null,
+    executable: HOST_EXECUTION_ENABLED, // false until S3 confirmed + daemon ships
+    reason: blast.reason,
+  }
+}
+
+// ─── Undo journal ────────────────────────────────────────────────────────────
+
+export interface UndoEntry {
+  op: HostOp
+  original: string          // canonical original path
+  staged: string | null     // where the original was staged (move/delete), null for read
+  performedAt: number       // ms epoch
+  expiresAt: number         // ms epoch — reversible window end
+}
+
+/** Default reversible window: 10 minutes. */
+export const DEFAULT_UNDO_WINDOW_MS = 10 * 60 * 1000
+
+/** Build an undo-journal entry for a reversible destructive op. The daemon stages
+ *  the original (not purged) and records this; `isReversible` gates "undo that". */
+export function buildUndoEntry(input: {
+  op: HostOp
+  original: string
+  staged: string | null
+  now: number
+  windowMs?: number
+}): UndoEntry {
+  const windowMs = input.windowMs ?? DEFAULT_UNDO_WINDOW_MS
+  return {
+    op: input.op,
+    original: canonicalizePath(input.original),
+    staged: input.staged,
+    performedAt: input.now,
+    expiresAt: input.now + windowMs,
+  }
+}
+
+/** Is an op still reversible (within its window and with staged originals)? */
+export function isReversible(entry: UndoEntry | null | undefined, now: number): boolean {
+  if (!entry || !entry.staged) return false
+  return now < entry.expiresAt
+}

--- a/backend/src/tests/host-planner.test.ts
+++ b/backend/src/tests/host-planner.test.ts
@@ -1,0 +1,116 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  HOST_EXECUTION_ENABLED, assertExecutionEnabled,
+  canonicalizePath, isWithinRoot, hitsDenylist, decideAccess,
+  classifyBlastRadius, planHostOp, buildUndoEntry, isReversible,
+  DEFAULT_DENYLIST, DEFAULT_BLAST_CAPS, DEFAULT_UNDO_WINDOW_MS,
+} from '../services/host-planner'
+
+// ─── Fail-closed master switch ───────────────────────────────────────────────
+
+test('[C1] host execution is DISABLED (fail-closed) until S3 confirmed', () => {
+  assert.equal(HOST_EXECUTION_ENABLED, false)
+  assert.throws(() => assertExecutionEnabled(), /DISABLED|fail-closed/i)
+})
+
+// ─── Path canonicalization ───────────────────────────────────────────────────
+
+test('[C1] canonicalizePath resolves . / .. and collapses slashes', () => {
+  assert.equal(canonicalizePath('/Users/a/./b/../c'), '/Users/a/c')
+  assert.equal(canonicalizePath('/Users/a//b/'), '/Users/a/b')
+  assert.equal(canonicalizePath('/Users/a/b/../../..'), '/')       // can't escape root
+  assert.equal(canonicalizePath('a/b/../c'), 'a/c')
+  assert.equal(canonicalizePath(''), '')
+})
+
+// ─── Root prefix check ───────────────────────────────────────────────────────
+
+test('[C1] isWithinRoot allows in-root, blocks traversal + sibling escape', () => {
+  const root = '/Users/op/Arturita'
+  assert.equal(isWithinRoot('/Users/op/Arturita/docs/x.md', root), true)
+  assert.equal(isWithinRoot('/Users/op/Arturita', root), true)               // root itself
+  assert.equal(isWithinRoot('/Users/op/Arturita/../secret', root), false)    // .. escape
+  assert.equal(isWithinRoot('/Users/op/ArturitaEvil/x', root), false)        // prefix-not-boundary
+  assert.equal(isWithinRoot('/etc/passwd', root), false)
+})
+
+// ─── Denylist ────────────────────────────────────────────────────────────────
+
+test('[C1] hitsDenylist hard-denies catastrophic targets anywhere in the path', () => {
+  assert.equal(hitsDenylist('/Users/op/.ssh/id_rsa'), true)
+  assert.equal(hitsDenylist('/Users/op/project/.env'), true)
+  assert.equal(hitsDenylist('/Users/op/Library/Keychains/login.keychain'), true)
+  assert.equal(hitsDenylist('/Users/op/.metamask/vault'), true)
+  assert.equal(hitsDenylist('/Users/op/.arturita-host/config.json'), true)
+  assert.equal(hitsDenylist('/Users/op/Documents/notes.md'), false)
+  assert.equal(hitsDenylist(''), true) // blank → denied (fail closed)
+})
+
+// ─── Access decision ─────────────────────────────────────────────────────────
+
+test('[C1] decideAccess: in-root non-denylisted allowed; escapes + denylist refused', () => {
+  const root = '/Users/op/Arturita'
+  assert.equal(decideAccess({ op: 'read', path: '/Users/op/Arturita/x.md', root }).allowed, true)
+  assert.equal(decideAccess({ op: 'read', path: '/Users/op/Arturita/.ssh/id_rsa', root }).allowed, false)
+  assert.equal(decideAccess({ op: 'write', path: '/etc/hosts', root }).allowed, false)
+  // symlink escape flag (set by the daemon after real resolution) → refused
+  assert.equal(decideAccess({ op: 'write', path: '/Users/op/Arturita/link', root, symlinkEscapes: true }).allowed, false)
+})
+
+// ─── Blast radius ────────────────────────────────────────────────────────────
+
+test('[C1] classifyBlastRadius: small read auto-safe; destructive needs approval', () => {
+  assert.equal(classifyBlastRadius({ op: 'read', radius: { fileCount: 1, totalBytes: 100 } }).verdict, 'auto_safe')
+  assert.equal(classifyBlastRadius({ op: 'write', radius: { fileCount: 2, totalBytes: 1000 } }).verdict, 'auto_safe')
+  // destructive is never auto-safe
+  assert.equal(classifyBlastRadius({ op: 'delete', radius: { fileCount: 1, totalBytes: 1 } }).verdict, 'needs_approval')
+  assert.equal(classifyBlastRadius({ op: 'move', radius: { fileCount: 1, totalBytes: 1 } }).verdict, 'needs_approval')
+})
+
+test('[C1] classifyBlastRadius: over auto-safe threshold or recursive → approval', () => {
+  assert.equal(classifyBlastRadius({ op: 'write', radius: { fileCount: 999, totalBytes: 1 } }).verdict, 'needs_approval')
+  assert.equal(classifyBlastRadius({ op: 'write', radius: { fileCount: 1, totalBytes: 1, recursive: true } }).verdict, 'needs_approval')
+})
+
+test('[C1] classifyBlastRadius: over the hard ceiling → refuse outright', () => {
+  const over = { fileCount: DEFAULT_BLAST_CAPS.hardMaxFiles + 1, totalBytes: 1 }
+  assert.equal(classifyBlastRadius({ op: 'delete', radius: over }).verdict, 'refuse')
+  const overBytes = { fileCount: 1, totalBytes: DEFAULT_BLAST_CAPS.hardMaxBytes + 1 }
+  assert.equal(classifyBlastRadius({ op: 'read', radius: overBytes }).verdict, 'refuse')
+})
+
+// ─── Combined plan ───────────────────────────────────────────────────────────
+
+test('[C1] planHostOp: refused outside root, never executable in this build', () => {
+  const root = '/Users/op/Arturita'
+  const outside = planHostOp({ op: 'delete', path: '/etc/passwd', root })
+  assert.equal(outside.outcome, 'refused')
+  assert.equal(outside.executable, false)
+
+  const safe = planHostOp({ op: 'read', path: '/Users/op/Arturita/x.md', root, radius: { fileCount: 1, totalBytes: 10 } })
+  assert.equal(safe.outcome, 'auto_safe')
+  assert.equal(safe.executable, false) // fail-closed: no execution until S3 + daemon
+
+  const destructive = planHostOp({ op: 'delete', path: '/Users/op/Arturita/old', root, radius: { fileCount: 42, totalBytes: 1000 } })
+  assert.equal(destructive.outcome, 'needs_approval')
+  assert.equal(destructive.approvalType, 'file_destructive')
+  assert.equal(destructive.executable, false)
+})
+
+test('[C1] planHostOp refuses a denylisted target even if small + in root', () => {
+  const p = planHostOp({ op: 'read', path: '/Users/op/Arturita/.env', root: '/Users/op/Arturita', radius: { fileCount: 1, totalBytes: 10 } })
+  assert.equal(p.outcome, 'refused')
+})
+
+// ─── Undo journal ────────────────────────────────────────────────────────────
+
+test('[C1] buildUndoEntry + isReversible respect the window and staged originals', () => {
+  const e = buildUndoEntry({ op: 'delete', original: '/Users/op/Arturita/x', staged: '/Users/op/.arturita-trash/x', now: 1000 })
+  assert.equal(e.expiresAt, 1000 + DEFAULT_UNDO_WINDOW_MS)
+  assert.equal(isReversible(e, 1000 + 5000), true)
+  assert.equal(isReversible(e, 1000 + DEFAULT_UNDO_WINDOW_MS + 1), false) // window passed
+  // no staged original (e.g. a read) → not reversible
+  assert.equal(isReversible({ ...e, staged: null }, 1001), false)
+  assert.equal(isReversible(null, 1001), false)
+})

--- a/docs/PLAN-arturita.md
+++ b/docs/PLAN-arturita.md
@@ -22,12 +22,12 @@ This table is the source of truth for per-story status. Update the **Status** + 
 | **B1** | Voice Gateway (STT/TTS) | `todo` | — | S1 |
 | **B2** | Cockpit voice panel | `todo` | — | S5 |
 | **B3** | Ask-vs-execute routing from voice | `todo` | — | — |
-| **C1** | Local Host daemon | `todo` | — | **S3** |
+| **C1** | Local Host daemon | `in-progress` (pure planner only — daemon blocked on **S3**) | PR pending | **S3** |
 | **C2** | File ops + preview + undo | `todo` | — | S3 |
 | **C3** | `machine_exec` allowlist + doc editing | `todo` | — | **S6** |
 | **D1** | Telegram voice notes + text + auth | `todo` | — | S2 |
 | **D2** | Telegram files + inline approvals + voice replies | `todo` | — | S2 |
-| **E1** | Wallet read + prepare + simulate | `in-progress` | PR pending | — |
+| **E1** | Wallet read + prepare + simulate | `done` | [#178](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/178) | — |
 | **E2** | Wallet approval card + WalletConnect handoff | `todo` | — | **S4** |
 | **F1** | LLM fallback chain + circuit breaker | `done` | [#177](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/177) (pure layer; executor wiring follow-up) | — |
 | **F2** | Degraded/offline + watchdogs | `todo` | — | — |

--- a/docs/REQUIREMENTS-arturita.md
+++ b/docs/REQUIREMENTS-arturita.md
@@ -86,9 +86,9 @@
 | NFR-3 | No dangerous surface (B/C/D/E) merges before A2 (the approval-type gate) is on `main`. | sequencing | `[ ]` |
 | NFR-4 | Destructive voice commands are never one-shot: ≥99% require an explicit confirmation utterance/tap; ambiguous/low-confidence → reject + re-prompt. | A3, B1 | `[~]` (A3: two-phase confirm logic — bare affirmative rejected, action-verb restatement or tap required, sub-threshold STT re-prompts; end-to-end voice wiring in B1) |
 | NFR-5 | Voice never authorizes an address or amount alone — entities echoed visually before wallet/email approval. | A3, E2 | `[ ]` |
-| NFR-6 | Machine ops cannot escape the allowlist root (canonicalize + prefix check; no `..`/symlink escape); denylist hard-refused for read + write. | C1 | `[ ]` |
-| NFR-7 | Blast-radius caps: over-cap ops require approval; over hard-ceiling refused outright. | C1, C2 | `[ ]` |
-| NFR-8 | Local host is fail-closed — acts only on an authenticated, approved backend command; runs as operator user, no sudo. | C1 | `[ ]` |
+| NFR-6 | Machine ops cannot escape the allowlist root (canonicalize + prefix check; no `..`/symlink escape); denylist hard-refused for read + write. | C1 | `[~]` (C1 planner: `canonicalizePath`/`isWithinRoot`/`hitsDenylist`/`decideAccess` logic done + tested (incl. `..`, symlink-escape flag, prefix-not-boundary); the daemon that resolves real symlinks + enforces this is blocked on **S3**) |
+| NFR-7 | Blast-radius caps: over-cap ops require approval; over hard-ceiling refused outright. | C1, C2 | `[~]` (C1 planner: `classifyBlastRadius` — auto-safe / needs-approval / refuse, destructive never auto-safe — done + tested; execution wiring blocked on S3) |
+| NFR-8 | Local host is fail-closed — acts only on an authenticated, approved backend command; runs as operator user, no sudo. | C1 | `[~]` (C1 planner: `HOST_EXECUTION_ENABLED=false` + `assertExecutionEnabled()` throw — nothing can execute until S3 confirmed + the daemon ships; daemon itself is the S3-gated deliverable) |
 
 ### Security
 | ID | Requirement | Story | Status |


### PR DESCRIPTION
## Epic C · Story C1 — SAFE SUBSET (pure planner only)

⚠️ **This ships the pure DECISION LOGIC for the future Arturita Local Host daemon — NOT the daemon.** No filesystem I/O, no command execution, no routes. The allowlist-root / denylist / blast-radius / path-canonicalization / undo-journal rules are written, owned, and exhaustively tested in the backend **behind a fail-closed master switch**, so the safety envelope exists and is verified **before** any real host write path ships.

**The real write/destructive path stays BLOCKED until decision S3** (mac-control adapter approach + allowlist root/denylist) is `CONFIRMED` in `docs/DECISIONS-arturita.md`.

### What shipped — `services/host-planner.ts` (pure, unit-tested)
- **`HOST_EXECUTION_ENABLED = false`** + **`assertExecutionEnabled()` throws** — fail-closed: a plan is never permission to act; nothing can touch the FS until S3.
- **`canonicalizePath`** (lexical `.`/`..`/slash-collapse, can't escape root) + **`isWithinRoot`** prefix check (blocks `..` traversal and the prefix-not-boundary trick like `/root` vs `/rootEvil`).
- **`hitsDenylist`** — catastrophic targets (`.ssh`, keychains, `.env`, wallet vaults, the host's own config) hard-denied for **read AND write**, anywhere in the path.
- **`decideAccess`** — combines root + denylist + a `symlinkEscapes` flag (the daemon sets it after real symlink resolution — defense in depth).
- **`classifyBlastRadius`** — `auto_safe` / `needs_approval` / `refuse`; destructive (move/delete) is **never** auto-safe; over the hard ceiling → refuse and ask to narrow.
- **`planHostOp`** — full plan, raising a `file_destructive` approval (A2) when needed; `executable` is always `false` in this build.
- **`buildUndoEntry` / `isReversible`** — the reversible-window undo journal.

### Safety
Fail-closed by construction. Nothing here can act; it only decides. The daemon + real execution are the S3-gated deliverable.

### Verification
**683 backend tests** (11 new, incl. traversal/symlink/denylist/blast-ceiling/undo-window) · **11/11 evals** · web build via CI · `npm audit` known non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)