### PR TITLE
feat(arturita B1 helpers): voice gateway pure core (STT confidence, wake-word, provider fallback)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -34,6 +34,8 @@ Full planning/tracking layer filed (docs-only, no code yet): **PRD** `docs/PRD-a
 
 | **C1** (pure planner) · Host safety logic | `services/host-planner.ts` (pure, **fail-closed**: `HOST_EXECUTION_ENABLED=false` + `assertExecutionEnabled()` throw until S3; `canonicalizePath`/`isWithinRoot` no-escape prefix check; `hitsDenylist` catastrophic-target hard-deny; `classifyBlastRadius` auto-safe/needs-approval/refuse with destructive-never-auto-safe; `decideAccess`; `planHostOp` combined plan → `file_destructive` approval; undo-journal `buildUndoEntry`/`isReversible`). **No daemon, no routes, NO filesystem execution** — the write/destructive path stays blocked on **S3**. | in progress | PR pending |
 
+| **B1** (pure helpers) · Voice gateway core | `services/voice.ts` (pure: `normalizeTranscript`; `hasWakeWord`/`stripWakeWord`/`shouldProcessCapture` — push-to-talk default, wake-word opt-in; `gateTranscript` empty/reprompt/accept confidence gate; `orderVoiceProviders` cloud→alt→local→text-only with **local-only for sensitive/wallet contexts** (S1 privacy default); `nextVoiceProvider`; `AUDIO_RETENTION` discard-after-transcription marker). Provider adapters + the `/voice` endpoint land when an **S1** STT/TTS provider is configured. | in progress | PR pending |
+
 Safety gate: **A2 (on `main`) is the mechanical approval-type gate** every dangerous surface depends on. `machine_exec` (C3) + wallet signing handoff (E2) + host filesystem writes (C1/C2 daemon) stay blocked on **S3/S6/S4** until CONFIRMED. **Arturita never signs; no key custody; no real destructive machine op ships until S3.**
 
 ## Paperclip gap-bridge — 5 / 5 phases shipped

--- a/backend/src/services/voice.ts
+++ b/backend/src/services/voice.ts
@@ -1,0 +1,129 @@
+// Arturita B1 (safe subset) — Voice Gateway PURE HELPERS.
+//
+// The provider layer for STT/TTS (same philosophy as `llm-router`) — this file
+// is the pure, testable core: transcript normalization, STT-confidence gating,
+// wake-word / push-to-talk handling, and provider fallback ORDERING
+// (cloud → alt → local → text-only) so a provider outage never drops a command.
+//
+// It performs NO audio I/O and holds NO provider keys — the route/provider
+// adapters do that. Scaffolded on the PROVISIONAL S1 decision (local-first,
+// provider-pluggable): the ordering here defaults to preferring LOCAL for
+// sensitive/wallet-adjacent contexts. Audio is discarded after transcription
+// (PRD §7.8) — `AUDIO_RETENTION` documents that invariant for callers.
+
+import { MIN_STT_CONFIDENCE } from './intent'
+
+// Re-export so voice callers have one source for the confidence threshold.
+export { MIN_STT_CONFIDENCE }
+
+/** Audio is transcribed then discarded — no long-term audio store (PRD §7.8). */
+export const AUDIO_RETENTION = 'discard_after_transcription' as const
+
+// ─── Transcript normalization ────────────────────────────────────────────────
+
+/** Normalize a raw STT transcript for downstream intent classification:
+ *  collapse whitespace, trim, and strip a leading wake word if present. Keeps
+ *  original casing for entity echo; downstream lower-cases as needed. */
+export function normalizeTranscript(raw: string | null | undefined): string {
+  return String(raw ?? '').replace(/\s+/g, ' ').trim()
+}
+
+// ─── Wake word ───────────────────────────────────────────────────────────────
+
+export const WAKE_WORD = 'arturita'
+
+/** Does the transcript start with the wake word ("Arturita, …")? Used only when
+ *  wake-word mode is opted in (push-to-talk is the default — S5). */
+export function hasWakeWord(transcript: string | null | undefined, wake: string = WAKE_WORD): boolean {
+  const t = normalizeTranscript(transcript).toLowerCase()
+  return t === wake || t.startsWith(wake + ' ') || t.startsWith(wake + ',')
+}
+
+/** Strip a leading wake word (+ following comma) so the command classifier sees
+ *  just the command. No-op when absent. */
+export function stripWakeWord(transcript: string | null | undefined, wake: string = WAKE_WORD): string {
+  const t = normalizeTranscript(transcript)
+  const re = new RegExp('^' + wake + '\\s*,?\\s*', 'i')
+  return t.replace(re, '').trim()
+}
+
+/** Should this capture be processed? Push-to-talk captures are always processed;
+ *  wake-word-mode captures are processed only if the wake word is present. */
+export function shouldProcessCapture(input: {
+  transcript: string | null | undefined
+  mode: 'push_to_talk' | 'wake_word'
+  wake?: string
+}): boolean {
+  if (input.mode === 'push_to_talk') return normalizeTranscript(input.transcript).length > 0
+  return hasWakeWord(input.transcript, input.wake ?? WAKE_WORD)
+}
+
+// ─── STT confidence gating ───────────────────────────────────────────────────
+
+export interface TranscriptResult {
+  transcript: string
+  confidence: number | null
+  provider: string
+}
+
+export type TranscriptDisposition = 'accept' | 'reprompt' | 'empty'
+
+/** Gate an STT result: empty → 'empty'; below the confidence threshold →
+ *  'reprompt' (never guess — PRD §7.2/§8); otherwise 'accept'. Null confidence
+ *  (provider gave none) is accepted (can't reprompt on unknown). */
+export function gateTranscript(
+  result: Pick<TranscriptResult, 'transcript' | 'confidence'>,
+  threshold: number = MIN_STT_CONFIDENCE,
+): TranscriptDisposition {
+  const t = normalizeTranscript(result.transcript)
+  if (!t) return 'empty'
+  if (result.confidence != null && result.confidence < threshold) return 'reprompt'
+  return 'accept'
+}
+
+// ─── Provider fallback ordering ──────────────────────────────────────────────
+
+export type VoiceTier = 'cloud' | 'alt' | 'local' | 'text_only'
+
+export interface VoiceProvider {
+  id: string
+  tier: VoiceTier
+  /** true if the provider runs locally (no data leaves the machine). */
+  local: boolean
+  healthy?: boolean
+}
+
+/** Order STT/TTS providers for a capture. When the context is sensitive
+ *  (wallet/secret-adjacent), LOCAL providers come first and cloud is dropped
+ *  entirely (privacy — S1 default); otherwise cloud-first with local as the
+ *  offline fallback, then a text-only last resort. Unhealthy providers are
+ *  dropped. Pure. */
+export function orderVoiceProviders(input: {
+  providers: VoiceProvider[]
+  sensitive: boolean
+}): VoiceProvider[] {
+  const healthy = input.providers.filter(p => p.healthy !== false)
+  if (input.sensitive) {
+    // sensitive: local only (no cloud), then text-only.
+    return healthy
+      .filter(p => p.local || p.tier === 'text_only')
+      .sort((a, b) => tierRank(a.tier) - tierRank(b.tier))
+  }
+  return [...healthy].sort((a, b) => tierRank(a.tier) - tierRank(b.tier))
+}
+
+const TIER_ORDER: VoiceTier[] = ['cloud', 'alt', 'local', 'text_only']
+function tierRank(t: VoiceTier): number {
+  const i = TIER_ORDER.indexOf(t)
+  return i === -1 ? TIER_ORDER.length : i
+}
+
+/** The next provider to try after `failedId` fell over — the next healthy one in
+ *  the ordered list, or null when the chain is exhausted (caller drops to
+ *  text-only / posts a notice). Pure. */
+export function nextVoiceProvider(ordered: VoiceProvider[], failedId: string | null): VoiceProvider | null {
+  if (!failedId) return ordered[0] ?? null
+  const idx = ordered.findIndex(p => p.id === failedId)
+  if (idx === -1) return ordered[0] ?? null
+  return ordered[idx + 1] ?? null
+}

--- a/backend/src/tests/voice.test.ts
+++ b/backend/src/tests/voice.test.ts
@@ -1,0 +1,89 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  normalizeTranscript, hasWakeWord, stripWakeWord, shouldProcessCapture,
+  gateTranscript, orderVoiceProviders, nextVoiceProvider,
+  AUDIO_RETENTION, WAKE_WORD, MIN_STT_CONFIDENCE, type VoiceProvider,
+} from '../services/voice'
+
+// ─── Retention invariant ─────────────────────────────────────────────────────
+
+test('[B1] audio retention default is discard-after-transcription (PRD §7.8)', () => {
+  assert.equal(AUDIO_RETENTION, 'discard_after_transcription')
+})
+
+// ─── Transcript normalization ────────────────────────────────────────────────
+
+test('[B1] normalizeTranscript collapses whitespace + trims', () => {
+  assert.equal(normalizeTranscript('  hello   world \n'), 'hello world')
+  assert.equal(normalizeTranscript(null), '')
+})
+
+// ─── Wake word ───────────────────────────────────────────────────────────────
+
+test('[B1] hasWakeWord matches a leading "Arturita"', () => {
+  assert.equal(hasWakeWord('Arturita, what is on my calendar'), true)
+  assert.equal(hasWakeWord('arturita move the files'), true)
+  assert.equal(hasWakeWord('Arturita'), true)
+  assert.equal(hasWakeWord('hey there'), false)
+  assert.equal(hasWakeWord('tell Arturita later'), false) // not leading
+  assert.equal(WAKE_WORD, 'arturita')
+})
+
+test('[B1] stripWakeWord removes the leading wake word + comma', () => {
+  assert.equal(stripWakeWord('Arturita, move the files'), 'move the files')
+  assert.equal(stripWakeWord('arturita delete downloads'), 'delete downloads')
+  assert.equal(stripWakeWord('move the files'), 'move the files') // no-op
+})
+
+test('[B1] shouldProcessCapture: push-to-talk always; wake-word only if present', () => {
+  assert.equal(shouldProcessCapture({ transcript: 'move it', mode: 'push_to_talk' }), true)
+  assert.equal(shouldProcessCapture({ transcript: '   ', mode: 'push_to_talk' }), false)
+  assert.equal(shouldProcessCapture({ transcript: 'move it', mode: 'wake_word' }), false)
+  assert.equal(shouldProcessCapture({ transcript: 'Arturita move it', mode: 'wake_word' }), true)
+})
+
+// ─── Confidence gating ───────────────────────────────────────────────────────
+
+test('[B1] gateTranscript: empty / low-confidence / accept', () => {
+  assert.equal(gateTranscript({ transcript: '', confidence: 0.9 }), 'empty')
+  assert.equal(gateTranscript({ transcript: 'delete it', confidence: MIN_STT_CONFIDENCE - 0.1 }), 'reprompt')
+  assert.equal(gateTranscript({ transcript: 'delete it', confidence: 0.95 }), 'accept')
+  assert.equal(gateTranscript({ transcript: 'delete it', confidence: null }), 'accept') // no score → accept
+})
+
+// ─── Provider fallback ordering ──────────────────────────────────────────────
+
+const PROVIDERS: VoiceProvider[] = [
+  { id: 'cloud-a', tier: 'cloud', local: false },
+  { id: 'cloud-b', tier: 'alt', local: false },
+  { id: 'local-whisper', tier: 'local', local: true },
+  { id: 'text', tier: 'text_only', local: false },
+]
+
+test('[B1] orderVoiceProviders: cloud-first for normal contexts', () => {
+  const ordered = orderVoiceProviders({ providers: PROVIDERS, sensitive: false })
+  assert.deepEqual(ordered.map(p => p.id), ['cloud-a', 'cloud-b', 'local-whisper', 'text'])
+})
+
+test('[B1] orderVoiceProviders: LOCAL-ONLY for sensitive (wallet/secret) contexts', () => {
+  const ordered = orderVoiceProviders({ providers: PROVIDERS, sensitive: true })
+  // no cloud/alt providers; local + text-only only
+  assert.deepEqual(ordered.map(p => p.id), ['local-whisper', 'text'])
+  assert.ok(!ordered.some(p => !p.local && p.tier !== 'text_only'))
+})
+
+test('[B1] orderVoiceProviders drops unhealthy providers', () => {
+  const withDown = PROVIDERS.map(p => p.id === 'cloud-a' ? { ...p, healthy: false } : p)
+  const ordered = orderVoiceProviders({ providers: withDown, sensitive: false })
+  assert.ok(!ordered.some(p => p.id === 'cloud-a'))
+  assert.equal(ordered[0].id, 'cloud-b')
+})
+
+test('[B1] nextVoiceProvider walks the chain then returns null when exhausted', () => {
+  const ordered = orderVoiceProviders({ providers: PROVIDERS, sensitive: false })
+  assert.equal(nextVoiceProvider(ordered, null)!.id, 'cloud-a')       // first
+  assert.equal(nextVoiceProvider(ordered, 'cloud-a')!.id, 'cloud-b')  // after failure
+  assert.equal(nextVoiceProvider(ordered, 'local-whisper')!.id, 'text')
+  assert.equal(nextVoiceProvider(ordered, 'text'), null)             // exhausted
+})

--- a/docs/PLAN-arturita.md
+++ b/docs/PLAN-arturita.md
@@ -19,10 +19,10 @@ This table is the source of truth for per-story status. Update the **Status** + 
 | **A1** | Persona, sessions & `/panic` kill switch | `done` | [#174](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/174) | — |
 | **A2** | Dangerous-action approval types + step-up | `done` | [#175](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/175) | — |
 | **A3** | Intent classifier + two-phase destructive confirm | `in-progress` | PR pending | — |
-| **B1** | Voice Gateway (STT/TTS) | `todo` | — | S1 |
+| **B1** | Voice Gateway (STT/TTS) | `in-progress` (pure helpers; provider layer + endpoint pending S1 keys) | PR pending | S1 |
 | **B2** | Cockpit voice panel | `todo` | — | S5 |
 | **B3** | Ask-vs-execute routing from voice | `todo` | — | — |
-| **C1** | Local Host daemon | `in-progress` (pure planner only — daemon blocked on **S3**) | PR pending | **S3** |
+| **C1** | Local Host daemon | `in-progress` (pure planner done [#179]; daemon blocked on **S3**) | [#179](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/179) | **S3** |
 | **C2** | File ops + preview + undo | `todo` | — | S3 |
 | **C3** | `machine_exec` allowlist + doc editing | `todo` | — | **S6** |
 | **D1** | Telegram voice notes + text + auth | `todo` | — | S2 |

--- a/docs/REQUIREMENTS-arturita.md
+++ b/docs/REQUIREMENTS-arturita.md
@@ -13,8 +13,8 @@
 | ID | Requirement | Story | Status |
 |---|---|---|---|
 | FR-1 | Operator can issue spoken commands from the desk (Cockpit mic, push-to-talk). | B2 | `[ ]` |
-| FR-2 | Spoken input is transcribed with a confidence score; low-confidence transcripts trigger a re-prompt, never a guess. | B1, A3 | `[ ]` |
-| FR-3 | Wake-word ("Arturita") is available as an opt-in; push-to-talk is the default. | B2 (S5) | `[ ]` |
+| FR-2 | Spoken input is transcribed with a confidence score; low-confidence transcripts trigger a re-prompt, never a guess. | B1, A3 | `[~]` (B1: `gateTranscript` (empty/reprompt/accept) + `TranscriptResult.confidence`; A3 re-prompt path done; live STT provider returning the score wires when an S1 provider is configured) |
+| FR-3 | Wake-word ("Arturita") is available as an opt-in; push-to-talk is the default. | B2 (S5) | `[~]` (B1: `hasWakeWord`/`stripWakeWord`/`shouldProcessCapture` — push-to-talk default, wake-word opt-in; Cockpit panel UI is B2) |
 | FR-4 | Arturita replies by voice (TTS) on the desk and as a Telegram voice message remotely. | B1, D2 | `[ ]` |
 | FR-5 | Questions route to a single-turn `ask` (no workspace/checkout); work orders route to the `execute` loop. | B3 | `[ ]` |
 | FR-6 | A follow-up utterance continues the same task thread (wake-on-comment). | B3 | `[ ]` |
@@ -109,7 +109,7 @@
 ### Privacy & observability
 | ID | Requirement | Story | Status |
 |---|---|---|---|
-| NFR-17 | Voice audio discarded after transcription; no long-term audio store; transcripts operator-deletable. | B1 | `[ ]` |
+| NFR-17 | Voice audio discarded after transcription; no long-term audio store; transcripts operator-deletable. | B1 | `[~]` (B1: `AUDIO_RETENTION='discard_after_transcription'` invariant marker + no audio persisted by design; enforced end-to-end when the voice endpoint lands with the S1 provider) |
 | NFR-18 | A "what did you hear/do" audit view lists recent transcripts + actions. | B2/G1 | `[ ]` |
 | NFR-19 | Every Arturita action is visible as a task with a thread + heartbeat block (no silent actions). | A1/C2/timeline | `[ ]` |
 


### PR DESCRIPTION
## Epic B · Story B1 — SAFE SUBSET (pure helpers)

The pure, testable **core** of the Voice Gateway. No audio I/O, no provider keys. Scaffolded on the **provisional S1** decision (local-first, provider-pluggable); the provider adapters + `POST /api/arturita/voice` land when an S1 STT/TTS provider is configured.

### `services/voice.ts` (pure, unit-tested)
- `normalizeTranscript`; `hasWakeWord` / `stripWakeWord` / `shouldProcessCapture` — **push-to-talk default**, wake-word opt-in (S5).
- `gateTranscript` — `empty` / `reprompt` (below `MIN_STT_CONFIDENCE`, **never guess**) / `accept`; composes with A3's re-prompt.
- `orderVoiceProviders` — cloud → alt → local → text-only, **LOCAL-ONLY for sensitive (wallet/secret) contexts** (S1 privacy default); drops unhealthy providers. `nextVoiceProvider` walks to exhaustion.
- `AUDIO_RETENTION='discard_after_transcription'` — the PRD §7.8 invariant.

### Verification
**693 backend tests** (10 new) · **11/11 evals** · web build via CI · `npm audit` known non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)