### PR TITLE
feat(arturita B3): ask-vs-execute routing from voice (pure)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -36,6 +36,8 @@ Full planning/tracking layer filed (docs-only, no code yet): **PRD** `docs/PRD-a
 
 | **B1** (pure helpers) · Voice gateway core | `services/voice.ts` (pure: `normalizeTranscript`; `hasWakeWord`/`stripWakeWord`/`shouldProcessCapture` — push-to-talk default, wake-word opt-in; `gateTranscript` empty/reprompt/accept confidence gate; `orderVoiceProviders` cloud→alt→local→text-only with **local-only for sensitive/wallet contexts** (S1 privacy default); `nextVoiceProvider`; `AUDIO_RETENTION` discard-after-transcription marker). Provider adapters + the `/voice` endpoint land when an **S1** STT/TTS provider is configured. | in progress | PR pending |
 
+| **B3** (pure routing) · Ask-vs-execute from voice | `services/voice-routing.ts` (pure: `isQuestion`; `routeVoiceCommand` → question→`ask` single-turn, work order→`execute`, **destructive→execute-always** even if phrased as a question; `isFollowUp` re-enters the thread via wake-on-comment). Reuses `intent.ts` + `askmode.ts` + `thread.ts` — no new loop. Endpoint wiring pends the B1 voice endpoint (S1). | in progress | PR pending |
+
 Safety gate: **A2 (on `main`) is the mechanical approval-type gate** every dangerous surface depends on. `machine_exec` (C3) + wallet signing handoff (E2) + host filesystem writes (C1/C2 daemon) stay blocked on **S3/S6/S4** until CONFIRMED. **Arturita never signs; no key custody; no real destructive machine op ships until S3.**
 
 ## Paperclip gap-bridge — 5 / 5 phases shipped

--- a/backend/src/services/voice-routing.ts
+++ b/backend/src/services/voice-routing.ts
@@ -1,0 +1,65 @@
+// Arturita B3 — ask-vs-execute routing from voice (pure).
+//
+// A voice command becomes a task on the existing board. This decides HOW it runs
+// (reusing the shipped primitives, not a new loop): a question routes to a
+// single-turn `ask` (askmode.ts `work_mode: 'ask'` — no workspace/checkout); a
+// work order routes to the full `execute` loop; a follow-up utterance re-enters
+// the same task thread (thread.ts wake-on-comment). This module only makes the
+// ROUTING DECISION — pure + tested; the endpoint (B1/S1) wires it to the executor.
+
+import { classifyIntent, type IntentClassification } from './intent'
+import { normalizeWorkMode, type WorkMode } from './askmode'
+
+// Interrogative openers + auxiliaries that mark a question ("what's on my
+// calendar", "do I have any meetings").
+const QUESTION_OPENERS = [
+  'what', 'whats', "what's", 'when', 'where', 'who', 'whom', 'whose', 'why', 'how',
+  'which', 'is', 'are', 'am', 'was', 'were', 'do', 'does', 'did', 'can', 'could',
+  'should', 'would', 'will', 'has', 'have', 'had', 'may', 'might',
+]
+
+function firstWord(s: string): string {
+  return s.toLowerCase().replace(/^[^a-z]+/, '').split(/\s+/)[0] ?? ''
+}
+
+/** Is this transcript phrased as a question? (interrogative opener or a trailing
+ *  '?'). Pure text heuristic. */
+export function isQuestion(transcript: string | null | undefined): boolean {
+  const t = String(transcript ?? '').trim()
+  if (!t) return false
+  if (t.endsWith('?')) return true
+  return QUESTION_OPENERS.includes(firstWord(t))
+}
+
+export interface VoiceRoute {
+  workMode: WorkMode
+  intent: IntentClassification
+  isFollowUp: boolean
+  reason: string
+}
+
+/**
+ * Route a voice command:
+ *  - A destructive intent is ALWAYS a work order → `execute` (a "delete the
+ *    files" phrased as a question is still an action; safety wins).
+ *  - A non-destructive question → `ask` (single-turn, no workspace/checkout).
+ *  - Anything else (a safe imperative — "summarize this file") → `execute`.
+ *  - `existingThreadId` present → this is a follow-up that re-enters that thread
+ *    (wake-on-comment), regardless of mode.
+ * Pure — the endpoint applies the decision (create task / post comment).
+ */
+export function routeVoiceCommand(input: {
+  transcript: string
+  existingThreadId?: string | null
+}): VoiceRoute {
+  const intent = classifyIntent(input.transcript)
+  const isFollowUp = !!input.existingThreadId
+
+  if (intent.destructive) {
+    return { workMode: 'execute', intent, isFollowUp, reason: 'destructive intent — runs as an execute-mode work order (gated by approval)' }
+  }
+  if (isQuestion(input.transcript)) {
+    return { workMode: normalizeWorkMode('ask'), intent, isFollowUp, reason: 'question — single-turn ask (no workspace/checkout)' }
+  }
+  return { workMode: 'execute', intent, isFollowUp, reason: 'work order — execute loop' }
+}

--- a/backend/src/tests/voice-routing.test.ts
+++ b/backend/src/tests/voice-routing.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isQuestion, routeVoiceCommand } from '../services/voice-routing'
+
+// ─── Question detection ──────────────────────────────────────────────────────
+
+test('[B3] isQuestion recognizes interrogatives + trailing ?', () => {
+  assert.equal(isQuestion('what is on my calendar Thursday'), true)
+  assert.equal(isQuestion("what's my ETH balance"), true)
+  assert.equal(isQuestion('do I have any meetings today'), true)
+  assert.equal(isQuestion('is the deploy done?'), true)
+  assert.equal(isQuestion('move the files'), false)
+  assert.equal(isQuestion('summarize this PDF'), false)
+  assert.equal(isQuestion(''), false)
+})
+
+// ─── Routing ─────────────────────────────────────────────────────────────────
+
+test('[B3] questions route to a single-turn ask', () => {
+  const r = routeVoiceCommand({ transcript: 'what is on my calendar Thursday' })
+  assert.equal(r.workMode, 'ask')
+  assert.equal(r.intent.tier, 'safe')
+  assert.match(r.reason, /single-turn/)
+})
+
+test('[B3] work orders route to the execute loop', () => {
+  const r = routeVoiceCommand({ transcript: 'summarize this PDF and save it' })
+  assert.equal(r.workMode, 'execute')
+})
+
+test('[B3] destructive intents ALWAYS execute, even phrased as a question', () => {
+  // "can you delete the downloads?" is phrased as a question but is an action.
+  const r = routeVoiceCommand({ transcript: 'can you delete the downloads?' })
+  assert.equal(r.workMode, 'execute')
+  assert.equal(r.intent.tier, 'critical')
+  assert.match(r.reason, /destructive/)
+})
+
+test('[B3] a wallet transfer is a work order (execute), never an ask', () => {
+  const r = routeVoiceCommand({ transcript: 'transfer 0.5 ETH to Bob' })
+  assert.equal(r.workMode, 'execute')
+  assert.equal(r.intent.approvalType, 'wallet_tx')
+})
+
+test('[B3] a follow-up utterance re-enters the same thread', () => {
+  const fresh = routeVoiceCommand({ transcript: 'what about Friday' })
+  assert.equal(fresh.isFollowUp, false)
+
+  const follow = routeVoiceCommand({ transcript: 'what about Friday', existingThreadId: 'task_123' })
+  assert.equal(follow.isFollowUp, true)
+  assert.equal(follow.workMode, 'ask') // still a question, continues the ask thread
+})
+
+test('[B3] read-only question about the wallet routes to ask (no tx)', () => {
+  const r = routeVoiceCommand({ transcript: 'what is my ETH balance and the gas price' })
+  assert.equal(r.workMode, 'ask')
+  assert.equal(r.intent.destructive, false)
+})

--- a/docs/PLAN-arturita.md
+++ b/docs/PLAN-arturita.md
@@ -19,9 +19,9 @@ This table is the source of truth for per-story status. Update the **Status** + 
 | **A1** | Persona, sessions & `/panic` kill switch | `done` | [#174](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/174) | — |
 | **A2** | Dangerous-action approval types + step-up | `done` | [#175](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/175) | — |
 | **A3** | Intent classifier + two-phase destructive confirm | `in-progress` | PR pending | — |
-| **B1** | Voice Gateway (STT/TTS) | `in-progress` (pure helpers; provider layer + endpoint pending S1 keys) | PR pending | S1 |
+| **B1** | Voice Gateway (STT/TTS) | `in-progress` (pure helpers done [#180]; provider layer + endpoint pending S1 keys) | [#180](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/180) | S1 |
 | **B2** | Cockpit voice panel | `todo` | — | S5 |
-| **B3** | Ask-vs-execute routing from voice | `todo` | — | — |
+| **B3** | Ask-vs-execute routing from voice | `in-progress` (pure routing done; endpoint wiring pends B1-full) | PR pending | — |
 | **C1** | Local Host daemon | `in-progress` (pure planner done [#179]; daemon blocked on **S3**) | [#179](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/179) | **S3** |
 | **C2** | File ops + preview + undo | `todo` | — | S3 |
 | **C3** | `machine_exec` allowlist + doc editing | `todo` | — | **S6** |

--- a/docs/REQUIREMENTS-arturita.md
+++ b/docs/REQUIREMENTS-arturita.md
@@ -16,8 +16,8 @@
 | FR-2 | Spoken input is transcribed with a confidence score; low-confidence transcripts trigger a re-prompt, never a guess. | B1, A3 | `[~]` (B1: `gateTranscript` (empty/reprompt/accept) + `TranscriptResult.confidence`; A3 re-prompt path done; live STT provider returning the score wires when an S1 provider is configured) |
 | FR-3 | Wake-word ("Arturita") is available as an opt-in; push-to-talk is the default. | B2 (S5) | `[~]` (B1: `hasWakeWord`/`stripWakeWord`/`shouldProcessCapture` — push-to-talk default, wake-word opt-in; Cockpit panel UI is B2) |
 | FR-4 | Arturita replies by voice (TTS) on the desk and as a Telegram voice message remotely. | B1, D2 | `[ ]` |
-| FR-5 | Questions route to a single-turn `ask` (no workspace/checkout); work orders route to the `execute` loop. | B3 | `[ ]` |
-| FR-6 | A follow-up utterance continues the same task thread (wake-on-comment). | B3 | `[ ]` |
+| FR-5 | Questions route to a single-turn `ask` (no workspace/checkout); work orders route to the `execute` loop. | B3 | `[~]` (B3: `routeVoiceCommand` — question→ask, work order→execute, destructive→execute-always; reuses `askmode`/`intent`. Executor wiring pends the B1 voice endpoint) |
+| FR-6 | A follow-up utterance continues the same task thread (wake-on-comment). | B3 | `[~]` (B3: `routeVoiceCommand` sets `isFollowUp` from an existing thread id → reuses `thread.ts` wake-on-comment; endpoint wiring pends B1) |
 | FR-7 | Operator can interrupt (barge-in) a spoken reply; long answers summarized aloud with full text in the thread. | B1/B2 | `[ ]` |
 
 ### Machine control


### PR DESCRIPTION
## Epic B · Story B3 — ask-vs-execute routing (pure core)

A voice command becomes a task on the existing board; this decides **how** it runs by **reusing the shipped primitives** (`askmode` / `intent` / `thread`), not a new loop. No dangerous surface.

### `services/voice-routing.ts` (pure, unit-tested)
- **`isQuestion()`** — interrogative-opener / trailing-`?` heuristic.
- **`routeVoiceCommand()`**:
  - a **question** → single-turn **`ask`** (no workspace/checkout — reuses `askmode`),
  - a **work order** → **`execute`**,
  - a **destructive** intent → **`execute` ALWAYS**, even phrased as a question ("can you delete the downloads?") — safety wins,
  - a **follow-up** (existing thread id) → re-enters the same thread (`thread.ts` wake-on-comment).

The executor wiring lands with the B1 voice endpoint (S1); this is the tested routing decision.

### Verification
**700 backend tests** (7 new) · **11/11 evals** · web build via CI · `npm audit` known non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)