### PR TITLE
feat(arturita F2): degraded/offline queue-replay + watchdog attach (pure)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -38,6 +38,8 @@ Full planning/tracking layer filed (docs-only, no code yet): **PRD** `docs/PRD-a
 
 | **B3** (pure routing) · Ask-vs-execute from voice | `services/voice-routing.ts` (pure: `isQuestion`; `routeVoiceCommand` → question→`ask` single-turn, work order→`execute`, **destructive→execute-always** even if phrased as a question; `isFollowUp` re-enters the thread via wake-on-comment). Reuses `intent.ts` + `askmode.ts` + `thread.ts` — no new loop. Endpoint wiring pends the B1 voice endpoint (S1). | in progress | PR pending |
 
+| **F2** (pure helpers) · Degraded/offline + watchdogs | `services/arturita-resilience.ts` (pure: `actionNeed` local/cloud/host; `routeForConnectivity` — local runs offline, cloud queues offline with a spoken notice, host fails closed when the daemon is down; `planReplay` idempotent nonce-guarded exactly-once replay on reconnect; `defaultArturitaWatchdogs` runtime/cost/no_activity via the shipped `watchdogs.ts`). Queue store + host-health wiring pends B1/C1 execution. | in progress | PR pending |
+
 Safety gate: **A2 (on `main`) is the mechanical approval-type gate** every dangerous surface depends on. `machine_exec` (C3) + wallet signing handoff (E2) + host filesystem writes (C1/C2 daemon) stay blocked on **S3/S6/S4** until CONFIRMED. **Arturita never signs; no key custody; no real destructive machine op ships until S3.**
 
 ## Paperclip gap-bridge — 5 / 5 phases shipped

--- a/backend/src/services/arturita-resilience.ts
+++ b/backend/src/services/arturita-resilience.ts
@@ -1,0 +1,150 @@
+// Arturita F2 — degraded / offline modes + watchdog attach (pure).
+//
+// Keeps Arturita usable when the network, a cloud connector, or the local host
+// is unavailable (PRD §7.6): conversational replies keep working on the local
+// LLM/STT/TTS, while actions that need cloud connectors (Gmail, calendar, wallet
+// RPC) are QUEUED with a spoken "queued, will run when back online" and replayed
+// idempotently on reconnect. Host actions fail closed when the host is down.
+//
+// Pure decision helpers only — the executor/scheduler wire them to the queue
+// table + the existing watchdog sweep. Reuses `watchdogs.ts` (no new sweep).
+
+import { parseWatchdogSpec, type WatchdogSpec } from './watchdogs'
+
+// ─── Action connectivity requirements ────────────────────────────────────────
+
+/** What an action needs to run. `local` = the local LLM/STT/TTS can serve it
+ *  offline (conversation, read from memory). `cloud` = a cloud connector (Gmail,
+ *  calendar, RPC). `host` = the local machine host daemon. */
+export type ActionNeed = 'local' | 'cloud' | 'host'
+
+// Map action kinds to what they require. Unknown kinds default to 'cloud' (the
+// safe direction — queue rather than run blind).
+const ACTION_NEEDS: Record<string, ActionNeed> = {
+  answer: 'local',
+  chat: 'local',
+  summarize: 'local',
+  memory_read: 'local',
+  gmail_send: 'cloud',
+  gmail_read: 'cloud',
+  calendar_read: 'cloud',
+  wallet_read: 'cloud',
+  wallet_prepare: 'cloud',
+  file_op: 'host',
+  machine_exec: 'host',
+}
+
+export function actionNeed(kind: string | null | undefined): ActionNeed {
+  return ACTION_NEEDS[String(kind ?? '').trim()] ?? 'cloud'
+}
+
+// ─── Connectivity routing ────────────────────────────────────────────────────
+
+export interface Connectivity {
+  online: boolean   // backend ↔ internet / cloud connectors reachable
+  hostUp: boolean   // Arturita Local Host daemon reachable
+}
+
+export type Disposition = 'run' | 'queue' | 'refuse'
+
+export interface ConnectivityDecision {
+  disposition: Disposition
+  spoken: string    // what Arturita says aloud
+  reason: string
+}
+
+/**
+ * Decide how to handle an action given current connectivity:
+ *  - local action → always `run` (works offline).
+ *  - cloud action offline → `queue` (replays on reconnect); online → `run`.
+ *  - host action with host down → `refuse` (fail closed, spoken reason); host up
+ *    → `run`. (Cloud being down never blocks a host action, and vice-versa.)
+ * Pure.
+ */
+export function routeForConnectivity(input: {
+  actionKind: string
+  connectivity: Connectivity
+}): ConnectivityDecision {
+  const need = actionNeed(input.actionKind)
+  const { online, hostUp } = input.connectivity
+
+  if (need === 'local') {
+    return { disposition: 'run', spoken: '', reason: 'local action — runs offline' }
+  }
+  if (need === 'host') {
+    if (hostUp) return { disposition: 'run', spoken: '', reason: 'host up — runs' }
+    return {
+      disposition: 'refuse',
+      spoken: "I can't do that right now — the machine host is offline. Read-only cloud actions still work.",
+      reason: 'host down — file/machine actions fail closed',
+    }
+  }
+  // cloud
+  if (online) return { disposition: 'run', spoken: '', reason: 'online — runs' }
+  return {
+    disposition: 'queue',
+    spoken: "We're offline, so I've queued that — it'll run when we're back online.",
+    reason: 'offline — cloud action queued for replay',
+  }
+}
+
+// ─── Offline queue + idempotent replay ───────────────────────────────────────
+
+export interface QueuedAction {
+  nonce: string       // dedupe key — a replayed/duplicated action runs at most once
+  kind: string
+  payload?: unknown
+  queuedAt: number
+}
+
+/** Build a queue entry for a deferred action. The nonce guards exactly-once
+ *  replay (a captured/redelivered action can't double-run). */
+export function buildQueuedAction(input: { nonce: string; kind: string; payload?: unknown; now: number }): QueuedAction {
+  return { nonce: String(input.nonce), kind: input.kind, payload: input.payload, queuedAt: input.now }
+}
+
+export interface ReplayPlan {
+  toRun: QueuedAction[]
+  skippedDuplicate: QueuedAction[]
+}
+
+/**
+ * On reconnect, plan which queued actions to replay: run each once, in queue
+ * order, skipping any whose nonce is already applied (idempotent — exactly-once).
+ * Also de-dupes within the batch itself. Pure over a snapshot of applied nonces.
+ */
+export function planReplay(input: {
+  queued: QueuedAction[]
+  appliedNonces: Iterable<string>
+}): ReplayPlan {
+  const applied = new Set(input.appliedNonces)
+  const seen = new Set<string>()
+  const toRun: QueuedAction[] = []
+  const skippedDuplicate: QueuedAction[] = []
+  for (const a of input.queued) {
+    if (applied.has(a.nonce) || seen.has(a.nonce)) { skippedDuplicate.push(a); continue }
+    seen.add(a.nonce)
+    toRun.push(a)
+  }
+  return { toRun, skippedDuplicate }
+}
+
+// ─── Watchdog attach for long Arturita tasks ─────────────────────────────────
+
+/** Default watchdogs attached to a long/expensive Arturita task: runtime, cost,
+ *  and no-activity. Thresholds are conservative defaults the operator can tune.
+ *  Reuses `parseWatchdogSpec` so specs stay valid + consistent with W4. */
+export function defaultArturitaWatchdogs(opts: {
+  runtimeMin?: number
+  costUsd?: number
+  noActivityMin?: number
+} = {}): WatchdogSpec[] {
+  const runtimeMin = opts.runtimeMin ?? 15
+  const costUsd = opts.costUsd ?? 1
+  const noActivityMin = opts.noActivityMin ?? 10
+  return [
+    parseWatchdogSpec({ kind: 'runtime', threshold: String(runtimeMin) }),
+    parseWatchdogSpec({ kind: 'cost', threshold: String(costUsd) }),
+    parseWatchdogSpec({ kind: 'no_activity', threshold: String(noActivityMin) }),
+  ]
+}

--- a/backend/src/tests/arturita-resilience.test.ts
+++ b/backend/src/tests/arturita-resilience.test.ts
@@ -1,0 +1,81 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  actionNeed, routeForConnectivity, buildQueuedAction, planReplay,
+  defaultArturitaWatchdogs,
+} from '../services/arturita-resilience'
+
+// ─── Action needs ────────────────────────────────────────────────────────────
+
+test('[F2] actionNeed maps kinds; unknown defaults to cloud (safe direction)', () => {
+  assert.equal(actionNeed('answer'), 'local')
+  assert.equal(actionNeed('summarize'), 'local')
+  assert.equal(actionNeed('gmail_send'), 'cloud')
+  assert.equal(actionNeed('wallet_read'), 'cloud')
+  assert.equal(actionNeed('file_op'), 'host')
+  assert.equal(actionNeed('machine_exec'), 'host')
+  assert.equal(actionNeed('who_knows'), 'cloud') // safe default: queue rather than run blind
+})
+
+// ─── Connectivity routing ────────────────────────────────────────────────────
+
+test('[F2] local actions always run (offline conversational)', () => {
+  const d = routeForConnectivity({ actionKind: 'answer', connectivity: { online: false, hostUp: false } })
+  assert.equal(d.disposition, 'run')
+})
+
+test('[F2] cloud actions queue offline, run online', () => {
+  const offline = routeForConnectivity({ actionKind: 'gmail_send', connectivity: { online: false, hostUp: true } })
+  assert.equal(offline.disposition, 'queue')
+  assert.match(offline.spoken, /queued/i)
+
+  const online = routeForConnectivity({ actionKind: 'gmail_send', connectivity: { online: true, hostUp: true } })
+  assert.equal(online.disposition, 'run')
+})
+
+test('[F2] host actions fail closed when the host is down', () => {
+  const down = routeForConnectivity({ actionKind: 'file_op', connectivity: { online: true, hostUp: false } })
+  assert.equal(down.disposition, 'refuse')
+  assert.match(down.spoken, /host is offline/i)
+
+  const up = routeForConnectivity({ actionKind: 'file_op', connectivity: { online: true, hostUp: true } })
+  assert.equal(up.disposition, 'run')
+})
+
+// ─── Idempotent replay ───────────────────────────────────────────────────────
+
+test('[F2] planReplay runs each queued action once, skipping applied + dup nonces', () => {
+  const q = [
+    buildQueuedAction({ nonce: 'n1', kind: 'gmail_send', now: 1 }),
+    buildQueuedAction({ nonce: 'n2', kind: 'gmail_send', now: 2 }),
+    buildQueuedAction({ nonce: 'n1', kind: 'gmail_send', now: 3 }), // dup within batch
+    buildQueuedAction({ nonce: 'n3', kind: 'calendar_read', now: 4 }),
+  ]
+  const plan = planReplay({ queued: q, appliedNonces: ['n3'] }) // n3 already applied
+  assert.deepEqual(plan.toRun.map(a => a.nonce), ['n1', 'n2'])
+  assert.deepEqual(plan.skippedDuplicate.map(a => a.nonce).sort(), ['n1', 'n3'])
+})
+
+test('[F2] planReplay with nothing applied runs all unique in order', () => {
+  const q = [
+    buildQueuedAction({ nonce: 'a', kind: 'x', now: 1 }),
+    buildQueuedAction({ nonce: 'b', kind: 'y', now: 2 }),
+  ]
+  const plan = planReplay({ queued: q, appliedNonces: [] })
+  assert.equal(plan.toRun.length, 2)
+  assert.equal(plan.skippedDuplicate.length, 0)
+})
+
+// ─── Watchdog attach ─────────────────────────────────────────────────────────
+
+test('[F2] defaultArturitaWatchdogs builds valid runtime/cost/no_activity specs', () => {
+  const specs = defaultArturitaWatchdogs()
+  assert.deepEqual(specs.map(s => s.kind), ['runtime', 'cost', 'no_activity'])
+  // all thresholds positive + well-formed (parseWatchdogSpec would throw otherwise)
+  for (const s of specs) assert.ok(Number(s.threshold) > 0)
+
+  const custom = defaultArturitaWatchdogs({ runtimeMin: 30, costUsd: 2.5, noActivityMin: 5 })
+  assert.equal(custom[0].threshold, '30')
+  assert.equal(custom[1].threshold, '2.5')
+  assert.equal(custom[2].threshold, '5')
+})

--- a/docs/PLAN-arturita.md
+++ b/docs/PLAN-arturita.md
@@ -21,7 +21,7 @@ This table is the source of truth for per-story status. Update the **Status** + 
 | **A3** | Intent classifier + two-phase destructive confirm | `in-progress` | PR pending | — |
 | **B1** | Voice Gateway (STT/TTS) | `in-progress` (pure helpers done [#180]; provider layer + endpoint pending S1 keys) | [#180](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/180) | S1 |
 | **B2** | Cockpit voice panel | `todo` | — | S5 |
-| **B3** | Ask-vs-execute routing from voice | `in-progress` (pure routing done; endpoint wiring pends B1-full) | PR pending | — |
+| **B3** | Ask-vs-execute routing from voice | `in-progress` (pure routing done [#181]; endpoint wiring pends B1-full) | [#181](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/181) | — |
 | **C1** | Local Host daemon | `in-progress` (pure planner done [#179]; daemon blocked on **S3**) | [#179](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/179) | **S3** |
 | **C2** | File ops + preview + undo | `todo` | — | S3 |
 | **C3** | `machine_exec` allowlist + doc editing | `todo` | — | **S6** |
@@ -30,7 +30,7 @@ This table is the source of truth for per-story status. Update the **Status** + 
 | **E1** | Wallet read + prepare + simulate | `done` | [#178](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/178) | — |
 | **E2** | Wallet approval card + WalletConnect handoff | `todo` | — | **S4** |
 | **F1** | LLM fallback chain + circuit breaker | `done` | [#177](https://github.com/Arturito7ei/7Ei-Mission_Control_App/pull/177) (pure layer; executor wiring follow-up) | — |
-| **F2** | Degraded/offline + watchdogs | `todo` | — | — |
+| **F2** | Degraded/offline + watchdogs | `in-progress` (pure helpers; queue/host wiring pends B1/C1 execution) | PR pending | — |
 | **G1** | Self-description + CLI | `todo` | — | — |
 | **G2** | Go-live gates + runbook | `todo` | — | — |
 

--- a/docs/REQUIREMENTS-arturita.md
+++ b/docs/REQUIREMENTS-arturita.md
@@ -62,7 +62,7 @@
 |---|---|---|---|
 | FR-29 | Arturita swaps LLM providers per task and fails over across an ordered fallback chain on provider failure. | F1 | `[~]` (F1: `parseFallbackChain` + `planFallback` pure ordered-chain logic done; wiring into the live `agent-executor`/`streamLLM` retry loop is a follow-up — kept off the LLM hot path overnight) |
 | FR-30 | Failover handles 5xx/timeout/429/auth/context-overflow/refusal; a circuit breaker skips unhealthy providers. | F1 | `[~]` (F1: `classifyLlmError` covers all six classes + `recordFailure`/`isProviderHealthy` circuit breaker with cooldown/re-probe, all tested; live wiring is the follow-up) |
-| FR-31 | Offline/degraded: local LLM + local STT/TTS keep Arturita conversational; cloud-dependent actions queue and replay idempotently on reconnect. | F2 | `[ ]` |
+| FR-31 | Offline/degraded: local LLM + local STT/TTS keep Arturita conversational; cloud-dependent actions queue and replay idempotently on reconnect. | F2 | `[~]` (F2: `routeForConnectivity` (local run / cloud queue-offline / host fail-closed) + `planReplay` idempotent nonce-guarded exactly-once replay — pure logic done; queue store + host-health wiring pends B1/C1 execution) |
 | FR-32 | Provider/model health is visible on `/health` + the Cockpit. | F1 | `[ ]` |
 
 ### Session, auth & orchestration
@@ -104,7 +104,7 @@
 | NFR-13 | LLM failover completes the task on a fallback in ≥95% of primary-provider outages, within the per-wake cost cap. | F1 | `[ ]` |
 | NFR-14 | Failover retries are cost-bounded — cannot exceed the preflight per-wake cap; exhausted chain parks the task with a plain-language `system_notice`. | F1 | `[~]` (F1: `planFallback` drops hops over the per-wake cap (reuses `estimateWakeCost`) and emits a plain-language park reason when exhausted; posting the `system_notice` wires with the executor follow-up) |
 | NFR-15 | Desk voice → first action ≤ 3s p50; Telegram voice note → acknowledged ≤ 5s p50. | B1/B2/D1 | `[ ]` |
-| NFR-16 | Long/expensive Arturita runs carry watchdogs (runtime/cost/no_activity), edge-triggered (fire once on transition). | F2 | `[ ]` |
+| NFR-16 | Long/expensive Arturita runs carry watchdogs (runtime/cost/no_activity), edge-triggered (fire once on transition). | F2 | `[~]` (F2: `defaultArturitaWatchdogs` builds runtime/cost/no_activity specs via the shipped `watchdogs.ts` (edge-triggered W4 sweep unchanged); attaching them on task creation wires with the voice endpoint) |
 
 ### Privacy & observability
 | ID | Requirement | Story | Status |


### PR DESCRIPTION
## Epic F · Story F2 — degraded / offline modes + watchdogs (pure helpers)

Keeps Arturita usable when the network, a cloud connector, or the local host is unavailable (PRD §7.6). No dangerous surface; reuses `watchdogs.ts` (no new sweep).

### `services/arturita-resilience.ts` (pure, unit-tested)
- **`actionNeed()`** — `local` | `cloud` | `host` per action kind; unknown → `cloud` (safe direction: queue rather than run blind).
- **`routeForConnectivity()`** — local actions **always run** (offline conversational); cloud actions **queue** offline with a spoken *"queued, will run when back online"* and run when online; host actions **FAIL CLOSED** (refuse + spoken reason) when the daemon is down.
- **`buildQueuedAction` / `planReplay()`** — **idempotent, nonce-guarded exactly-once** replay on reconnect; skips already-applied + in-batch duplicate nonces.
- **`defaultArturitaWatchdogs()`** — runtime / cost / no_activity specs via the shipped `parseWatchdogSpec` (edge-triggered W4 sweep unchanged).

Queue store + host-health wiring pends the B1 voice endpoint + C1 daemon.

### Verification
**707 backend tests** (7 new) · **11/11 evals** · web build via CI · `npm audit` known non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)