### PR TITLE
docs: reconcile stale 588→707 backend test count

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,12 +1,12 @@
 # Mission Control — Session Handoff (for a fresh agent)
 
-_Last updated: 2026-07-07 — **all four Paperclip-gap-bridge v2 epics complete** (MCA-82 Theme, MCA-83 Work surface, MCA-84 Visibility, MCA-85 DX), plus unplanned security hardening. The app is at a clean checkpoint, prepped for a **major update** (plan placeholder at the foot of this doc). Paste the "Kickoff prompt" below into a new session; the rest is detail to verify._
+_Last updated: 2026-07-08 — **all four Paperclip-gap-bridge v2 epics complete** (MCA-82 Theme, MCA-83 Work surface, MCA-84 Visibility, MCA-85 DX), plus unplanned security hardening. The app is at a clean checkpoint, prepped for a **major update** (plan placeholder at the foot of this doc). Paste the "Kickoff prompt" below into a new session; the rest is detail to verify._
 
 ## Kickoff prompt
 
 You're taking over the **7Ei Mission Control App** — an AI-agent "virtual office" control plane (our flagship). Read `HANDOFF.md`, `STATUS.md`, `CLAUDE.md` (layered — subsystem guides load on demand), `GO-LIVE.md`, and `docs/DESIGN_SYSTEM.md` (v2 — binding design rules incl. the red-green colorblind constraint). Run the verification commands at the foot of this doc and flag any divergence.
 
-**Where things stand:** all four filed gap-bridge v2 epics are **shipped and merged to `main`** — MCA-82 Theme (T1/T2/T3 ✅), MCA-83 Work surface (W1–W5 ✅), MCA-84 Visibility (V1–V3 ✅), MCA-85 DX (D1/D2 ✅) — plus two unplanned security PRs (auth-scoping hardening #165, per-org webhook signing #166). Invariant is green: **588 backend tests · 11/11 evals · web build**. Backend healthy at v1.3.0.
+**Where things stand:** all four filed gap-bridge v2 epics are **shipped and merged to `main`** — MCA-82 Theme (T1/T2/T3 ✅), MCA-83 Work surface (W1–W5 ✅), MCA-84 Visibility (V1–V3 ✅), MCA-85 DX (D1/D2 ✅) — plus two unplanned security PRs (auth-scoping hardening #165, per-org webhook signing #166). Invariant is green: **707 backend tests · 11/11 evals · web build green**. Backend healthy at v1.3.0.
 
 **This is a checkpoint before a major update.** No feature epic is currently in flight. Read the **State of the app** section below to orient, then the **Incoming major update** placeholder for the plan the operator will drop in. Do **not** start new feature work off the old open-candidates list (R4 vault RAG / R6 Sync-Registry / MCA-81 follow-ups / `app/` archive) unless the operator directs it — the major-update plan supersedes it.
 
@@ -21,7 +21,7 @@ Monorepo (npm workspaces), all merged to `main`, auto-deploys on merge.
 
 | Workspace | Stack | Deploy | Notes |
 |---|---|---|---|
-| **backend/** | Node 22 · TypeScript · Fastify · Drizzle · Turso/libSQL | Fly `7ei-backend` (fra) | 44 services, ~158 API paths / 26 tag groups, 588 tests. Live: https://7ei-backend.fly.dev |
+| **backend/** | Node 22 · TypeScript · Fastify · Drizzle · Turso/libSQL | Fly `7ei-backend` (fra) | 44 services, ~158 API paths / 26 tag groups, 707 tests. Live: https://7ei-backend.fly.dev |
 | **web/** | Next.js 15 App Router · Clerk (dev instance) | Vercel `app.7ei.ai` | **PRIMARY UI.** Dashboard = `web/app/dashboard/` + 15 `cockpit/` section components |
 | **adapters/** | Python OpenClaw runtime, mac-mini installer, presets | self-hosted | External BYO-agent execution. **Live adapter is off-limits without asking.** |
 | **cli/** | `7ei-mc` zero-dep Node CLI over the agent API | npm `@7ei/mc` | `openapi`, `onboard`, task/agent verbs |
@@ -99,7 +99,7 @@ Canonical Obsidian vault: `/Users/artutito/7Ei-MC_TARCO` (repo `Arturito7ei/7Ei-
 ```bash
 cd /Users/artutito/Developer/7Ei-Mission_Control_App
 git log --oneline -15
-cd backend && npm test && npm run evals   # expect 588 tests + 11/11
+cd backend && npm test && npm run evals   # expect 707 tests + 11/11
 cd ../web && npm run build
 curl -s https://7ei-backend.fly.dev/api/health   # expect 200, db: connected, scheduler: running
 ```

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,7 +3,7 @@
 _Last updated: 2026-07-07 (W5 wrap-up — all four Paperclip-gap-bridge v2 epics complete) · auto-maintained by the build agent (bumped at each story/phase)._
 
 **Live:** backend on Fly (`7ei-backend`, v1.3.0), web on Vercel (`app.7ei.ai`), Turso DB. All PRs merged to `main`.
-Health `GET /api/health` → 200, `db: connected`, `scheduler: running`. Invariant green: **588 backend tests · 11/11 evals · web build**.
+Health `GET /api/health` → 200, `db: connected`, `scheduler: running`. Invariant green: **707 backend tests · 11/11 evals · web build green**.
 Full write-up in the shared vault: `07-Agents/STATUS-Mission-Control-2026-07-02.md` · plan: `01-Projects/Paperclip-Gap-Analysis-v2-2026-07-06.md`.
 
 ## Paperclip gap-bridge v2 — 4 / 4 epics complete


### PR DESCRIPTION
Housekeeping (operator-approved, docs-only). The overnight build (2026-07-08) took the invariant to **707 backend tests · 11/11 evals · web build green**, and the reconciled body of HANDOFF.md already reflects that — but four current-state spots still cited the old **588**:

- HANDOFF.md header invariant ("Where things stand")
- HANDOFF.md architecture table (backend row)
- HANDOFF.md foot "Verify before trusting the above" block
- STATUS.md current-state invariant line

All four updated to 707. HANDOFF "Last updated" bumped to 2026-07-08. Historical changelog entries in STATUS.md (past 588/482 test counts for shipped stories) intentionally left untouched — they record what was true at ship time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)