### PR TITLE
feat(Epic B2): Cockpit voice panel — push-to-talk + wake-word, STT→task flow, TTS reply

### DIFF
--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -10,6 +10,7 @@ import { Button, Card, SectionLabel, Skeleton } from './ui'
 import { sx, type Approval, type ApprovalDecision, type Budget, type Cockpit, type Getter, type GoalNode, type InboxItem, type OrgNode, type Plugin, type Preflight, type Secret, type Timeline, type Workspace } from './cockpit/shared'
 import StatsRow from './cockpit/StatsRow'
 import InboxSection from './cockpit/InboxSection'
+import VoiceSection from './cockpit/VoiceSection'
 import AgentFleet from './cockpit/AgentFleet'
 import TimelineSection from './cockpit/TimelineSection'
 import OrgChart from './cockpit/OrgChart'
@@ -153,6 +154,7 @@ export default function CockpitPanel({ orgId, getToken, onOpenTask }: { orgId: s
       ) : (
         <>
           <InboxSection inbox={inbox} approvals={approvals} onDismiss={dismiss} onDecide={decide} onRetry={retry} />
+          <VoiceSection orgId={orgId} getToken={getToken} approvals={approvals} onDecide={decide} />
           <AgentFleet agents={data ? data.agents : null} onControl={agentControl} onAsk={askAgent} />
           <TimelineSection timeline={timeline} />
           <OrgChart chart={chart} />

--- a/web/app/dashboard/cockpit/VoiceSection.tsx
+++ b/web/app/dashboard/cockpit/VoiceSection.tsx
@@ -1,0 +1,300 @@
+'use client'
+// Arturita B2 — Cockpit voice panel. Push-to-talk (default) or "Arturita"
+// wake-word (opt-in, S5). Captures speech in-browser (Web Speech API), routes
+// the transcript through the existing /arturita/voice flow (ask vs execute —
+// B3), and voices the reply back via the configured mode (provider TTS bytes,
+// else local browser SpeechSynthesis — B1 local|provider). Approval-aware: a
+// destructive command is flagged as pausing at the A2 gate, and any live
+// approvals render inline with the tri-state controls (approve / request
+// changes / reject). Colorblind-safe: every state carries an icon + text +
+// shape; red is never the lone CTA (DESIGN_SYSTEM v2).
+//
+// Decision logic is pure + unit-tested in ./voicePanel.logic (this file is the
+// impure shell: capture, network, playback).
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { api } from '@/lib/api'
+import { tk, text, space } from '../tokens'
+import { Button, Card, SectionLabel, TextInput, Select } from '../ui'
+import { EXT_PURPLE, sx, type Approval, type ApprovalDecision, type Getter } from './shared'
+import {
+  decideSubmit, pickPlayback, toFeedItem, WAKE_WORD,
+  type FeedItem, type VoiceMode, type VoiceResponse,
+} from './voicePanel.logic'
+
+type Props = {
+  orgId: string
+  getToken: Getter
+  /** live pending approvals (same source InboxSection uses) — rendered inline */
+  approvals?: Approval[]
+  onDecide?: (id: string, decision: ApprovalDecision, note?: string) => void
+}
+
+export default function VoiceSection({ orgId, getToken, approvals = [], onDecide }: Props) {
+  const [supported, setSupported] = useState(false)
+  const [listening, setListening] = useState(false)
+  const [interim, setInterim] = useState('')
+  const [mode, setMode] = useState<VoiceMode>('local')
+  const [wakeWord, setWakeWord] = useState(false)
+  const [feed, setFeed] = useState<FeedItem[]>([])
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [typed, setTyped] = useState('')
+  const [revising, setRevising] = useState<string | null>(null)
+  const [note, setNote] = useState('')
+
+  const recogRef = useRef<any>(null)
+  const seqRef = useRef(0)
+  const threadRef = useRef<string | null>(null)
+  const wakeRef = useRef(wakeWord)
+  const modeRef = useRef(mode)
+  useEffect(() => { wakeRef.current = wakeWord }, [wakeWord])
+  useEffect(() => { modeRef.current = mode }, [mode])
+
+  // ── Send a command (from speech or the typed fallback) ─────────────────────
+  const send = useCallback(async (command: string, confidence: number | null) => {
+    setBusy(true); setErr(null)
+    try {
+      const resp = await api<VoiceResponse>(`/api/orgs/${orgId}/arturita/voice`, {
+        token: await getToken(),
+        method: 'POST',
+        body: JSON.stringify({
+          transcript: command,
+          confidence,
+          mode: modeRef.current,
+          speak: true,
+          existingThreadId: threadRef.current,
+        }),
+      })
+      const item = toFeedItem({ command, resp, seq: ++seqRef.current })
+      if (item.taskId) threadRef.current = item.taskId
+      setFeed(f => [item, ...f].slice(0, 12))
+      playReply(resp)
+    } catch (e: any) {
+      setErr(e?.message ?? 'Voice command failed')
+    } finally {
+      setBusy(false)
+    }
+  }, [orgId, getToken])
+
+  // ── Speech capture (Web Speech API) ────────────────────────────────────────
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const SR = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    if (!SR) { setSupported(false); return }
+    setSupported(true)
+    const r = new SR()
+    r.continuous = true
+    r.interimResults = true
+    r.lang = 'en-US'
+    r.onresult = (ev: any) => {
+      let live = ''
+      for (let i = ev.resultIndex; i < ev.results.length; i++) {
+        const res = ev.results[i]
+        const alt = res[0]
+        if (res.isFinal) {
+          const decision = decideSubmit({ transcript: alt.transcript, wakeWordMode: wakeRef.current })
+          if (decision.submit) send(decision.cleaned, typeof alt.confidence === 'number' ? alt.confidence : null)
+        } else {
+          live += alt.transcript
+        }
+      }
+      setInterim(live)
+    }
+    r.onerror = (ev: any) => {
+      if (ev?.error === 'not-allowed' || ev?.error === 'service-not-allowed') {
+        setErr('Microphone permission denied — allow mic access or type a command below.')
+      } else if (ev?.error && ev.error !== 'no-speech' && ev.error !== 'aborted') {
+        setErr(`Speech error: ${ev.error}`)
+      }
+    }
+    r.onend = () => {
+      // Keep listening across natural pauses while the toggle is on.
+      if (recogRef.current?.__active) { try { r.start() } catch { /* already starting */ } }
+      else setListening(false)
+    }
+    recogRef.current = r
+    return () => { try { r.__active = false; r.stop() } catch { /* noop */ } ; recogRef.current = null }
+  }, [send])
+
+  const toggleListen = () => {
+    const r = recogRef.current
+    if (!r) return
+    setErr(null)
+    if (listening) {
+      r.__active = false
+      try { r.stop() } catch { /* noop */ }
+      setListening(false); setInterim('')
+    } else {
+      r.__active = true
+      try { r.start(); setListening(true) } catch { /* start after prior stop settles */ }
+    }
+  }
+
+  const playReply = (resp: VoiceResponse) => {
+    const pb = pickPlayback(resp.reply)
+    if (pb.kind === 'audio' && pb.audioSrc) {
+      try { void new Audio(pb.audioSrc).play() } catch { /* autoplay may be blocked; text still shown */ }
+    } else if (pb.kind === 'speech' && pb.text && typeof window !== 'undefined' && 'speechSynthesis' in window) {
+      try {
+        const u = new SpeechSynthesisUtterance(pb.text)
+        u.lang = 'en-US'
+        window.speechSynthesis.cancel()
+        window.speechSynthesis.speak(u)
+      } catch { /* TTS unavailable; text still shown */ }
+    }
+  }
+
+  const submitTyped = () => {
+    const t = typed.trim()
+    if (!t || busy) return
+    // The typed box is an explicit command, so wake-word gating does not apply.
+    setTyped('')
+    send(t, 1)
+  }
+
+  const sendRevision = (id: string) => {
+    const n = note.trim()
+    if (!n || !onDecide) return
+    onDecide(id, 'revision_requested', n)
+    setRevising(null); setNote('')
+  }
+
+  return (
+    <div>
+      <div style={sx.sectionHead}>
+        <SectionLabel style={{ margin: 0 }}>🎙 Arturita voice</SectionLabel>
+        {listening
+          ? <span style={{ ...sx.tag, background: 'var(--accent-dim)', color: EXT_PURPLE }} role="status">● Listening…</span>
+          : <span style={{ ...sx.tag, background: 'var(--s2)', color: tk.muted }}>○ Idle</span>}
+      </div>
+
+      <Card style={{ display: 'flex', flexDirection: 'column', gap: space.md }}>
+        {/* Controls row */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: space.md, flexWrap: 'wrap' }}>
+          <Button
+            variant={listening ? 'default' : 'primary'}
+            disabled={!supported}
+            aria-pressed={listening}
+            onClick={toggleListen}
+            style={listening ? { borderColor: 'var(--accent-line)', color: tk.accent } : undefined}
+          >
+            {listening ? '■ Stop' : '🎙 Push to talk'}
+          </Button>
+
+          <label style={s.toggle}>
+            <input type="checkbox" checked={wakeWord} onChange={e => setWakeWord(e.target.checked)} />
+            <span>Wake word <b>“{WAKE_WORD}”</b></span>
+          </label>
+
+          <div style={{ flex: 1 }} />
+
+          <label style={{ ...s.toggle, gap: space.sm }}>
+            <span style={{ color: tk.muted, fontSize: text.xs.fontSize }}>Voice</span>
+            <Select value={mode} onChange={e => setMode(e.target.value as VoiceMode)} aria-label="Voice privacy mode" style={{ width: 130 }}>
+              <option value="local">🔒 Local</option>
+              <option value="provider">☁ Provider</option>
+            </Select>
+          </label>
+        </div>
+
+        {/* Live transcript (aria-live so it's announced) */}
+        <div aria-live="polite" style={s.transcript}>
+          {interim
+            ? <span style={{ color: tk.text }}>{interim}<span style={{ color: tk.muted }}> …</span></span>
+            : <span style={{ color: tk.muted }}>
+                {supported
+                  ? (wakeWord ? `Listening for “${WAKE_WORD}, …”` : 'Tap “Push to talk”, then speak your command.')
+                  : 'Speech capture isn’t available in this browser — type a command below.'}
+              </span>}
+        </div>
+
+        {/* Typed fallback — always available (no-mic browsers, quiet rooms, a11y) */}
+        <div style={{ display: 'flex', gap: space.sm }}>
+          <TextInput
+            value={typed}
+            onChange={e => setTyped(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') submitTyped() }}
+            placeholder="…or type a command for Arturita"
+            aria-label="Type a command for Arturita"
+            style={{ flex: 1 }}
+          />
+          <Button variant="primary" disabled={busy || !typed.trim()} onClick={submitTyped}>{busy ? '…' : 'Send'}</Button>
+        </div>
+
+        {err && <div style={sx.err}>⚠ {err}</div>}
+        <p style={sx.hint}>
+          {mode === 'local'
+            ? '🔒 Local mode keeps audio off third-party servers. Sensitive (wallet/secret) commands are always forced local.'
+            : '☁ Provider mode uses the configured cloud voice (Chatterbox/NVIDIA) for spoken replies; it falls back to local text if unavailable.'}
+        </p>
+
+        {/* Inline approvals — tri-state, approval-aware (A2 gate) */}
+        {approvals.length > 0 && onDecide && (
+          <div style={{ borderTop: `1px solid ${tk.line}`, paddingTop: space.md, display: 'flex', flexDirection: 'column', gap: space.xs }}>
+            <span style={{ fontSize: text.xs.fontSize, color: tk.muted, fontWeight: 600 }}>⛔ Awaiting your approval</span>
+            {approvals.map(a => (
+              <div key={a.id}>
+                <div style={sx.row}>
+                  <span style={{ ...sx.tag, background: 'var(--accent-dim)', color: EXT_PURPLE }}>Approval · {a.type}</span>
+                  <div style={{ flex: 1, minWidth: 0, fontWeight: 600 }}>{a.summary}</div>
+                  <Button style={{ color: tk.accent }} onClick={() => onDecide(a.id, 'approved')}>✓ Approve</Button>
+                  <Button style={{ color: tk.accent }} onClick={() => { setRevising(r => r === a.id ? null : a.id); setNote('') }}>↩ Request changes</Button>
+                  <Button style={{ color: tk.red }} onClick={() => onDecide(a.id, 'rejected')}>✕ Reject</Button>
+                </div>
+                {revising === a.id && (
+                  <div style={{ ...sx.row, gap: space.md }}>
+                    <TextInput autoFocus value={note} onChange={e => setNote(e.target.value)}
+                      onKeyDown={e => { if (e.key === 'Enter') sendRevision(a.id); if (e.key === 'Escape') { setRevising(null); setNote('') } }}
+                      placeholder="What needs to change?" style={{ flex: 1 }} />
+                    <Button variant="primary" disabled={!note.trim()} onClick={() => sendRevision(a.id)}>Send</Button>
+                    <Button style={{ color: tk.muted }} onClick={() => { setRevising(null); setNote('') }}>Cancel</Button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Action feed — what was heard, how it routed */}
+        {feed.length > 0 && (
+          <div style={{ borderTop: `1px solid ${tk.line}`, paddingTop: space.md, display: 'flex', flexDirection: 'column' }}>
+            {feed.map(f => <FeedRow key={f.seq} item={f} />)}
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}
+
+function FeedRow({ item }: { item: FeedItem }) {
+  const badge = item.workMode === 'reprompt'
+    ? { icon: '↺', label: 'Repeat', bg: 'var(--warn-bg)', fg: tk.amber }
+    : item.workMode === 'ask'
+      ? { icon: 'ℹ', label: 'Ask', bg: 'var(--info-bg)', fg: tk.blue }
+      : { icon: '▸', label: 'Execute', bg: 'var(--accent-dim)', fg: EXT_PURPLE }
+  return (
+    <div style={{ ...sx.row, alignItems: 'flex-start' }}>
+      <span style={{ ...sx.tag, background: badge.bg, color: badge.fg, marginTop: 2 }} title={badge.label} aria-label={badge.label}>
+        {badge.icon} {badge.label}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: 600 }}>
+          {item.isFollowUp && <span title="continues the same thread" style={{ color: tk.muted }}>↳ </span>}
+          {item.command || <span style={{ color: tk.muted }}>(reprompt)</span>}
+        </div>
+        <div style={{ fontSize: text.xs.fontSize, color: tk.muted, marginTop: 1 }}>{item.ack}</div>
+      </div>
+      {item.needsApproval && (
+        <span style={{ ...sx.tag, background: 'var(--danger-bg)', color: 'var(--danger-text)', marginTop: 2 }}
+          title="pauses at the approval gate before anything irreversible">
+          ⛔ Needs approval
+        </span>
+      )}
+    </div>
+  )
+}
+
+const s: Record<string, React.CSSProperties> = {
+  toggle: { display: 'flex', alignItems: 'center', gap: space.xs, fontSize: text.sm.fontSize, color: tk.textDim, cursor: 'pointer', userSelect: 'none' },
+  transcript: { minHeight: 40, padding: `${space.sm}px ${space.md}px`, borderRadius: tk.r.md, background: 'var(--s2)', border: `1px solid ${tk.line}`, fontSize: text.sm.fontSize, lineHeight: 1.5 },
+}

--- a/web/app/dashboard/cockpit/voicePanel.logic.test.ts
+++ b/web/app/dashboard/cockpit/voicePanel.logic.test.ts
@@ -1,0 +1,114 @@
+// Arturita B2 — pure voice-panel logic tests. Run with the Node 22 built-in
+// runner + type-stripping (see web/package.json `test`), no test-runner dep.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  normalizeTranscript, hasWakeWord, stripWakeWord, decideSubmit,
+  pickPlayback, toFeedItem, type VoiceResponse,
+} from './voicePanel.logic.ts'
+
+test('[B2] normalizeTranscript collapses whitespace and trims', () => {
+  assert.equal(normalizeTranscript('  hello   world \n'), 'hello world')
+  assert.equal(normalizeTranscript(null), '')
+})
+
+test('[B2] hasWakeWord matches case- and punctuation-insensitively', () => {
+  assert.equal(hasWakeWord('Arturita, deploy the build'), true)
+  assert.equal(hasWakeWord('ARTURITA what time is it'), true)
+  assert.equal(hasWakeWord('deploy the build'), false)
+  // substring must not falsely match (word-boundary)
+  assert.equal(hasWakeWord('arturitas are cool'), false)
+})
+
+test('[B2] stripWakeWord removes the wake word, leaves the command', () => {
+  assert.equal(stripWakeWord('Arturita, deploy the build'), 'deploy the build')
+  assert.equal(stripWakeWord('hey Arturita what is on my calendar'), 'hey what is on my calendar')
+  assert.equal(stripWakeWord('Arturita'), '')
+})
+
+test('[B2] decideSubmit — push-to-talk submits any non-empty transcript verbatim', () => {
+  const d = decideSubmit({ transcript: 'ship the release', wakeWordMode: false })
+  assert.equal(d.submit, true)
+  assert.equal(d.cleaned, 'ship the release')
+})
+
+test('[B2] decideSubmit — empty transcript never submits', () => {
+  assert.equal(decideSubmit({ transcript: '   ', wakeWordMode: false }).submit, false)
+  assert.equal(decideSubmit({ transcript: '', wakeWordMode: true }).submit, false)
+})
+
+test('[B2] decideSubmit — wake-word mode ignores utterances without the wake word', () => {
+  const d = decideSubmit({ transcript: 'deploy the build', wakeWordMode: true })
+  assert.equal(d.submit, false)
+  assert.match(d.reason, /no "Arturita"/)
+})
+
+test('[B2] decideSubmit — wake-word mode strips the wake word before submitting', () => {
+  const d = decideSubmit({ transcript: 'Arturita deploy the build', wakeWordMode: true })
+  assert.equal(d.submit, true)
+  assert.equal(d.cleaned, 'deploy the build')
+})
+
+test('[B2] decideSubmit — wake word only (no command) does not submit', () => {
+  assert.equal(decideSubmit({ transcript: 'Arturita', wakeWordMode: true }).submit, false)
+})
+
+test('[B2] pickPlayback — provider audio → play the returned bytes', () => {
+  const p = pickPlayback({ text: 'On it.', provider: 'chatterbox_nvidia', mime: 'audio/wav', audioBase64: 'QUJD' })
+  assert.equal(p.kind, 'audio')
+  assert.equal(p.audioSrc, 'data:audio/wav;base64,QUJD')
+})
+
+test('[B2] pickPlayback — no audio but text → speak locally (browser TTS)', () => {
+  const p = pickPlayback({ text: 'Let me check that for you.', provider: 'text_only' })
+  assert.equal(p.kind, 'speech')
+  assert.equal(p.text, 'Let me check that for you.')
+})
+
+test('[B2] pickPlayback — empty reply → nothing to say', () => {
+  assert.equal(pickPlayback({ text: '', provider: 'text_only' }).kind, 'none')
+  assert.equal(pickPlayback(null).kind, 'none')
+})
+
+test('[B2] toFeedItem — ask command routes without approval', () => {
+  const resp: VoiceResponse = {
+    disposition: 'accept', taskId: 't1',
+    route: { workMode: 'ask', reason: 'question', destructive: false, isFollowUp: false },
+    reply: { text: 'Let me check that for you.', provider: 'text_only' },
+  }
+  const f = toFeedItem({ command: "what's on my calendar", resp, seq: 1 })
+  assert.equal(f.workMode, 'ask')
+  assert.equal(f.needsApproval, false)
+  assert.equal(f.taskId, 't1')
+})
+
+test('[B2] toFeedItem — destructive execute command needs approval', () => {
+  const resp: VoiceResponse = {
+    disposition: 'accept', taskId: 't2',
+    route: { workMode: 'execute', reason: 'work order', destructive: true, isFollowUp: false },
+    reply: { text: "Got it — I'll prepare that and stop for your approval.", provider: 'text_only' },
+  }
+  const f = toFeedItem({ command: 'delete the old branch', resp, seq: 2 })
+  assert.equal(f.workMode, 'execute')
+  assert.equal(f.needsApproval, true)
+})
+
+test('[B2] toFeedItem — non-destructive execute does not need approval', () => {
+  const resp: VoiceResponse = {
+    disposition: 'accept', taskId: 't3',
+    route: { workMode: 'execute', reason: 'work order', destructive: false, isFollowUp: false },
+    reply: { text: 'On it.', provider: 'text_only' },
+  }
+  assert.equal(toFeedItem({ command: 'summarize the inbox', resp, seq: 3 }).needsApproval, false)
+})
+
+test('[B2] toFeedItem — low-confidence re-prompt surfaces as a reprompt row', () => {
+  const resp: VoiceResponse = {
+    disposition: 'reprompt', reprompt: true,
+    reply: { text: "I didn't quite catch that — could you repeat it?", provider: 'text_only' },
+  }
+  const f = toFeedItem({ command: 'mumble', resp, seq: 4 })
+  assert.equal(f.workMode, 'reprompt')
+  assert.equal(f.needsApproval, false)
+  assert.equal(f.taskId, null)
+})

--- a/web/app/dashboard/cockpit/voicePanel.logic.ts
+++ b/web/app/dashboard/cockpit/voicePanel.logic.ts
@@ -1,0 +1,143 @@
+// Arturita B2 — Cockpit voice panel PURE LOGIC (no DOM / React / network).
+//
+// The browser-facing panel (VoiceSection.tsx) does the impure work: Web Speech
+// API capture, POST /arturita/voice, and TTS playback. Every DECISION it makes
+// is a pure function here so it can be unit-tested with `node --test` (Node 22
+// type-stripping — no test-runner dependency). Mirrors the backend helpers in
+// `backend/src/services/voice.ts` (wake word, transcript normalization) so the
+// client gate matches the server gate.
+
+export const WAKE_WORD = 'arturita'
+
+/** Collapse whitespace + trim (mirror of backend normalizeTranscript). */
+export function normalizeTranscript(raw: string | null | undefined): string {
+  return String(raw ?? '').replace(/\s+/g, ' ').trim()
+}
+
+/** True when the transcript contains the wake word (case/punctuation-insensitive). */
+export function hasWakeWord(transcript: string | null | undefined, wake: string = WAKE_WORD): boolean {
+  const t = normalizeTranscript(transcript).toLowerCase().replace(/[^a-z0-9 ]/g, '')
+  return t.split(' ').includes(wake.toLowerCase())
+}
+
+/** Remove a leading/anywhere wake word so the command is what's left. */
+export function stripWakeWord(transcript: string | null | undefined, wake: string = WAKE_WORD): string {
+  const re = new RegExp(`\\b${wake}\\b[,\\.!\\s]*`, 'ig')
+  return normalizeTranscript(String(transcript ?? '').replace(re, ' '))
+}
+
+export interface SubmitDecision {
+  submit: boolean
+  cleaned: string
+  reason: string
+}
+
+/**
+ * Decide whether a captured utterance should be sent to the backend.
+ * - Push-to-talk (default): submit any non-empty final transcript verbatim.
+ * - Wake-word mode (opt-in, S5): only submit utterances containing "Arturita",
+ *   and strip the wake word so the command is what's routed.
+ */
+export function decideSubmit(input: { transcript: string | null | undefined; wakeWordMode: boolean }): SubmitDecision {
+  const norm = normalizeTranscript(input.transcript)
+  if (!norm) return { submit: false, cleaned: '', reason: 'empty transcript' }
+  if (!input.wakeWordMode) return { submit: true, cleaned: norm, reason: 'push-to-talk — submit verbatim' }
+  if (!hasWakeWord(norm)) return { submit: false, cleaned: norm, reason: 'wake-word mode — no "Arturita", ignored' }
+  const cleaned = stripWakeWord(norm)
+  if (!cleaned) return { submit: false, cleaned: '', reason: 'wake word only — no command' }
+  return { submit: true, cleaned, reason: 'wake-word mode — command after wake word' }
+}
+
+// ─── Shape of the /voice response (subset the panel consumes) ────────────────
+
+export type VoiceMode = 'local' | 'provider'
+
+export interface VoiceReply {
+  text: string
+  provider: string
+  mime?: string | null
+  audioBase64?: string | null
+  degraded?: boolean
+}
+
+export interface VoiceResponse {
+  disposition?: 'accept' | 'reprompt' | 'empty'
+  reprompt?: boolean
+  taskId?: string
+  route?: { workMode: 'ask' | 'execute'; reason: string; destructive: boolean; isFollowUp: boolean }
+  reply?: VoiceReply
+  voiceMode?: { mode: VoiceMode; forcedLocal: boolean; reason: string }
+}
+
+// ─── Reply playback source ───────────────────────────────────────────────────
+
+export type PlaybackKind = 'audio' | 'speech' | 'none'
+
+export interface Playback {
+  kind: PlaybackKind
+  text: string
+  /** a `data:` URL ready for `new Audio(src)` when kind==='audio' */
+  audioSrc?: string
+}
+
+/**
+ * Pick how to voice the reply back:
+ * - provider TTS returned audio bytes → play that audio ('audio');
+ * - otherwise speak the text locally via the browser SpeechSynthesis ('speech')
+ *   — this IS the `local` provider on the client;
+ * - no text at all → nothing to say ('none').
+ * Never throws; the panel always has a reply to show even when silent.
+ */
+export function pickPlayback(reply: VoiceReply | null | undefined): Playback {
+  const text = normalizeTranscript(reply?.text)
+  const b64 = reply?.audioBase64
+  if (b64) {
+    const mime = reply?.mime || 'audio/mpeg'
+    return { kind: 'audio', text, audioSrc: `data:${mime};base64,${b64}` }
+  }
+  if (text) return { kind: 'speech', text }
+  return { kind: 'none', text: '' }
+}
+
+// ─── Action-feed item ────────────────────────────────────────────────────────
+
+export interface FeedItem {
+  taskId: string | null
+  /** what the operator said (post wake-word strip) */
+  command: string
+  workMode: 'ask' | 'execute' | 'reprompt'
+  /** execute + destructive → the run will pause at the A2 approval gate */
+  needsApproval: boolean
+  isFollowUp: boolean
+  /** the spoken acknowledgement text */
+  ack: string
+  /** monotonic sequence for stable keys/ordering (caller-supplied) */
+  seq: number
+}
+
+/**
+ * Fold a /voice response + the command that produced it into a feed row.
+ * A low-confidence re-prompt is surfaced as its own row (workMode 'reprompt')
+ * so the operator sees that Arturita asked them to repeat rather than acted.
+ */
+export function toFeedItem(input: { command: string; resp: VoiceResponse; seq: number }): FeedItem {
+  const { command, resp, seq } = input
+  if (resp.reprompt || resp.disposition !== 'accept') {
+    return {
+      taskId: null, command: normalizeTranscript(command), workMode: 'reprompt',
+      needsApproval: false, isFollowUp: false,
+      ack: resp.reply?.text ?? "I didn't quite catch that — could you repeat it?", seq,
+    }
+  }
+  const r = resp.route
+  const workMode = r?.workMode ?? 'ask'
+  return {
+    taskId: resp.taskId ?? null,
+    command: normalizeTranscript(command),
+    workMode,
+    needsApproval: workMode === 'execute' && !!r?.destructive,
+    isFollowUp: !!r?.isFollowUp,
+    ack: resp.reply?.text ?? 'On it.',
+    seq,
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "test": "node --test --experimental-strip-types \"app/**/*.test.ts\"",
     "build:vault-graph": "node scripts/build-vault-graph-preview.mjs"
   },
   "dependencies": {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -36,6 +36,7 @@
   ],
   "exclude": [
     "node_modules",
-    ".next"
+    ".next",
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
## What

Ships **B2 — the Cockpit voice panel** (`docs/PLAN-arturita.md` Epic B), the operator-facing voice surface for Arturita. Renders in the Cockpit directly under the Inbox.

## Behavior

- **Push-to-talk by default; "Arturita" wake-word opt-in** (S5). Capture uses the browser Web Speech API. A **typed-command fallback** is always present (no-mic browsers, quiet rooms, accessibility).
- **Routes into the existing flow**: the recognized command is POSTed to `POST /api/orgs/:orgId/arturita/voice` (the B1 endpoint + B3 ask-vs-execute routing), which creates the task. An **action feed** shows what was heard and how it routed (Ask / Execute / Repeat), including follow-up threading.
- **Spoken reply via the configured mode (B1 `local|provider`)**: provider TTS bytes play directly; otherwise the browser `SpeechSynthesis` voices the text locally. A `local|provider` selector is exposed; sensitive contexts remain forced-local server-side.
- **Approval-aware**: destructive execute commands are flagged **⛔ Needs approval** (they pause at the A2 gate), and any live approvals render **inline with the tri-state controls** (✓ approve / ↩ request changes / ✕ reject), reusing the InboxSection pattern.
- **Colorblind-safe** (DESIGN_SYSTEM v2): every state carries icon + text + shape; red is never the lone CTA. Design tokens only (no raw hex).

## Tests

Decision logic is pure and unit-tested in `voicePanel.logic.ts` (wake-word gate, submit decision, reply-playback source, response→feed mapping) — **15 tests** via the Node 22 built-in runner + type-stripping. New `npm test` in `web/` with **zero new dependencies**; test files excluded from the Next/tsc build.

## Not in scope (go-live)

Server-side **live raw-audio STT engine** — capture is client-side here, matching the B1 transcript-in contract. That remains the documented go-live item.

## Verify

- `cd web && npm run typecheck` ✅
- `cd web && npm run build` ✅
- `cd web && npm test` ✅ 15/15

> In-app live drive (mic + spoken reply) needs an authenticated Clerk session and is exercised by the operator; logic paths are covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)