### PR TITLE
feat(Epic J2): Config panel — free-first pipeline chain editor

### DIFF
--- a/web/app/dashboard/AssistantPanel.tsx
+++ b/web/app/dashboard/AssistantPanel.tsx
@@ -18,6 +18,7 @@ import { api } from '@/lib/api'
 import { tk, text, space, ui } from './tokens'
 import { Button, Card, TextInput } from './ui'
 import AssistantOrb from './AssistantOrb'
+import AssistantPipelineConfig from './AssistantPipelineConfig'
 import {
   resolveVoiceState, toConverseRequest, toArturitaMessage,
   revealStepFor, routingBadge, type Message, type ConverseResponse,
@@ -243,6 +244,9 @@ export default function AssistantPanel({ orgId, getToken }: { orgId: string; get
           <span>▸ Delegate this to the office <span style={{ color: tk.muted }}>(instead of a direct answer)</span></span>
         </label>
       </Card>
+
+      {/* ── Free-first pipeline config (LLM/STT/TTS chains, switchable) ─────── */}
+      <AssistantPipelineConfig orgId={orgId} getToken={getToken} />
     </div>
   )
 }

--- a/web/app/dashboard/AssistantPipelineConfig.tsx
+++ b/web/app/dashboard/AssistantPipelineConfig.tsx
@@ -1,0 +1,138 @@
+'use client'
+// Arturita J2 — the Config panel for the free-first pipeline (LLM/STT/TTS).
+// Reads/saves the three ordered fallback chains via GET/PUT /arturita/pipeline.
+// Each layer: primary first, then fallbacks; per-entry mode (🔒 local / ☁
+// provider), reorder, remove, add-from-presets, reset-to-free-first. Colorblind-
+// safe: mode is icon+label (never color-only); destructive "Remove" is a red
+// outline, never a lone red CTA. Edit logic is pure in ./assistantConfig.logic.
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+import { tk, text, space } from './tokens'
+import { Button, Card, Select, SectionLabel } from './ui'
+import {
+  PRESETS, entryLabel, entryKey, moveEntry, removeAt, appendEntry, toggleMode,
+  type Entry, type PipelineLayer,
+} from './assistantConfig.logic'
+
+type Getter = () => Promise<string | null>
+type Chains = { llm: Entry[]; stt: Entry[]; tts: Entry[] }
+type PipelineResp = Chains & { defaults: Chains }
+
+const LAYERS: { key: PipelineLayer; label: string; hint: string }[] = [
+  { key: 'llm', label: '🧠 Language model', hint: 'Local Ollama first; free-tier cloud + your paid keys as fallbacks.' },
+  { key: 'stt', label: '🎧 Speech-to-text', hint: 'Self-hosted Whisper first; browser Web Speech as the zero-install fallback.' },
+  { key: 'tts', label: '🔊 Text-to-speech', hint: 'Self-hosted Piper/Chatterbox first; browser voice + hosted Chatterbox as fallbacks.' },
+]
+
+export default function AssistantPipelineConfig({ orgId, getToken }: { orgId: string; getToken: Getter }) {
+  const [open, setOpen] = useState(false)
+  const [chains, setChains] = useState<Chains | null>(null)
+  const [defaults, setDefaults] = useState<Chains | null>(null)
+  const [dirty, setDirty] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setErr(null)
+    try {
+      const r = await api<PipelineResp>(`/api/orgs/${orgId}/arturita/pipeline`, { token: await getToken() })
+      setChains({ llm: r.llm, stt: r.stt, tts: r.tts })
+      setDefaults(r.defaults)
+      setDirty(false)
+    } catch (e: any) { setErr(e?.message ?? 'Failed to load pipeline config') }
+  }, [orgId, getToken])
+
+  useEffect(() => { if (open && !chains) load() }, [open, chains, load])
+
+  const edit = (layer: PipelineLayer, next: Entry[]) => { setChains(c => c ? { ...c, [layer]: next } : c); setDirty(true); setMsg(null) }
+
+  const save = async () => {
+    if (!chains) return
+    setBusy(true); setErr(null); setMsg(null)
+    try {
+      await api(`/api/orgs/${orgId}/arturita/pipeline`, {
+        token: await getToken(), method: 'PUT',
+        body: JSON.stringify({ arturita_llm_chain: chains.llm, arturita_stt_chain: chains.stt, arturita_tts_chain: chains.tts }),
+      })
+      setDirty(false); setMsg('Saved — Arturita will use these on the next turn.')
+    } catch (e: any) { setErr(e?.message ?? 'Save failed') }
+    finally { setBusy(false) }
+  }
+
+  const resetDefaults = () => { if (defaults) { setChains({ ...defaults }); setDirty(true); setMsg(null) } }
+
+  return (
+    <Card style={{ display: 'flex', flexDirection: 'column', gap: space.sm }}>
+      <button onClick={() => setOpen(o => !o)} aria-expanded={open}
+        style={{ display: 'flex', alignItems: 'center', gap: space.sm, background: 'transparent', border: 'none', cursor: 'pointer', color: tk.text, fontSize: text.md.fontSize, fontWeight: 700, padding: 0, textAlign: 'left' }}>
+        <span style={{ color: tk.muted }}>{open ? '▾' : '▸'}</span>
+        ⚙ Pipeline &amp; voice — free-first, with fallbacks
+        <span style={{ flex: 1 }} />
+        {dirty && <span style={{ fontSize: text.xs.fontSize, color: tk.amber }}>● unsaved</span>}
+      </button>
+
+      {open && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: space.lg, marginTop: space.xs }}>
+          {!chains && !err && <p style={{ color: tk.muted, fontSize: text.sm.fontSize }}>Loading…</p>}
+          {chains && LAYERS.map(({ key, label, hint }) => (
+            <LayerEditor key={key} layer={key} label={label} hint={hint} entries={chains[key]} onChange={next => edit(key, next)} />
+          ))}
+          {(msg || err) && <div style={err ? errBox : okBox}>{err ? `⚠ ${err}` : `✓ ${msg}`}</div>}
+          {chains && (
+            <div style={{ display: 'flex', gap: space.sm, flexWrap: 'wrap' }}>
+              <Button variant="primary" disabled={busy || !dirty} onClick={save}>{busy ? 'Saving…' : 'Save pipeline'}</Button>
+              <Button onClick={resetDefaults} style={{ color: tk.accent }}>↺ Reset to free-first defaults</Button>
+              <Button onClick={load} disabled={busy} style={{ color: tk.muted }}>Discard changes</Button>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+function LayerEditor({ layer, label, hint, entries, onChange }: { layer: PipelineLayer; label: string; hint: string; entries: Entry[]; onChange: (n: Entry[]) => void }) {
+  const [addIdx, setAddIdx] = useState('')
+  const presets = PRESETS[layer]
+  const add = () => { const i = Number(addIdx); if (Number.isInteger(i) && presets[i]) { onChange(appendEntry(layer, entries, presets[i])); setAddIdx('') } }
+  return (
+    <div>
+      <SectionLabel style={{ marginBottom: 2 }}>{label}</SectionLabel>
+      <p style={{ ...hintStyle }}>{hint}</p>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: space.xs, marginTop: space.xs }}>
+        {entries.map((e, i) => (
+          <div key={entryKey(layer, e) + i} style={rowStyle}>
+            <span style={{ ...pill, background: 'var(--s2)', color: tk.muted }}>{i === 0 ? 'primary' : `#${i + 1}`}</span>
+            <span style={{ flex: 1, minWidth: 0, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{entryLabel(layer, e)}</span>
+            <button onClick={() => onChange(entries.map((x, xi) => xi === i ? toggleMode(x) : x))}
+              title="toggle local / provider (privacy: local never leaves the device)"
+              style={{ ...pill, cursor: 'pointer', border: `1px solid var(--line-strong)`, background: 'transparent', color: e.mode === 'local' ? tk.accent : tk.muted }}>
+              {e.mode === 'local' ? '🔒 local' : '☁ provider'}
+            </button>
+            <button onClick={() => onChange(moveEntry(entries, i, -1))} disabled={i === 0} aria-label="move up" style={iconBtn(i === 0)}>▲</button>
+            <button onClick={() => onChange(moveEntry(entries, i, 1))} disabled={i === entries.length - 1} aria-label="move down" style={iconBtn(i === entries.length - 1)}>▼</button>
+            <button onClick={() => onChange(removeAt(entries, i))} aria-label="remove" title="Remove"
+              style={{ ...iconBtn(false), border: '1px solid var(--danger-line)', color: tk.red }}>✕</button>
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', gap: space.sm, marginTop: space.sm }}>
+        <Select value={addIdx} onChange={e => setAddIdx(e.target.value)} aria-label={`Add ${layer} option`} style={{ flex: 1, maxWidth: 320 }}>
+          <option value="">＋ Add a fallback…</option>
+          {presets.map((p, i) => <option key={i} value={i}>{entryLabel(layer, p)} {p.mode === 'local' ? '(local)' : '(cloud)'}</option>)}
+        </Select>
+        <Button onClick={add} disabled={addIdx === ''} style={{ color: tk.accent }}>Add</Button>
+      </div>
+    </div>
+  )
+}
+
+const rowStyle: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: space.sm, padding: `${space.xs}px ${space.sm}px`, border: `1px solid ${tk.line}`, borderRadius: tk.r.sm, background: tk.surface, fontSize: text.sm.fontSize }
+const pill: React.CSSProperties = { fontSize: text.xs.fontSize, fontWeight: 700, borderRadius: tk.r.pill, padding: '1px 8px', whiteSpace: 'nowrap' }
+const hintStyle: React.CSSProperties = { fontSize: text.xs.fontSize, color: tk.muted, margin: 0 }
+const errBox: React.CSSProperties = { background: 'var(--danger-bg)', border: '1px solid var(--danger-line)', color: tk.red, borderRadius: tk.r.md, padding: `${space.sm}px ${space.md}px`, fontSize: text.sm.fontSize }
+const okBox: React.CSSProperties = { background: 'var(--ok-bg)', border: '1px solid var(--ok)', color: tk.green, borderRadius: tk.r.md, padding: `${space.sm}px ${space.md}px`, fontSize: text.sm.fontSize }
+function iconBtn(disabled: boolean): React.CSSProperties {
+  return { background: 'transparent', border: '1px solid var(--line-strong)', color: disabled ? tk.muted : tk.textDim, borderRadius: 6, padding: '1px 6px', fontSize: text.xs.fontSize, cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.45 : 1 }
+}

--- a/web/app/dashboard/assistantConfig.logic.test.ts
+++ b/web/app/dashboard/assistantConfig.logic.test.ts
@@ -1,0 +1,58 @@
+// Arturita J2 — pure Config-panel logic tests. Node 22 runner + type-stripping.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  PRESETS, entryLabel, entryKey, moveEntry, removeAt, appendEntry, toggleMode,
+  type Entry, type LlmEntry,
+} from './assistantConfig.logic.ts'
+
+test('[J2] presets are free-first (first entry of each layer is local)', () => {
+  assert.equal(PRESETS.llm[0].mode, 'local')
+  assert.equal(PRESETS.stt[0].mode, 'local')
+  assert.equal(PRESETS.tts[0].mode, 'local')
+  assert.equal((PRESETS.llm[0] as LlmEntry).provider, 'ollama')
+})
+
+test('[J2] entryLabel renders provider/model or engine·detail', () => {
+  assert.equal(entryLabel('llm', { provider: 'ollama', model: 'llama3.2:3b', mode: 'local' }), 'ollama · llama3.2:3b')
+  assert.equal(entryLabel('stt', { engine: 'whisper_cpp', model: 'small', mode: 'local' }), 'whisper_cpp · small')
+  assert.equal(entryLabel('tts', { engine: 'speech_synth', mode: 'local' }), 'speech_synth')
+})
+
+test('[J2] moveEntry swaps neighbours and no-ops at the ends', () => {
+  const a: number[] = [1, 2, 3]
+  assert.deepEqual(moveEntry(a, 0, 1), [2, 1, 3])
+  assert.deepEqual(moveEntry(a, 2, 1), [1, 2, 3])   // last down → no-op
+  assert.deepEqual(moveEntry(a, 0, -1), [1, 2, 3])  // first up → no-op
+  assert.deepEqual(a, [1, 2, 3])                    // original untouched (immutable)
+})
+
+test('[J2] removeAt drops the index immutably', () => {
+  const a = ['x', 'y', 'z']
+  assert.deepEqual(removeAt(a, 1), ['x', 'z'])
+  assert.deepEqual(removeAt(a, 9), ['x', 'y', 'z'])
+  assert.deepEqual(a, ['x', 'y', 'z'])
+})
+
+test('[J2] appendEntry adds new, dedups identical (label+mode)', () => {
+  const arr: Entry[] = [{ provider: 'ollama', model: 'llama3.2:3b', mode: 'local' }]
+  const added = appendEntry('llm', arr, { provider: 'groq', model: 'x', mode: 'provider' })
+  assert.equal(added.length, 2)
+  const dup = appendEntry('llm', added, { provider: 'ollama', model: 'llama3.2:3b', mode: 'local' })
+  assert.equal(dup.length, 2)   // identical → not added
+})
+
+test('[J2] toggleMode flips local⇄provider immutably', () => {
+  const e: Entry = { provider: 'ollama', model: 'x', mode: 'local' }
+  const t = toggleMode(e)
+  assert.equal(t.mode, 'provider')
+  assert.equal(e.mode, 'local')
+  assert.equal(toggleMode(t).mode, 'local')
+})
+
+test('[J2] entryKey distinguishes by label + mode', () => {
+  assert.notEqual(
+    entryKey('llm', { provider: 'ollama', model: 'a', mode: 'local' }),
+    entryKey('llm', { provider: 'ollama', model: 'a', mode: 'provider' }),
+  )
+})

--- a/web/app/dashboard/assistantConfig.logic.ts
+++ b/web/app/dashboard/assistantConfig.logic.ts
@@ -1,0 +1,76 @@
+// Arturita J2 — pure logic for the Config-panel pipeline editor (no DOM/React).
+// Immutable list ops + presets + labels for the three free-first chains
+// (LLM/STT/TTS). Mirrors backend `arturita-pipeline.ts` shapes. Unit-tested.
+
+export type LayerMode = 'local' | 'provider'
+export type PipelineLayer = 'llm' | 'stt' | 'tts'
+
+export interface LlmEntry { provider: string; model: string; mode: LayerMode }
+export interface SttEntry { engine: string; model?: string; mode: LayerMode }
+export interface TtsEntry { engine: string; voice?: string; mode: LayerMode }
+export type Entry = LlmEntry | SttEntry | TtsEntry
+
+// Known options for the "add" dropdowns (free-first first). Not exhaustive — the
+// operator can add anything the backend accepts; these are the ergonomic picks.
+export const PRESETS: Record<PipelineLayer, Entry[]> = {
+  llm: [
+    { provider: 'ollama', model: 'llama3.2:3b', mode: 'local' },
+    { provider: 'ollama', model: 'qwen3:8b', mode: 'local' },
+    { provider: 'ollama', model: 'gemma3:4b', mode: 'local' },
+    { provider: 'ollama', model: 'qwen2.5:14b', mode: 'local' },
+    { provider: 'groq', model: 'llama-3.3-70b-versatile', mode: 'provider' },
+    { provider: 'google', model: 'gemini-2.5-flash', mode: 'provider' },
+    { provider: 'anthropic', model: 'claude-sonnet-4-20250514', mode: 'provider' },
+  ],
+  stt: [
+    { engine: 'whisper_cpp', model: 'small', mode: 'local' },
+    { engine: 'whisper_cpp', model: 'base', mode: 'local' },
+    { engine: 'faster_whisper', model: 'small', mode: 'local' },
+    { engine: 'web_speech', mode: 'provider' },
+  ],
+  tts: [
+    { engine: 'piper', voice: 'en_US-amy', mode: 'local' },
+    { engine: 'chatterbox', voice: 'arturita', mode: 'local' },
+    { engine: 'speech_synth', mode: 'local' },
+    { engine: 'chatterbox_nvidia', voice: 'arturita', mode: 'provider' },
+  ],
+}
+
+/** Human label for an entry (provider/model or engine[·voice/model]). */
+export function entryLabel(layer: PipelineLayer, e: Entry): string {
+  if (layer === 'llm') { const x = e as LlmEntry; return `${x.provider} · ${x.model}` }
+  const x = e as SttEntry & TtsEntry
+  const detail = x.model ?? x.voice
+  return detail ? `${x.engine} · ${detail}` : x.engine
+}
+
+/** Stable-ish identity for dedupe/keys. */
+export function entryKey(layer: PipelineLayer, e: Entry): string {
+  return `${layer}:${entryLabel(layer, e)}:${e.mode}`
+}
+
+// ─── Immutable list ops ──────────────────────────────────────────────────────
+
+export function moveEntry<T>(arr: T[], i: number, dir: -1 | 1): T[] {
+  const j = i + dir
+  if (i < 0 || i >= arr.length || j < 0 || j >= arr.length) return arr
+  const next = arr.slice()
+  ;[next[i], next[j]] = [next[j], next[i]]
+  return next
+}
+
+export function removeAt<T>(arr: T[], i: number): T[] {
+  if (i < 0 || i >= arr.length) return arr
+  return arr.slice(0, i).concat(arr.slice(i + 1))
+}
+
+/** Append an entry unless an identical one (same label+mode) is already present. */
+export function appendEntry(layer: PipelineLayer, arr: Entry[], e: Entry): Entry[] {
+  const k = entryKey(layer, e)
+  if (arr.some(x => entryKey(layer, x) === k)) return arr
+  return arr.concat([e])
+}
+
+export function toggleMode(e: Entry): Entry {
+  return { ...e, mode: e.mode === 'local' ? 'provider' : 'local' } as Entry
+}


### PR DESCRIPTION
A collapsible **⚙ Pipeline & voice** panel in the Arturita tab to view + edit the three fallback chains (LLM/STT/TTS), reading/saving via `GET/PUT /arturita/pipeline` (#202).

- Per layer, primary-first ordered list: per-entry **mode** (🔒 local / ☁ provider), **reorder** (▲▼), **remove** (✕, red outline — never a lone red CTA), **add-from-presets**, **reset-to-free-first-defaults**, save/discard.
- Colorblind-safe (mode is icon+label, never color-only), tokens only, light+dark.
- Pure edit logic in `assistantConfig.logic` (move/remove/append/toggle + presets + labels) — **7 web tests**.

Web build green · **34 web tests**. Slice 3 of 4 (logo #201 → pipeline #202 → **config panel** → tab wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)