### PR TITLE
fix(Arturita): honest talk-path LLM reachability (self-test + actionable degrade)

### DIFF
--- a/backend/src/routes/arturita-converse.ts
+++ b/backend/src/routes/arturita-converse.ts
@@ -23,8 +23,8 @@ import { buildArturitaAgent } from '../services/arturita-session'
 import { decideConverseMode, buildConverseSystemPrompt } from '../services/arturita-converse'
 import { routeVoiceCommand } from '../services/voice-routing'
 import { streamLLMWithFallback } from '../services/llm-fallback-runtime'
-import { parseLlmChain, usableLlmChain } from '../services/arturita-pipeline'
-import { resolveLlmCreds, hasStoredKey } from '../services/custom-model'
+import { parseLlmChain, usableLlmChain, usableCloudProviders } from '../services/arturita-pipeline'
+import { resolveLlmCreds, keyAvailableFor } from '../services/custom-model'
 import { estimateInputTokens, parseCapUsd } from '../services/preflight'
 
 const ConverseBody = z.object({
@@ -41,6 +41,14 @@ const ConverseBody = z.object({
    *  streams tokens locally. Delegation still runs server-side. */
   deferAnswer: z.boolean().optional(),
 })
+
+// Shown when no language model can answer — deliberately actionable (names the
+// two operator fixes) instead of a vague "network error"/"check config".
+export const NO_LLM_MESSAGE =
+  "I can't reach any language model right now, so I can't answer this turn. " +
+  "Two ways to fix it: run local Ollama on the machine you're talking to me from " +
+  "(Ollama started + `OLLAMA_ORIGINS=https://app.7ei.ai`, then restart Ollama), " +
+  "or add a working cloud key (a free Groq or Gemini key works) in ⚙ Pipeline config below."
 
 async function ensureArturita(orgId: string): Promise<typeof schema.agents.$inferSelect> {
   const existing = await db.query.agents.findFirst({
@@ -135,12 +143,7 @@ export async function arturitaConverseRoutes(app: FastifyInstance) {
     // to usable hops with the agent's own model guaranteed as the last resort so
     // the live path never breaks when local Ollama / free-tier keys are absent.
     const deployCfg = (org?.deployConfig ?? {}) as Record<string, any>
-    const keyAvailable = (p: string) =>
-      hasStoredKey(deployCfg, p) ||       // plaintext or encrypted (custom models)
-      (p === 'anthropic' && !!process.env.ANTHROPIC_API_KEY) ||
-      (p === 'openai' && !!process.env.OPENAI_API_KEY) ||
-      (p === 'google' && !!(process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY)) ||
-      (p === 'groq' && !!process.env.GROQ_API_KEY)
+    const keyAvailable = keyAvailableFor(deployCfg)  // shared with GET /arturita/llm-status
     const chain = usableLlmChain({
       entries: parseLlmChain(deployCfg),
       keyAvailable,
@@ -169,14 +172,62 @@ export async function arturitaConverseRoutes(app: FastifyInstance) {
         mode: 'answer',
         routing: { trigger: decision.trigger, reason: decision.reason, destructive: false },
         degraded: true,
-        reply: { text: "I couldn't reach a language model just now — the provider chain is unavailable. Try again in a moment, or check the LLM config.", provider: 'text_only' },
+        reply: { text: NO_LLM_MESSAGE, provider: 'text_only' },
         error: e?.message ?? 'llm unavailable',
       }
+    }
+  })
+
+  // ── Talk-path LLM reachability probe (for the Config self-test) ─────────────
+  // Answers the honest question the reachability-of-`/pipeline` check can't: can
+  // the CLOUD fallback actually produce a token? It runs a tiny real completion
+  // through the usable cloud chain, so a stored-but-INVALID key (e.g. an expired
+  // Anthropic key) is reported as unusable — not a false ✓. Local Ollama is NOT
+  // probed here (it lives on the operator's machine; the browser probes that
+  // directly). Read-only, operator-initiated; capped to a 1-token ping.
+  app.get('/api/orgs/:orgId/arturita/llm-status', async (req, reply) => {
+    const { orgId } = req.params as any
+    const org = await db.query.organisations.findFirst({ where: eq(schema.organisations.id, orgId) })
+    if (!org) return reply.code(404).send({ error: 'Organisation not found' })
+    const agent = await ensureArturita(orgId)
+    const deployCfg = (org.deployConfig ?? {}) as Record<string, any>
+    const keyAvailable = keyAvailableFor(deployCfg)
+    const provider = agent.llmProvider ?? 'anthropic'
+    const model = agent.llmModel ?? 'claude-sonnet-4-20250514'
+    // Cloud-only chain: drop local/ollama hops; keep the guaranteed hop (backend
+    // env key) so a working env key still counts even without an org key.
+    const cloudEntries = parseLlmChain(deployCfg).filter(e => e.mode !== 'local' && e.provider !== 'ollama')
+    const chain = usableLlmChain({ entries: cloudEntries, keyAvailable, guaranteed: { provider, model } })
+    const configuredProviders = usableCloudProviders(parseLlmChain(deployCfg), keyAvailable)
+
+    if (chain.length === 0) {
+      return { cloudUsable: false, configuredProviders, checked: false, detail: 'No cloud LLM provider with a key is configured.' }
+    }
+    try {
+      const fb = await streamLLMWithFallback({
+        base: { system: 'Reply with the single word: ok', messages: [{ role: 'user', content: 'ping' }], onToken: () => {} },
+        chain,
+        resolveCreds: (prov) => resolveLlmCreds(deployCfg, prov),
+        inputTokens: estimateInputTokens(['ping']),
+        capUsd: parseCapUsd(org.deployConfig as any, agent.id),
+      })
+      return { cloudUsable: true, checked: true, provider: fb.used.provider, model: fb.used.model, configuredProviders, detail: `Cloud LLM reachable via ${fb.used.provider} (${fb.used.model}).` }
+    } catch (e: any) {
+      const raw = String(e?.message ?? 'provider chain unavailable')
+      // Surface the common cause plainly without leaking the key/full payload.
+      const detail = /invalid|x-api-key|401|403|authentication/i.test(raw)
+        ? `A configured cloud key was rejected (invalid or expired). Providers tried: ${chain.map(c => c.provider).join(', ')}.`
+        : `Cloud LLM unreachable: ${raw.slice(0, 160)}`
+      return { cloudUsable: false, checked: true, configuredProviders, detail }
     }
   })
 
   documentEndpoint('POST', '/api/orgs/:orgId/arturita/converse', {
     summary: 'Conversational front door — Arturita answers directly (F1 fallback chain) unless the operator explicitly delegates/builds (→ task/agent flow)',
     tag: 'arturita', body: ConverseBody,
+  })
+  documentEndpoint('GET', '/api/orgs/:orgId/arturita/llm-status', {
+    summary: 'Talk-path cloud-LLM reachability probe (real 1-token ping) — powers the Config self-test; catches stored-but-invalid keys',
+    tag: 'arturita',
   })
 }

--- a/backend/src/services/arturita-pipeline.ts
+++ b/backend/src/services/arturita-pipeline.ts
@@ -174,6 +174,23 @@ export function usableLlmChain(input: {
   return out
 }
 
+/**
+ * The distinct `provider`-mode LLM providers that have a usable key — i.e. the
+ * cloud providers Arturita can fall back to when no local engine is reachable
+ * from the operator's browser. Local/ollama hops are excluded: they need the
+ * operator's own machine and are probed client-side. Pure; `keyAvailable`
+ * injected. (Key PRESENCE, not validity — a live call is needed for validity.)
+ */
+export function usableCloudProviders(entries: LlmEntry[], keyAvailable: (provider: string) => boolean): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const e of entries) {
+    if (e.mode === 'local' || LOCAL_LLM_PROVIDERS.has(e.provider)) continue
+    if (keyAvailable(e.provider) && !seen.has(e.provider)) { seen.add(e.provider); out.push(e.provider) }
+  }
+  return out
+}
+
 // ─── Resolve everything for a context (for the tab / a GET) ───────────────────
 
 export interface ResolvedPipeline {

--- a/backend/src/services/custom-model.ts
+++ b/backend/src/services/custom-model.ts
@@ -194,3 +194,23 @@ export function hasStoredKey(deployConfig: Record<string, unknown> | null | unde
   const cfg = (deployConfig ?? {}) as Record<string, unknown>
   return !!(cfg[plainKeyKey(provider)] || cfg[encKeyKey(provider)])
 }
+
+/**
+ * Build the per-provider "is a usable key available?" predicate shared by the
+ * converse route AND the talk-path LLM-reachability probe — a key is available
+ * when the org stored one (plaintext or encrypted) OR the backend env holds one.
+ * One source of truth so the answer path and the self-test can never drift.
+ * (Presence only — a stored-but-invalid key still reads as available here; the
+ * live probe in `/arturita/llm-status` is what catches an invalid key.)
+ */
+export function keyAvailableFor(
+  deployConfig: Record<string, unknown> | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): (provider: string) => boolean {
+  return (p: string) =>
+    hasStoredKey(deployConfig, p) ||
+    (p === 'anthropic' && !!env.ANTHROPIC_API_KEY) ||
+    (p === 'openai' && !!env.OPENAI_API_KEY) ||
+    (p === 'google' && !!(env.GEMINI_API_KEY || env.GOOGLE_API_KEY)) ||
+    (p === 'groq' && !!env.GROQ_API_KEY)
+}

--- a/backend/src/tests/arturita-pipeline.test.ts
+++ b/backend/src/tests/arturita-pipeline.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   parseLlmChain, parseSttChain, parseTtsChain, filterForContext,
-  usableLlmChain, resolvePipeline, validatePipelineConfig,
+  usableLlmChain, usableCloudProviders, resolvePipeline, validatePipelineConfig,
   DEFAULT_LLM_CHAIN, DEFAULT_STT_CHAIN, DEFAULT_TTS_CHAIN, PIPELINE_KEYS,
 } from '../services/arturita-pipeline'
 
@@ -129,4 +129,27 @@ test('[J2] validate ignores absent layers (partial update)', () => {
   assert.equal(v.value.llm, undefined)
   assert.equal(v.value.stt, undefined)
   assert.equal(v.value.tts?.length, 1)
+})
+
+// ─── usableCloudProviders: the cloud fallback the self-test actually depends on ─
+
+test('[talk] usableCloudProviders excludes local/ollama hops and keys the rest', () => {
+  // default chain: 2 local ollama hops + groq + google (providers)
+  const withGroq = usableCloudProviders(DEFAULT_LLM_CHAIN, p => p === 'groq')
+  assert.deepEqual(withGroq, ['groq'])           // only the provider WITH a key
+})
+
+test('[talk] usableCloudProviders is empty when no cloud key is present (the live failure)', () => {
+  // no keys at all → the cloud fallback cannot answer → empty
+  assert.deepEqual(usableCloudProviders(DEFAULT_LLM_CHAIN, () => false), [])
+})
+
+test('[talk] usableCloudProviders dedupes and skips local-mode entries even for cloud providers', () => {
+  const chain = [
+    { provider: 'ollama', model: 'llama3.2:3b', mode: 'local' as const },
+    { provider: 'groq', model: 'a', mode: 'provider' as const },
+    { provider: 'groq', model: 'b', mode: 'provider' as const },       // dup provider
+    { provider: 'google', model: 'g', mode: 'local' as const },        // marked local → skipped
+  ]
+  assert.deepEqual(usableCloudProviders(chain, () => true), ['groq'])
 })

--- a/web/app/dashboard/AssistantPanel.tsx
+++ b/web/app/dashboard/AssistantPanel.tsx
@@ -25,7 +25,7 @@ import {
 } from './assistant.logic'
 import { decideSubmit, WAKE_WORD } from './cockpit/voicePanel.logic'
 import { probeOllama, streamOllamaChat, DEFAULT_OLLAMA_URL, type ChatMsg } from '@/lib/ollama'
-import { pickSpeechVoice, classifyTtsError, describeTalkError } from '@/lib/talkDiagnostics'
+import { pickSpeechVoice, classifyTtsError, describeTalkError, NO_LLM_FIX_HINT } from '@/lib/talkDiagnostics'
 
 type Getter = () => Promise<string | null>
 
@@ -144,6 +144,12 @@ export default function AssistantPanel({ orgId, getToken }: { orgId: string; get
     const reqHistory = [...messages, userMsg]
     const baseReq = toConverseRequest({ message, explicitDelegate: explicit, existingThreadId: threadRef.current, history: reqHistory })
     const post = async (body: object) => api<ConverseResponse>(`/api/orgs/${orgId}/arturita/converse`, { token: await getToken(), method: 'POST', body: JSON.stringify(body) })
+    // When the backend answered but no LLM was reachable (degraded/text_only),
+    // surface the actionable fix (enable local Ollama, or add a free cloud key)
+    // right under the transcript instead of leaving only a ⚠ badge on the bubble.
+    const noticeIfDegraded = (r: ConverseResponse) => {
+      if (r.degraded || r.reply?.provider === 'text_only') setNotice({ tone: 'warn', text: `No language model was reachable for that reply. ${NO_LLM_FIX_HINT} Open ⚙ Pipeline config below and “Run self-test” to check each leg.` })
+    }
     try {
       const resp = await post({ ...baseReq, deferAnswer: !!localLlm })
 
@@ -177,6 +183,7 @@ export default function AssistantPanel({ orgId, getToken }: { orgId: string; get
           const d = describeTalkError(localErr, 'local-ollama')
           setNotice({ tone: 'info', text: `${d.message} ${d.hint ?? ''}`.trim() })
           const cloud = await post({ ...baseReq, deferAnswer: false })
+          noticeIfDegraded(cloud)
           const arturita = toArturitaMessage({ id: nextId(), resp: cloud })
           setMessages(m => [...m, arturita]); setReveal({ id: arturita.id, shown: 0 }); setSpeaking(true)
           return
@@ -184,6 +191,7 @@ export default function AssistantPanel({ orgId, getToken }: { orgId: string; get
       }
 
       // Plain cloud answer → client-side reveal.
+      noticeIfDegraded(resp)
       const arturita = toArturitaMessage({ id: nextId(), resp })
       setThinking(false); setMessages(m => [...m, arturita]); setReveal({ id: arturita.id, shown: 0 }); setSpeaking(true)
     } catch (e: any) {

--- a/web/app/dashboard/AssistantPipelineConfig.tsx
+++ b/web/app/dashboard/AssistantPipelineConfig.tsx
@@ -74,10 +74,20 @@ export default function AssistantPipelineConfig({ orgId, getToken }: { orgId: st
     let backendOk = false, backendDetail: string | null = null
     try { await api(`/api/orgs/${orgId}/arturita/pipeline`, { token: await getToken() }); backendOk = true }
     catch (e: any) { backendDetail = e?.message ?? 'unreachable' }
-    // 2. local Ollama reachable? (+ configured primary model)
+    // 2. cloud LLM actually reachable? — a REAL 1-token probe on the backend, so a
+    // stored-but-invalid key (e.g. an expired Anthropic key) reads as unusable,
+    // not a false ✓. null = couldn't run the probe (backend down / error).
+    let cloudLlmUsable: boolean | null = null, cloudLlmDetail: string | null = null
+    if (backendOk) {
+      try {
+        const s = await api<{ cloudUsable: boolean; detail?: string }>(`/api/orgs/${orgId}/arturita/llm-status`, { token: await getToken() })
+        cloudLlmUsable = !!s.cloudUsable; cloudLlmDetail = s.detail ?? null
+      } catch (e: any) { cloudLlmUsable = null; cloudLlmDetail = e?.message ?? null }
+    }
+    // 3. local Ollama reachable? (+ configured primary model)
     const primary = (chains?.llm ?? []).find((e): e is LlmEntry => 'provider' in e && (e as LlmEntry).provider === 'ollama' && (e as LlmEntry).mode === 'local')
     const ollamaModels = await probeOllama(DEFAULT_OLLAMA_URL)
-    // 3/4. browser TTS + STT capabilities
+    // 4/5. browser TTS + STT capabilities
     const hasTts = typeof window !== 'undefined' && 'speechSynthesis' in window
     const voices = hasTts ? (window.speechSynthesis.getVoices() ?? []) : []
     const localVoice = !!pickSpeechVoice(voices as any, 'en-US')?.localService
@@ -85,6 +95,7 @@ export default function AssistantPipelineConfig({ orgId, getToken }: { orgId: st
     setSelfTest(runSelfTest({
       backendOk, backendDetail,
       ollamaModels, ollamaPrimaryModel: primary ? (primary as LlmEntry).model : null,
+      cloudLlmUsable, cloudLlmDetail,
       ttsSupported: hasTts, ttsLocalVoice: localVoice, sttSupported: hasStt,
     }))
     setTesting(false)

--- a/web/lib/talkDiagnostics.test.ts
+++ b/web/lib/talkDiagnostics.test.ts
@@ -92,10 +92,33 @@ const BASE = {
 }
 
 test('runSelfTest is all-green when every leg is healthy', () => {
-  const r = runSelfTest(BASE)
+  const r = runSelfTest({ ...BASE, cloudLlmUsable: true })
   assert.equal(overallSeverity(r), 'ok')
-  assert.equal(r.length, 4)
+  assert.equal(r.length, 5)               // answers + backend + ollama + tts + stt
   assert.ok(r.every(x => x.icon === '✓'))
+})
+
+test('runSelfTest FAILS the answers leg when neither local Ollama nor a cloud key works (the live root cause)', () => {
+  const r = runSelfTest({ ...BASE, ollamaModels: null, cloudLlmUsable: false })
+  const ans = r.find(x => x.leg === 'answers')!
+  assert.equal(ans.severity, 'fail')
+  assert.equal(ans.icon, '✕')
+  assert.match(String(ans.hint), /OLLAMA_ORIGINS/)
+  assert.match(String(ans.hint), /Groq or Gemini/)
+  assert.equal(overallSeverity(r), 'fail')
+})
+
+test('runSelfTest answers leg is OK via cloud when local Ollama is down but a cloud key works', () => {
+  const r = runSelfTest({ ...BASE, ollamaModels: null, cloudLlmUsable: true, cloudLlmDetail: 'Cloud LLM reachable via groq (llama-3.3-70b-versatile).' })
+  const ans = r.find(x => x.leg === 'answers')!
+  assert.equal(ans.severity, 'ok')
+  assert.match(ans.detail, /groq/)
+})
+
+test('runSelfTest answers leg warns (not fails) when cloud was not probed and no local model', () => {
+  const r = runSelfTest({ ...BASE, ollamaModels: null, cloudLlmUsable: null })
+  const ans = r.find(x => x.leg === 'answers')!
+  assert.equal(ans.severity, 'warn')
 })
 
 test('runSelfTest fails the backend leg (never color-only) and reports overall fail', () => {

--- a/web/lib/talkDiagnostics.ts
+++ b/web/lib/talkDiagnostics.ts
@@ -172,6 +172,11 @@ export interface SelfTestInput {
   ollamaModels: string[] | null
   /** the configured local primary model id, if the chain has one. */
   ollamaPrimaryModel?: string | null
+  /** cloud LLM reachability from a REAL backend probe (GET /arturita/llm-status):
+   *  true = a token came back; false = no usable/valid cloud key; null/undefined
+   *  = not probed. This is what catches a stored-but-invalid key. */
+  cloudLlmUsable?: boolean | null
+  cloudLlmDetail?: string | null
   /** SpeechSynthesis present in this browser. */
   ttsSupported: boolean
   /** an on-device voice is available. */
@@ -179,6 +184,12 @@ export interface SelfTestInput {
   /** SpeechRecognition (mic capture) present. */
   sttSupported: boolean
 }
+
+/** The single actionable fix when NO language model can answer — names both
+ *  operator options. Shared so the self-test + panel notice say the same thing. */
+export const NO_LLM_FIX_HINT =
+  'Either run local Ollama on THIS machine (Ollama started + `OLLAMA_ORIGINS=https://app.7ei.ai`, then restart Ollama), ' +
+  'or add a working cloud key (a free Groq or Gemini key works) in the LLM chain below.'
 
 const ICON: Record<LegSeverity, string> = { ok: '✓', warn: '▲', fail: '✕' }
 
@@ -193,7 +204,28 @@ function leg(leg: string, severity: LegSeverity, label: string, detail: string, 
 export function runSelfTest(input: SelfTestInput): LegResult[] {
   const out: LegResult[] = []
 
-  // 1. Backend converse (cloud LLM chain — the guaranteed answer path).
+  // 0. THE headline question: can Arturita actually produce an answer at all?
+  // She can if EITHER a local Ollama model is reachable from this browser, OR the
+  // backend's cloud chain has a working (valid) key. Neither → she can't answer,
+  // and this is the leg that most often reads as a bare "network error".
+  const localAnswers = Array.isArray(input.ollamaModels) && input.ollamaModels.length > 0
+  const cloudAnswers = input.cloudLlmUsable === true
+  if (localAnswers) {
+    out.push(leg('answers', 'ok', 'Arturita can answer', `A local Ollama model on this machine is ready (${input.ollamaModels![0]}) — free & private.`))
+  } else if (cloudAnswers) {
+    out.push(leg('answers', 'ok', 'Arturita can answer', input.cloudLlmDetail || 'A cloud language model is reachable.'))
+  } else if (input.cloudLlmUsable === false) {
+    // Real probe said the cloud key is missing/invalid AND no local model → dead.
+    out.push(leg('answers', 'fail', 'Arturita can’t answer — no reachable language model',
+      input.cloudLlmDetail || 'No local Ollama model here, and no working cloud key.', NO_LLM_FIX_HINT))
+  } else {
+    // Cloud not probed (unknown). Report on local only, don't over-claim.
+    out.push(leg('answers', 'warn', 'Answer path unverified',
+      'No local Ollama model on this machine; cloud LLM not checked.',
+      'Nothing to answer with locally — ' + NO_LLM_FIX_HINT))
+  }
+
+  // 1. Backend converse (routing + prompt/answer path — required every turn).
   out.push(input.backendOk
     ? leg('backend', 'ok', 'Backend reachable', input.backendDetail || 'Cloud answer + delegate path available.')
     : leg('backend', 'fail', 'Backend unreachable', input.backendDetail || 'Could not reach 7ei-backend.',


### PR DESCRIPTION
## Root cause (diagnosed live on app.7ei.ai)

Reproduced in the operator's logged-in browser. Findings:

- **Deployed build is current** — #206 (talkDiagnostics) + #214 are live; API base is `https://7ei-backend.fly.dev`. Not stale.
- **Local Ollama works from the https page** — `http://localhost:11434` is a secure context (no mixed-content block); CORS is correct (`Access-Control-Allow-Origin: https://app.7ei.ai`), models pulled. A real talk succeeded: converse→200 (deferred prompt) → `POST /api/chat`→200 → answer via 🔒 local · llama3.2:3b.
- **The cloud fallback is dead** — `converse deferAnswer:false` → 200 `degraded:true` with `error:"401 invalid x-api-key"`. A stored Anthropic key exists but is **invalid**, and there is no working Groq/Gemini key (`/health` → `llm.providers:[]`). So **off the operator's Ollama machine there is no reachable LLM**.
- **The self-test hid this** — it only probed backend *reachability* (200 from `/pipeline`), so it showed ✓ backend + ▲ optional even when nothing could answer. Key *presence* ≠ validity.

The bare "Network error" is not reproducible on the current build (#206's per-leg messaging is live); the actual operator-facing failure is a silent/vague "can't answer" whenever local Ollama isn't running.

## Fix

- **`GET /api/orgs/:orgId/arturita/llm-status`** — a real 1-token cloud ping so a stored-but-**invalid** key reads as unusable (not a false ✓). Reuses the new `keyAvailableFor()` predicate shared with the converse route (one source of truth) + pure `usableCloudProviders()`.
- **Self-test headline "answers" leg** — OK if local Ollama **or** a valid cloud key can answer; **FAIL** (with the two-option fix) if neither.
- **Actionable degrade** — the degraded converse reply and a new panel notice now name the two fixes: enable local Ollama (`OLLAMA_ORIGINS=https://app.7ei.ai`) or add a free Groq/Gemini key — via shared `NO_LLM_MESSAGE` / `NO_LLM_FIX_HINT`.

## What the operator must still do (not fabricated in code)

Set **one** working LLM: a valid `ANTHROPIC_API_KEY`, or a free `GROQ_API_KEY` / `GEMINI_API_KEY`, via Cockpit → Secrets / Fly secrets — **or** keep local Ollama running wherever they talk to Arturita (already works on their Mac today).

## Tests
- backend `npm test` → 870 pass; `npm run evals` → 11/11
- web `npm test` → 83 pass; `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)