### PR TITLE
test(Arturita): lock local-first LLM default + no-spurious-cloud-call invariant

### DIFF
--- a/backend/src/tests/arturita-pipeline.test.ts
+++ b/backend/src/tests/arturita-pipeline.test.ts
@@ -17,6 +17,41 @@ test('[J2] unconfigured org gets the free-first defaults (local Ollama/whisper/P
   assert.equal(DEFAULT_TTS_CHAIN[0].engine, 'piper')
 })
 
+// Lock the LLM default as strictly LOCAL-FIRST: the two Ollama models lead (fast
+// primary, then heavier), and NO cloud/provider entry ever precedes a local one.
+// This is the shipped guarantee that the invalid cloud key is only a fallback.
+test('[J2] LLM default is strictly local-first: Ollama primary + no cloud before local', () => {
+  assert.equal(DEFAULT_LLM_CHAIN[0].provider, 'ollama')
+  assert.equal(DEFAULT_LLM_CHAIN[0].model, 'llama3.2:3b')   // fast primary
+  assert.equal(DEFAULT_LLM_CHAIN[0].mode, 'local')
+  assert.equal(DEFAULT_LLM_CHAIN[1].provider, 'ollama')
+  assert.equal(DEFAULT_LLM_CHAIN[1].model, 'qwen3:8b')      // heavier local next
+  assert.equal(DEFAULT_LLM_CHAIN[1].mode, 'local')
+  // Every local entry precedes every provider entry (no cloud jumps the queue).
+  const firstProvider = DEFAULT_LLM_CHAIN.findIndex(e => e.mode === 'provider')
+  const lastLocal = DEFAULT_LLM_CHAIN.map(e => e.mode).lastIndexOf('local')
+  assert.ok(firstProvider === -1 || firstProvider > lastLocal, 'a provider entry precedes a local one')
+  // No cloud provider is anthropic (the bad-key provider) — it only ever enters
+  // at runtime as the appended `guaranteed` last-resort hop, never in the default.
+  assert.ok(!DEFAULT_LLM_CHAIN.some(e => e.provider === 'anthropic'))
+})
+
+// With the default chain and no cloud keys, the usable chain keeps both local
+// Ollama hops FIRST and puts the guaranteed cloud hop (bad key) strictly LAST.
+test('[J2] usable default chain: local Ollama hops first, cloud guarantee strictly last', () => {
+  const chain = usableLlmChain({
+    entries: DEFAULT_LLM_CHAIN,
+    keyAvailable: () => false,                                   // off-Mac, no free-tier keys
+    guaranteed: { provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
+  })
+  assert.equal(chain[0].provider, 'ollama')
+  assert.equal(chain[1].provider, 'ollama')
+  assert.equal(chain[chain.length - 1].provider, 'anthropic')   // last resort only
+  const firstCloud = chain.findIndex(c => c.provider !== 'ollama')
+  const lastLocal = chain.map(c => c.provider === 'ollama').lastIndexOf(true)
+  assert.ok(firstCloud > lastLocal, 'a cloud hop precedes a local one')
+})
+
 // ─── Parsing configured chains (array or JSON string) ────────────────────────
 
 test('[J2] parses a configured LLM chain and infers mode from provider', () => {

--- a/backend/src/tests/llm-fallback-runtime.test.ts
+++ b/backend/src/tests/llm-fallback-runtime.test.ts
@@ -35,6 +35,29 @@ test('[F1] single-hop chain: one call, returns the result (identical to bare str
   assert.equal(r.attempts[0].ok, true)
 })
 
+test('[J2] local primary success short-circuits — a later cloud hop (bad key) is never called', async () => {
+  // The Arturita default chain shape: local Ollama first, cloud last-resort.
+  const LOCAL_FIRST = [
+    { provider: 'ollama', model: 'llama3.2:3b' },
+    { provider: 'anthropic', model: 'claude-sonnet-4-20250514' }, // invalid/expired key IRL
+  ]
+  const breakers = new Map<string, BreakerState>()
+  const called: string[] = []
+  const streamFn: (o: LLMStreamOpts) => Promise<LLMResult> = async (o) => {
+    called.push(o.provider)
+    if (o.provider === 'ollama') return { output: 'ok:local', model: o.model, provider: o.provider, usage: { inputTokens: 10, outputTokens: 5 } }
+    throw new Error('anthropic error 401 invalid api key') // must never be reached
+  }
+  const r = await streamLLMWithFallback({
+    base, chain: LOCAL_FIRST, resolveCreds: creds, inputTokens: 100, capUsd: null,
+    now: 1000, breakers, streamFn,
+  })
+  assert.equal(r.used.provider, 'ollama')
+  assert.equal(r.result.output, 'ok:local')
+  assert.equal(r.attempts.length, 1)            // stopped at the first success
+  assert.deepEqual(called, ['ollama'])          // anthropic (bad key) never invoked
+})
+
 test('[P2] reasoningEffort in base opts flows through to the LLM call', async () => {
   const breakers = new Map<string, BreakerState>()
   let seenEffort: string | undefined


### PR DESCRIPTION
## What & why

Make Arturita's **local-Ollama-first** behavior a *locked* guarantee so the invalid/expired cloud (Anthropic) key can never silently return to the primary path.

Investigation finding: **Arturita is already local-first by default.**
- `DEFAULT_LLM_CHAIN` = `ollama/llama3.2:3b` → `ollama/qwen3:8b` → `groq` → `google` (cloud only as fallback).
- The runtime (`streamLLMWithFallback`) returns the **first success**, so when local Ollama answers the cloud leg is never attempted — the invalid Anthropic key only enters as the appended last-resort `guaranteed` hop.
- The browser-direct-to-Ollama streaming path (`deferAnswer`) stays primary.
- The actionable degraded message ("run local Ollama / add a free Groq or Gemini key") already ships via #215's `NO_LLM_MESSAGE` + the `/arturita/llm-status` cloud probe.

So no runtime change was needed — this PR **locks** those invariants with tests:

- `DEFAULT_LLM_CHAIN` is strictly local-first: `llama3.2:3b` fast primary, `qwen3:8b` next, no `provider` entry ever precedes a `local` one, and `anthropic` never appears in the default.
- `usableLlmChain(default, no cloud keys)` keeps both Ollama hops first, cloud guarantee strictly last.
- `streamLLMWithFallback` short-circuits: a successful local primary never invokes a later cloud hop (the bad Anthropic key is never hit).

## Test
- Backend: **873 pass / 0 fail**
- Evals: **11/11**
- `tsc --noEmit`: clean

Test-only; no runtime/deploy behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)