### PR TITLE
fix(Arturita): graceful STT — no more bare "Speech error: network" (Brave)

### DIFF
--- a/web/app/dashboard/AssistantPanel.tsx
+++ b/web/app/dashboard/AssistantPanel.tsx
@@ -25,7 +25,8 @@ import {
 } from './assistant.logic'
 import { decideSubmit, WAKE_WORD } from './cockpit/voicePanel.logic'
 import { probeOllama, streamOllamaChat, DEFAULT_OLLAMA_URL, type ChatMsg } from '@/lib/ollama'
-import { pickSpeechVoice, classifyTtsError, describeTalkError, NO_LLM_FIX_HINT } from '@/lib/talkDiagnostics'
+import { pickSpeechVoice, classifyTtsError, classifySttError, describeTalkError, NO_LLM_FIX_HINT } from '@/lib/talkDiagnostics'
+import { detectBrave } from '@/lib/browserEnv'
 
 type Getter = () => Promise<string | null>
 
@@ -43,6 +44,11 @@ export default function AssistantPanel({ orgId, getToken }: { orgId: string; get
   const [typed, setTyped] = useState('')
   const [interim, setInterim] = useState('')
   const [supported, setSupported] = useState(false)
+  // Built-in Web Speech STT feature-detects as present but can't actually work
+  // here (Brave disables its Google STT backend → a persistent `network` error).
+  // When that happens we stop steering the operator at the mic and point them at
+  // the typed box / local Whisper instead.
+  const [sttUnavailable, setSttUnavailable] = useState(false)
   const [listening, setListening] = useState(false)
   const [thinking, setThinking] = useState(false)
   const [speaking, setSpeaking] = useState(false)
@@ -59,6 +65,7 @@ export default function AssistantPanel({ orgId, getToken }: { orgId: string; get
   const [localLlm, setLocalLlm] = useState<{ model: string; baseUrl: string } | null>(null)
 
   const recogRef = useRef<any>(null)
+  const braveRef = useRef(false)
   const voicesRef = useRef<SpeechSynthesisVoice[]>([])
   const threadRef = useRef<string | null>(null)
   const wakeRef = useRef(wakeWord)
@@ -70,6 +77,9 @@ export default function AssistantPanel({ orgId, getToken }: { orgId: string; get
   useEffect(() => { voiceRef.current = voiceReplies }, [voiceReplies])
 
   const voiceState = resolveVoiceState({ speaking, thinking, listening })
+
+  // Detect Brave once (async) so a built-in-STT failure can name it specifically.
+  useEffect(() => { let ok = true; detectBrave().then(b => { if (ok) braveRef.current = b }); return () => { ok = false } }, [])
 
   // Browser voices populate asynchronously (Chrome fires `voiceschanged` after
   // the list is ready). Cache them so `speak` can pick an on-device voice.
@@ -245,8 +255,21 @@ export default function AssistantPanel({ orgId, getToken }: { orgId: string; get
       setInterim(live)
     }
     r.onerror = (ev: any) => {
-      if (ev?.error === 'not-allowed' || ev?.error === 'service-not-allowed') setErr('Microphone permission denied — allow mic access or type below.')
-      else if (ev?.error && ev.error !== 'no-speech' && ev.error !== 'aborted') setErr(`Speech error: ${ev.error}`)
+      const st = classifySttError(ev?.error, { brave: braveRef.current })
+      if (!st.failed) return
+      // `network` = built-in STT can't reach its backend (Brave disables it).
+      // Non-fatal: stop listening, mark it unavailable, and steer to typing /
+      // Whisper via the colorblind-safe notice (icon+label) — never a bare error.
+      if (st.unavailable) {
+        setSttUnavailable(true)
+        recogRef.current && (recogRef.current.__active = false)
+        try { r.stop() } catch { /* noop */ }
+        setListening(false); setInterim('')
+        setNotice({ tone: 'warn', text: st.hint ? `${st.message} ${st.hint}` : st.message! })
+      } else {
+        // permission / no-mic / unknown — actionable, typed input still works.
+        setErr(st.hint ? `${st.message} ${st.hint}` : st.message)
+      }
     }
     r.onend = () => { if (recogRef.current?.__active) { try { r.start() } catch { /* restarting */ } } else setListening(false) }
     recogRef.current = r
@@ -296,6 +319,9 @@ export default function AssistantPanel({ orgId, getToken }: { orgId: string; get
           </label>
         </div>
         {!supported && <p style={sxHint}>Speech capture isn’t available in this browser — type below.</p>}
+        {supported && sttUnavailable && (
+          <p style={sxHint}>🎙 Built-in voice input is blocked in this browser{braveRef.current ? ' (Brave)' : ''} — type below, or enable free local Whisper in ⚙ Pipeline config.</p>
+        )}
         <p style={sxHint}>
           {localLlm
             ? <>🔒 Running on your local <b>{localLlm.model}</b> (Ollama) — free &amp; on-device.</>

--- a/web/app/dashboard/cockpit/VoiceSection.tsx
+++ b/web/app/dashboard/cockpit/VoiceSection.tsx
@@ -20,6 +20,8 @@ import {
   decideSubmit, pickPlayback, toFeedItem, WAKE_WORD,
   type FeedItem, type VoiceMode, type VoiceResponse,
 } from './voicePanel.logic'
+import { classifySttError } from '@/lib/talkDiagnostics'
+import { detectBrave } from '@/lib/browserEnv'
 
 type Props = {
   orgId: string
@@ -43,12 +45,16 @@ export default function VoiceSection({ orgId, getToken, approvals = [], onDecide
   const [note, setNote] = useState('')
 
   const recogRef = useRef<any>(null)
+  const braveRef = useRef(false)
   const seqRef = useRef(0)
   const threadRef = useRef<string | null>(null)
   const wakeRef = useRef(wakeWord)
   const modeRef = useRef(mode)
   useEffect(() => { wakeRef.current = wakeWord }, [wakeWord])
   useEffect(() => { modeRef.current = mode }, [mode])
+  // Detect Brave once so a built-in-STT failure can name it (Brave disables the
+  // Google speech backend Web Speech relies on → a persistent `network` error).
+  useEffect(() => { let ok = true; detectBrave().then(b => { if (ok) braveRef.current = b }); return () => { ok = false } }, [])
 
   // ── Send a command (from speech or the typed fallback) ─────────────────────
   const send = useCallback(async (command: string, confidence: number | null) => {
@@ -101,11 +107,12 @@ export default function VoiceSection({ orgId, getToken, approvals = [], onDecide
       setInterim(live)
     }
     r.onerror = (ev: any) => {
-      if (ev?.error === 'not-allowed' || ev?.error === 'service-not-allowed') {
-        setErr('Microphone permission denied — allow mic access or type a command below.')
-      } else if (ev?.error && ev.error !== 'no-speech' && ev.error !== 'aborted') {
-        setErr(`Speech error: ${ev.error}`)
-      }
+      const st = classifySttError(ev?.error, { brave: braveRef.current })
+      if (!st.failed) return
+      // Built-in STT unusable here (Brave/network) or blocked/no-mic — all map to
+      // a specific, actionable line; typing the command below always works.
+      if (st.unavailable) { r.__active = false; try { r.stop() } catch { /* noop */ }; setListening(false); setInterim('') }
+      setErr(st.hint ? `${st.message} ${st.hint}` : st.message)
     }
     r.onend = () => {
       // Keep listening across natural pauses while the toggle is on.

--- a/web/lib/browserEnv.ts
+++ b/web/lib/browserEnv.ts
@@ -1,0 +1,28 @@
+// Arturita STT — tiny impure browser-environment probes (no React).
+//
+// Kept out of the pure diagnostics module (talkDiagnostics.ts) because these
+// touch `navigator`. Split so the classification logic stays unit-testable and
+// the DOM sniffing lives in one place both voice panels share.
+
+/**
+ * Best-effort Brave detection. Brave exposes `navigator.brave.isBrave()` (async,
+ * returns true) and no other engine does — so a true result is reliable. Any
+ * error or absence resolves false. We use this only to *name Brave* in the
+ * "voice input unavailable" message; the graceful degradation itself never
+ * depends on it. Impure (reads `navigator`).
+ */
+export async function detectBrave(): Promise<boolean> {
+  try {
+    const nav = (typeof navigator !== 'undefined' ? navigator : null) as any
+    if (!nav?.brave?.isBrave) return false
+    return await nav.brave.isBrave()
+  } catch {
+    return false
+  }
+}
+
+/** Web Speech `SpeechRecognition` (mic capture) constructor is present. Impure. */
+export function hasWebSpeechStt(): boolean {
+  if (typeof window === 'undefined') return false
+  return !!((window as any).SpeechRecognition || (window as any).webkitSpeechRecognition)
+}

--- a/web/lib/talkDiagnostics.test.ts
+++ b/web/lib/talkDiagnostics.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  pickSpeechVoice, classifyTtsError, describeTalkError, runSelfTest, overallSeverity,
+  pickSpeechVoice, classifyTtsError, classifySttError, describeTalkError, runSelfTest, overallSeverity,
   type VoiceLike,
 } from './talkDiagnostics.ts'
 
@@ -61,6 +61,56 @@ test('classifyTtsError maps an unknown code to a generic non-fatal failure', () 
   const s = classifyTtsError('weird-new-code')
   assert.equal(s.failed, true)
   assert.equal(s.kind, 'unknown')
+})
+
+// ─── classifySttError (mic capture / SpeechRecognition) ──────────────────────
+
+test('classifySttError treats a network error as unavailable + hinted (the Brave root cause), never a bare code', () => {
+  const s = classifySttError('network')
+  assert.equal(s.failed, true)
+  assert.equal(s.kind, 'network')
+  assert.equal(s.unavailable, true)               // stop steering to the mic
+  assert.doesNotMatch(String(s.message), /^Speech error/i) // no more bare "Speech error: network"
+  assert.match(String(s.hint), /Whisper|text box/i)
+})
+
+test('classifySttError names Brave specifically when told it is Brave', () => {
+  const brave = classifySttError('network', { brave: true })
+  assert.match(String(brave.message), /Brave/)
+  const other = classifySttError('network', { brave: false })
+  assert.doesNotMatch(String(other.message), /Brave/)
+  assert.equal(other.unavailable, true)           // still unavailable, just not named Brave
+})
+
+test('classifySttError maps not-allowed / service-not-allowed to a permission status (not unavailable)', () => {
+  for (const c of ['not-allowed', 'service-not-allowed']) {
+    const s = classifySttError(c)
+    assert.equal(s.kind, 'permission')
+    assert.equal(s.unavailable, false)
+    assert.match(String(s.message), /mic|microphone/i)
+  }
+})
+
+test('classifySttError maps audio-capture to a no-mic status', () => {
+  const s = classifySttError('audio-capture')
+  assert.equal(s.kind, 'no-mic')
+  assert.equal(s.failed, true)
+})
+
+test('classifySttError does NOT report benign no-speech / aborted / empty codes', () => {
+  for (const c of ['no-speech', 'aborted', '', null, undefined]) {
+    const s = classifySttError(c as any)
+    assert.equal(s.failed, false, `code ${c} should be benign`)
+    assert.equal(s.kind, null)
+    assert.equal(s.unavailable, false)
+  }
+})
+
+test('classifySttError maps an unknown code to a generic non-fatal, non-unavailable failure', () => {
+  const s = classifySttError('weird-stt-code')
+  assert.equal(s.failed, true)
+  assert.equal(s.kind, 'unknown')
+  assert.equal(s.unavailable, false)              // don't over-claim "unavailable" for unknowns
 })
 
 // ─── describeTalkError ───────────────────────────────────────────────────────

--- a/web/lib/talkDiagnostics.ts
+++ b/web/lib/talkDiagnostics.ts
@@ -107,6 +107,81 @@ export function classifyTtsError(errorCode: string | null | undefined): TtsStatu
   }
 }
 
+// ─── Browser STT: classify a SpeechRecognition (mic capture) error ────────────
+// The push-to-talk path uses the Web Speech API `SpeechRecognition`. In Chromium
+// its backend is Google's cloud speech service — which BRAVE DISABLES. So in
+// Brave the constructor exists (feature-detect passes, the mic button enables)
+// but every `.start()` fires `onerror` with `error === 'network'`, dead-ending
+// voice input even while fully online. That used to surface as a bare
+// "Speech error: network". This maps each code to a specific, NON-FATAL status
+// (typing always works) and, when built-in STT is unusable, points the operator
+// at the free local-Whisper path. Distinct from `classifyTtsError` (the speak()
+// leg). Pure.
+
+export type SttFailure = 'permission' | 'no-mic' | 'network' | 'unknown'
+
+export interface SttStatus {
+  /** false for benign codes we ignore (`no-speech`, `aborted` on stop). */
+  failed: boolean
+  kind: SttFailure | null
+  /** true when the browser's built-in STT can't work here (Brave / STT backend
+   *  unreachable) — the caller should stop retrying and steer to typing/Whisper. */
+  unavailable: boolean
+  message: string | null
+  hint: string | null
+}
+
+const STT_OK: SttStatus = { failed: false, kind: null, unavailable: false, message: null, hint: null }
+
+/** The always-available fallbacks when built-in STT can't be used. Shared so the
+ *  panels + self-test say the same thing. */
+export const WHISPER_STT_HINT =
+  'Use the text box below (always available), or enable free local Whisper voice input — see ⚙ Pipeline config.'
+
+/**
+ * Map a `SpeechRecognitionErrorEvent.error` code to a specific, NON-FATAL
+ * operator status. `no-speech`/`aborted` are benign (we stop the recognizer on
+ * toggle-off and on natural pauses). `network` is the Brave / STT-backend-down
+ * case — the one that read as "Speech error: network"; pass `opts.brave` to name
+ * Brave explicitly. Pure.
+ */
+export function classifySttError(errorCode: string | null | undefined, opts: { brave?: boolean } = {}): SttStatus {
+  const code = String(errorCode ?? '').trim().toLowerCase()
+  switch (code) {
+    case '':
+    case 'no-speech':
+    case 'aborted':
+      return STT_OK
+    case 'not-allowed':
+    case 'service-not-allowed':
+      return {
+        failed: true, kind: 'permission', unavailable: false,
+        message: 'Microphone access is blocked for this site.',
+        hint: 'Allow mic access in your browser’s site settings, or type your message below.',
+      }
+    case 'audio-capture':
+      return {
+        failed: true, kind: 'no-mic', unavailable: false,
+        message: 'No microphone was found.',
+        hint: 'Check that a mic is connected and enabled, or type your message below.',
+      }
+    case 'network':
+      return {
+        failed: true, kind: 'network', unavailable: true,
+        message: opts.brave
+          ? 'Voice input isn’t available in this browser — Brave disables the built-in speech recognition it relies on.'
+          : 'Voice input isn’t available — the browser’s built-in speech-recognition service couldn’t be reached.',
+        hint: WHISPER_STT_HINT,
+      }
+    default:
+      return {
+        failed: true, kind: 'unknown', unavailable: false,
+        message: `Voice input error (${code}).`,
+        hint: 'Type your message below, or try again.',
+      }
+  }
+}
+
 // ─── Converse leg: classify a caught fetch/HTTP error ─────────────────────────
 
 export type TalkLeg = 'backend' | 'local-ollama' | 'tts'


### PR DESCRIPTION
## The bug
The operator gets **"Speech Error: network"** when pushing to talk to Arturita — even though the LLM (local Ollama) now works. This is the **STT / mic-capture** layer, not the TTS `speak()` path fixed in #206.

## Root cause (confirmed)
`web/app/dashboard/AssistantPanel.tsx` and `cockpit/VoiceSection.tsx` capture speech via the Web Speech API `webkitSpeechRecognition`. In Chromium its recognition backend is **Google's cloud STT** — which **Brave disables**. So:
- the constructor exists → feature-detect passes → the mic button enables;
- the moment `.start()` reaches for Google's servers, `onerror` fires with `error === 'network'`;
- the old handler printed it verbatim (`Speech error: ${ev.error}`) → **"Speech error: network"**.

Browser-native STT is therefore fundamentally non-working in Brave, online or not.

## Fix (this PR — immediate graceful handling)
- **`classifySttError()`** — new pure classifier in `talkDiagnostics.ts` (sibling of `classifyTtsError`). `network` → a specific, **non-fatal** *"Voice input isn't available in this browser…"* status that names **Brave** when detected and steers to the text box + free local Whisper; `not-allowed`/`service-not-allowed` → permission, `audio-capture` → no-mic, `no-speech`/`aborted` → benign.
- Both voice panels stop the recognizer on the unavailable case and show a **colorblind-safe** notice (icon + label, never a raw error code). **Typed input stays fully working** as the always-available fallback.
- `lib/browserEnv.ts`: shared `detectBrave()` / `hasWebSpeechStt()`.
- **+6 tests** (89 web tests green); web build green.

Part B — **real free voice input via local Whisper** (MediaRecorder → local Whisper endpoint, selectable in ⚙ Pipeline config) ships in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)