### PR TITLE
feat(Arturita): tolerant fuzzy wake-word + lock whisper-first STT default

### DIFF
--- a/backend/src/services/voice.ts
+++ b/backend/src/services/voice.ts
@@ -28,23 +28,117 @@ export function normalizeTranscript(raw: string | null | undefined): string {
   return String(raw ?? '').replace(/\s+/g, ' ').trim()
 }
 
-// ─── Wake word ───────────────────────────────────────────────────────────────
+// ─── Wake word (fuzzy) ───────────────────────────────────────────────────────
 
 export const WAKE_WORD = 'arturita'
 
-/** Does the transcript start with the wake word ("Arturita, …")? Used only when
- *  wake-word mode is opted in (push-to-talk is the default — S5). */
-export function hasWakeWord(transcript: string | null | undefined, wake: string = WAKE_WORD): boolean {
-  const t = normalizeTranscript(transcript).toLowerCase()
-  return t === wake || t.startsWith(wake + ' ') || t.startsWith(wake + ',')
+// Whisper (and browser STT) routinely mis-hear the coined name "Arturita" as a
+// near-miss — "Arturator", "Arturito", "Arturia" — or split it across tokens
+// ("art of eta"). Exact-prefix matching made wake-word mode unreliable, so wake
+// detection is FUZZY: an explicit allowlist of known mishears (belt) plus a
+// normalized edit-distance threshold (suspenders) over the leading 1–3 tokens.
+// Push-to-talk stays the default reliable path (S5); this only affects the
+// opt-in wake-word mode, where a rare false positive is cheaper than failing to
+// answer to her name.
+
+/** Known STT mishears of "Arturita" (lowercased, punctuation-free). The fuzzy
+ *  threshold below catches most of these on its own; the allowlist guarantees
+ *  the common ones even if the threshold is later tightened. Includes a few
+ *  space-collapsed split-name forms ("art of eta" → "artofeta"). */
+export const WAKE_VARIANTS = new Set([
+  'arturita', 'arturito', 'arturado', 'arturato', 'arturador',
+  'arturator', 'arturater', 'arturitta', 'arturitas', 'arturit',
+  'arturia', 'arturi', 'arturida', 'arturna', 'arturina',
+  'arthurita', 'arthurito', 'alturita', 'artureta', 'arturela',
+  'artofeta', 'artoreta', 'artaeta', 'arturetta',
+])
+
+/** Similarity threshold in [0,1] (1 = identical). 0.6 accepts an edit distance
+ *  of ~3 against the 8-char wake word — enough for "arturator"/"art of eta"
+ *  while rejecting ordinary command words. Tuned + locked by unit tests. */
+const WAKE_SIMILARITY = 0.6
+const MAX_WAKE_SPAN = 3
+
+/** Levenshtein edit distance (two-row DP). Pure, no deps. */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0
+  if (!a.length) return b.length
+  if (!b.length) return a.length
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i)
+  let curr = new Array(b.length + 1)
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost)
+    }
+    ;[prev, curr] = [curr, prev]
+  }
+  return prev[b.length]
 }
 
-/** Strip a leading wake word (+ following comma) so the command classifier sees
- *  just the command. No-op when absent. */
+/** Normalized similarity in [0,1]; 1 for identical, 0 for empty-vs-nonempty. */
+function similarity(a: string, b: string): number {
+  const max = Math.max(a.length, b.length)
+  if (max === 0) return 1
+  return 1 - levenshtein(a, b) / max
+}
+
+/** Strip to comparable form: lowercase, drop everything but a–z0–9. */
+const cleanToken = (t: string) => t.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+/** Is `cand` (a joined leading span) close enough to be the wake word? */
+function isWakeCandidate(cand: string, wake: string): boolean {
+  if (!cand) return false
+  return WAKE_VARIANTS.has(cand) || similarity(cand, wake) >= WAKE_SIMILARITY
+}
+
+/** Does `tok` look like the START of the name? Anchors multi-token joins so we
+ *  only stitch fragments of a split name ("art" + "of" + "eta") and never a
+ *  junk word that merely precedes the name ("tell" in "tell arturita later"). */
+function isNameStart(tok: string, wake: string): boolean {
+  if (tok.length < 2) return false
+  if (wake.startsWith(tok)) return true
+  return similarity(tok, wake.slice(0, tok.length)) >= WAKE_SIMILARITY
+}
+
+export interface WakeMatch { matched: boolean; tokensConsumed: number }
+
+/** Fuzzy-match the wake word against the LEADING tokens of a transcript. Returns
+ *  whether it matched and how many whitespace tokens the name spanned (so the
+ *  caller can strip exactly the name). Pure. */
+export function matchWakeWord(transcript: string | null | undefined, wake: string = WAKE_WORD): WakeMatch {
+  const tokens = normalizeTranscript(transcript).split(' ').map(cleanToken).filter(Boolean)
+  if (!tokens.length) return { matched: false, tokensConsumed: 0 }
+  // 1) Single leading token is the name (exact, a variant, or fuzzy-close).
+  if (isWakeCandidate(tokens[0], wake)) return { matched: true, tokensConsumed: 1 }
+  // 2) The name was split across tokens — stitch, but only from a plausible
+  //    name-start so unrelated leading words can't be deleted into a match.
+  if (isNameStart(tokens[0], wake)) {
+    let joined = tokens[0]
+    for (let k = 2; k <= Math.min(MAX_WAKE_SPAN, tokens.length); k++) {
+      joined += tokens[k - 1]
+      if (isWakeCandidate(joined, wake)) return { matched: true, tokensConsumed: k }
+    }
+  }
+  return { matched: false, tokensConsumed: 0 }
+}
+
+/** Does the transcript start with the wake word ("Arturita, …")? Tolerant of STT
+ *  mishears. Used only when wake-word mode is opted in (push-to-talk is the
+ *  default — S5). */
+export function hasWakeWord(transcript: string | null | undefined, wake: string = WAKE_WORD): boolean {
+  return matchWakeWord(transcript, wake).matched
+}
+
+/** Strip a leading wake word (+ any following comma) so the command classifier
+ *  sees just the command. Tolerant of mishears/splits. No-op when absent. */
 export function stripWakeWord(transcript: string | null | undefined, wake: string = WAKE_WORD): string {
-  const t = normalizeTranscript(transcript)
-  const re = new RegExp('^' + wake + '\\s*,?\\s*', 'i')
-  return t.replace(re, '').trim()
+  const norm = normalizeTranscript(transcript)
+  const m = matchWakeWord(norm, wake)
+  if (!m.matched) return norm
+  const rest = norm.split(' ').slice(m.tokensConsumed).join(' ')
+  return rest.replace(/^\s*,\s*/, '').trim()
 }
 
 /** Should this capture be processed? Push-to-talk captures are always processed;

--- a/backend/src/tests/arturita-pipeline.test.ts
+++ b/backend/src/tests/arturita-pipeline.test.ts
@@ -52,6 +52,25 @@ test('[J2] usable default chain: local Ollama hops first, cloud guarantee strict
   assert.ok(firstCloud > lastLocal, 'a cloud hop precedes a local one')
 })
 
+// Lock the STT default as strictly WHISPER-FIRST: a local whisper engine leads,
+// browser Web Speech is only a fallback, and no provider entry ever precedes the
+// local one. This is the shipped guarantee that the operator's reachable local
+// whisper bridge is used automatically without flipping a switch (typed input is
+// always available as the UI's final fallback, not modelled in the chain).
+test('[J2] STT default is strictly whisper-first: local whisper primary + no provider before local', () => {
+  const LOCAL_STT = new Set(['whisper_cpp', 'faster_whisper', 'whisper'])
+  assert.ok(LOCAL_STT.has(DEFAULT_STT_CHAIN[0].engine), 'primary STT engine must be a local whisper engine')
+  assert.equal(DEFAULT_STT_CHAIN[0].mode, 'local')
+  assert.equal(DEFAULT_STT_CHAIN[DEFAULT_STT_CHAIN.length - 1].engine, 'web_speech') // browser fallback last
+  // Every local entry precedes every provider entry (no cloud/provider jumps the queue).
+  const firstProvider = DEFAULT_STT_CHAIN.findIndex(e => e.mode === 'provider')
+  const lastLocal = DEFAULT_STT_CHAIN.map(e => e.mode).lastIndexOf('local')
+  assert.ok(firstProvider === -1 || firstProvider > lastLocal, 'a provider STT entry precedes a local one')
+  // An unconfigured org (no stored arturita_stt_chain override) gets this default.
+  assert.deepEqual(parseSttChain(null), DEFAULT_STT_CHAIN)
+  assert.deepEqual(parseSttChain({}), DEFAULT_STT_CHAIN)
+})
+
 // ─── Parsing configured chains (array or JSON string) ────────────────────────
 
 test('[J2] parses a configured LLM chain and infers mode from provider', () => {

--- a/backend/src/tests/voice.test.ts
+++ b/backend/src/tests/voice.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   normalizeTranscript, hasWakeWord, stripWakeWord, shouldProcessCapture,
   gateTranscript, orderVoiceProviders, nextVoiceProvider,
+  matchWakeWord, levenshtein, WAKE_VARIANTS,
   AUDIO_RETENTION, WAKE_WORD, MIN_STT_CONFIDENCE, type VoiceProvider,
 } from '../services/voice'
 
@@ -41,6 +42,64 @@ test('[B1] shouldProcessCapture: push-to-talk always; wake-word only if present'
   assert.equal(shouldProcessCapture({ transcript: '   ', mode: 'push_to_talk' }), false)
   assert.equal(shouldProcessCapture({ transcript: 'move it', mode: 'wake_word' }), false)
   assert.equal(shouldProcessCapture({ transcript: 'Arturita move it', mode: 'wake_word' }), true)
+})
+
+// ─── Fuzzy wake word (STT mishears her name) ─────────────────────────────────
+
+test('[wake] levenshtein basic distances', () => {
+  assert.equal(levenshtein('arturita', 'arturita'), 0)
+  assert.equal(levenshtein('arturita', 'arturito'), 1)   // last char
+  assert.equal(levenshtein('arturita', 'arturia'), 1)    // dropped 't'
+  assert.equal(levenshtein('', 'abc'), 3)
+})
+
+test('[wake] hasWakeWord tolerates common Whisper mishears of "Arturita"', () => {
+  // Each of these should reliably trigger wake-word mode.
+  for (const v of ['Arturator', 'Arturito', 'Arturia', 'Arturater', 'Arthurita', 'arturi']) {
+    assert.equal(hasWakeWord(`${v}, open the cockpit`), true, `variant "${v}" should match`)
+  }
+})
+
+test('[wake] hasWakeWord tolerates the name split across tokens ("art of eta")', () => {
+  assert.equal(hasWakeWord('art of eta what is on my calendar'), true)
+  assert.equal(hasWakeWord('art of eta'), true)
+})
+
+test('[wake] hasWakeWord still rejects unrelated leading speech', () => {
+  assert.equal(hasWakeWord('hey there'), false)
+  assert.equal(hasWakeWord('open the cockpit'), false)
+  assert.equal(hasWakeWord('are we there yet'), false)
+  // The name present but NOT leading must not trigger (back-compat invariant).
+  assert.equal(hasWakeWord('tell Arturita later'), false)
+  assert.equal(hasWakeWord('please tell arturita to wait'), false)
+})
+
+test('[wake] exact + case-insensitive still work (no regression)', () => {
+  assert.equal(hasWakeWord('Arturita, what is on my calendar'), true)
+  assert.equal(hasWakeWord('arturita move the files'), true)
+  assert.equal(hasWakeWord('Arturita'), true)
+  assert.equal(WAKE_WORD, 'arturita')
+})
+
+test('[wake] matchWakeWord reports how many tokens the name spanned', () => {
+  assert.deepEqual(matchWakeWord('Arturita move it'), { matched: true, tokensConsumed: 1 })
+  assert.deepEqual(matchWakeWord('art of eta move it'), { matched: true, tokensConsumed: 3 })
+  assert.deepEqual(matchWakeWord('move it'), { matched: false, tokensConsumed: 0 })
+  assert.deepEqual(matchWakeWord(''), { matched: false, tokensConsumed: 0 })
+})
+
+test('[wake] stripWakeWord removes a fuzzy/split leading name, keeps the command', () => {
+  assert.equal(stripWakeWord('Arturator, move the files'), 'move the files')
+  assert.equal(stripWakeWord('Arturito delete downloads'), 'delete downloads')
+  assert.equal(stripWakeWord('art of eta open the cockpit'), 'open the cockpit')
+  assert.equal(stripWakeWord('Arturita, move the files'), 'move the files') // exact still works
+  assert.equal(stripWakeWord('move the files'), 'move the files')           // no-op
+})
+
+test('[wake] every allowlisted variant matches as a leading wake word', () => {
+  for (const v of WAKE_VARIANTS) {
+    assert.equal(hasWakeWord(`${v} do the thing`), true, `allowlist entry "${v}" should match`)
+  }
 })
 
 // ─── Confidence gating ───────────────────────────────────────────────────────

--- a/web/lib/sttEngine.test.ts
+++ b/web/lib/sttEngine.test.ts
@@ -8,6 +8,16 @@ test('resolveSttEngine picks whisper when the bridge is reachable (chain primary
   assert.equal(resolveSttEngine({ sttChain: CHAIN, whisperReachable: true, webSpeechAvailable: true }), 'whisper')
 })
 
+// The shipped DEFAULT_STT_CHAIN (backend arturita-pipeline: whisper_cpp → web_speech)
+// resolves to local whisper AUTOMATICALLY on the operator's Mac (bridge running at
+// 127.0.0.1:8790 → whisperReachable), so the operator never flips the engine manually.
+test('resolveSttEngine: shipped whisper-first default → whisper on the operator Mac', () => {
+  const SHIPPED_DEFAULT = [{ engine: 'whisper_cpp', mode: 'local' }, { engine: 'web_speech', mode: 'provider' }]
+  assert.equal(resolveSttEngine({ sttChain: SHIPPED_DEFAULT, whisperReachable: true, webSpeechAvailable: true }), 'whisper')
+  // Only when the bridge is unreachable does it fall back to the browser engine.
+  assert.equal(resolveSttEngine({ sttChain: SHIPPED_DEFAULT, whisperReachable: false, webSpeechAvailable: true }), 'web_speech')
+})
+
 test('resolveSttEngine falls to web_speech when whisper is down but web speech works', () => {
   assert.equal(resolveSttEngine({ sttChain: CHAIN, whisperReachable: false, webSpeechAvailable: true }), 'web_speech')
 })


### PR DESCRIPTION
## Two Arturita voice fixes

### TASK 1 — Whisper is the DEFAULT STT engine (confirm + lock)
`DEFAULT_STT_CHAIN` was **already whisper-first** (`whisper_cpp` local primary → `web_speech` provider fallback), and `resolveSttEngine` **already prefers the reachable local bridge** (falls to Web Speech only when whisper is unreachable). On the operator's Mac with the bridge at `127.0.0.1:8790`, push-to-talk uses local Whisper automatically — no manual flip.

Locks it with tests: strict whisper-first default (local primary, no provider before local, unconfigured org → default) and default chain → `whisper` when the bridge is reachable.

**Per-org override caveat:** a stored `arturita_stt_chain` in the org `deployConfig` would take precedence and can't be inspected headlessly (Clerk-secured endpoint). STT config only shipped in #218 so an override is unlikely; operator can confirm/fix in one step in ⚙ Pipeline config.

### TASK 2 — tolerant fuzzy wake-word
Whisper mis-hears "Arturita" as "Arturator"/"Arturito"/"Arturia" or splits it ("art of eta"). `hasWakeWord`/`stripWakeWord` now fuzzy-match the leading 1–3 tokens via a mishear allowlist + normalized Levenshtein (threshold 0.6), anchored at a plausible name-start so a non-leading name ("tell Arturita later") still does NOT trigger. New pure `matchWakeWord`/`levenshtein`, fully tested. Push-to-talk stays the default reliable path; no UI changes.

## Verification
- backend `npm test` → **882 / 0 fail**; `typecheck` clean; `evals` **11/11**
- web `npm run build` → passes
- whisper bridge `curl 127.0.0.1:8790/health` → healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)