### PR TITLE
feat(AG1): agent detail page shell — header + six-tab bar + deep-link routing

### DIFF
--- a/web/app/dashboard/agent/AgentDetail.tsx
+++ b/web/app/dashboard/agent/AgentDetail.tsx
@@ -1,0 +1,166 @@
+'use client'
+// Epic AG / AG1 — per-agent detail page: header (avatar · name · role · status
+// pill · actions) + the six-tab bar, mirroring the Paperclip agent page. Routing
+// is the pure `lib/agentRoute` hash contract; the tab panels land in AG2–AG6.
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+import { AGENT_TABS, AGENT_TAB_LABEL, type AgentTab } from '@/lib/agentRoute'
+import { Button, Card, Skeleton, TextInput } from '../ui'
+import { Modal, ModalTitle, FormLabel } from '../cockpit/shared'
+import { tk, text, space } from '../tokens'
+import { AgentAvatar, StatusPill, ax, type DAgent, type Getter } from './shared'
+
+export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getToken }: {
+  orgId: string
+  agentId: string
+  tab: AgentTab
+  onTab: (t: AgentTab) => void
+  onBack: () => void
+  getToken: Getter
+}) {
+  const [agent, setAgent] = useState<DAgent | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+  const [assignOpen, setAssignOpen] = useState(false)
+  const [taskTitle, setTaskTitle] = useState('')
+
+  const load = useCallback(async () => {
+    setErr(null)
+    try {
+      const { agent: a } = await api<{ agent: DAgent }>(`/api/agents/${agentId}`, { token: await getToken() })
+      setAgent(a)
+    } catch (e: any) { setErr(e?.message ?? 'Could not load this agent.') }
+  }, [agentId, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  // Header actions. Pause/resume/terminate reuse the existing agent controls;
+  // "Run heartbeat" reuses the org heartbeat sweep (which wakes due agents —
+  // there is no per-agent wake endpoint, so the label says sweep in its title).
+  const control = async (verb: 'pause' | 'resume' | 'terminate') => {
+    setBusy(true); setMsg(null)
+    try {
+      await api(`/api/agents/${agentId}/${verb}`, { token: await getToken(), method: 'POST' })
+      await load()
+    } catch (e: any) { setErr(e?.message ?? `Could not ${verb} this agent.`) }
+    setBusy(false)
+  }
+
+  const heartbeat = async () => {
+    setBusy(true); setMsg(null); setErr(null)
+    try {
+      await api(`/api/orgs/${orgId}/heartbeat/sweep`, { token: await getToken(), method: 'POST' })
+      setMsg('Heartbeat sweep ran — any due agent was woken.')
+      await load()
+    } catch (e: any) { setErr(e?.message ?? 'Heartbeat sweep failed.') }
+    setBusy(false)
+  }
+
+  const assign = async () => {
+    const title = taskTitle.trim()
+    if (!title) return
+    setBusy(true); setErr(null)
+    try {
+      await api(`/api/orgs/${orgId}/tasks`, { token: await getToken(), method: 'POST', body: JSON.stringify({ agentId, title }) })
+      setAssignOpen(false); setTaskTitle('')
+      setMsg(`Assigned "${title}".`)
+    } catch (e: any) { setErr(e?.message ?? 'Could not assign the task.') }
+    setBusy(false)
+  }
+
+  if (err && !agent) return (
+    <div style={ax.page}>
+      <button style={ax.crumbLink} onClick={onBack}>← Agents</button>
+      <div style={ax.err}>{err}</div>
+    </div>
+  )
+
+  if (!agent) return (
+    <div style={ax.page}>
+      <div style={{ display: 'flex', gap: space.lg, alignItems: 'center' }}>
+        <Skeleton w={56} h={56} /><div style={{ flex: 1 }}><Skeleton w={180} h={20} /><Skeleton w={110} h={12} style={{ marginTop: 8 }} /></div>
+      </div>
+      <Skeleton h={32} />
+    </div>
+  )
+
+  const paused = agent.status === 'paused'
+
+  return (
+    <div style={ax.page}>
+      <nav style={ax.crumbs} aria-label="Breadcrumb">
+        <button style={ax.crumbLink} onClick={onBack}>Agents</button>
+        <span aria-hidden="true">›</span>
+        <span style={{ color: tk.text }}>{agent.name}</span>
+      </nav>
+
+      <header style={ax.header}>
+        <AgentAvatar agent={agent} size={56} />
+        <div style={{ minWidth: 0 }}>
+          <h1 style={ax.name}>{agent.name}</h1>
+          <div style={ax.role}>{agent.title || agent.role}</div>
+        </div>
+        <div style={ax.actions}>
+          <Button onClick={() => setAssignOpen(true)} disabled={busy}>＋ Assign Task</Button>
+          <Button onClick={heartbeat} disabled={busy} title="Runs the org heartbeat sweep — wakes any agent that is due">▷ Run Heartbeat</Button>
+          {paused
+            ? <Button onClick={() => control('resume')} disabled={busy}>▶ Resume</Button>
+            : <Button onClick={() => control('pause')} disabled={busy}>❙❙ Pause</Button>}
+          <StatusPill status={agent.status} />
+        </div>
+      </header>
+
+      {msg && <p style={{ ...ax.empty, color: tk.green }}>{msg}</p>}
+      {err && <div style={ax.err}>{err}</div>}
+
+      <div role="tablist" aria-label="Agent sections" style={ax.tabbar}>
+        {AGENT_TABS.map(t => (
+          <button key={t} role="tab" aria-selected={t === tab} id={`agent-tab-${t}`} aria-controls={`agent-panel-${t}`}
+            onClick={() => onTab(t)}
+            style={{ ...ax.tab, ...(t === tab ? ax.tabOn : {}) }}>
+            {AGENT_TAB_LABEL[t]}
+          </button>
+        ))}
+      </div>
+
+      <div role="tabpanel" id={`agent-panel-${tab}`} aria-labelledby={`agent-tab-${tab}`}>
+        <TabPanel tab={tab} />
+      </div>
+
+      {assignOpen && (
+        <Modal onClose={() => setAssignOpen(false)}>
+          <ModalTitle onClose={() => setAssignOpen(false)}>Assign a task to {agent.name}</ModalTitle>
+          <FormLabel>Title
+            <TextInput autoFocus value={taskTitle} placeholder="What should this agent do?"
+              onChange={e => setTaskTitle(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') assign() }} />
+          </FormLabel>
+          <div style={{ display: 'flex', gap: space.sm, justifyContent: 'flex-end' }}>
+            <Button onClick={() => setAssignOpen(false)}>Cancel</Button>
+            <Button variant="primary" onClick={assign} disabled={busy || !taskTitle.trim()}>Assign</Button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+// AG1 ships the shell; each tab's real panel lands in its own story (AG2–AG6).
+const PENDING: Record<AgentTab, string> = {
+  dashboard: 'Latest run, run activity, tasks by priority/status, success rate, recent tasks and costs.',
+  instructions: 'The agent’s personal markdown files (AGENTS.md, HEARTBEAT.md, SOUL.md, TOOLS.md) with an editor.',
+  skills: 'The company skills library — installed vs. available for this agent.',
+  configuration: 'Identity, avatar, reports-to, adapter and model.',
+  runs: 'Run history with per-run logs.',
+  budget: 'This agent’s budget and spend.',
+}
+
+function TabPanel({ tab }: { tab: AgentTab }) {
+  return (
+    <Card style={{ display: 'flex', flexDirection: 'column', gap: space.sm }}>
+      <h2 style={ax.sectionTitle}>{AGENT_TAB_LABEL[tab]}</h2>
+      <p style={{ ...ax.empty, fontSize: text.sm.fontSize }}>Coming in this wave — {PENDING[tab]}</p>
+    </Card>
+  )
+}

--- a/web/app/dashboard/agent/shared.tsx
+++ b/web/app/dashboard/agent/shared.tsx
@@ -1,0 +1,83 @@
+'use client'
+// Epic AG — shared types + styles for the per-agent detail page (AG1 shell,
+// AG2–AG6 tabs). Everything structural comes from tokens.ts; no raw hex here.
+import type { CSSProperties } from 'react'
+import { tk, text, space } from '../tokens'
+import { statusColor, statusIcon } from '../status'
+
+export type Getter = () => Promise<string | null>
+
+/** The `agents` row as the detail page reads it (backend GET /api/agents/:id). */
+export type DAgent = {
+  id: string
+  name: string
+  role: string
+  title?: string | null
+  status: string
+  avatarEmoji?: string | null
+  /** AG5 — uploaded picture (data URI or URL). Falls back to avatarEmoji when absent. */
+  avatarUrl?: string | null
+  runtime: string
+  llmProvider: string
+  llmModel: string
+  primaryModel?: string | null
+  skills?: string[]
+  reportsTo?: string | null
+  heartbeatStatus?: string | null
+  lastHeartbeatAt?: number | null
+  termsOfReference?: string | null
+  jobDescription?: string | null
+}
+
+/**
+ * Agent avatar — the uploaded picture when there is one, else the icon/emoji
+ * (AG5 keeps upload optional, so the emoji stays the safe default for every
+ * existing agent). `alt` is empty because the name is always rendered next to it.
+ */
+export function AgentAvatar({ agent, size = 40, radius }: { agent: Pick<DAgent, 'avatarUrl' | 'avatarEmoji' | 'name'>; size?: number; radius?: number }) {
+  const r = radius ?? Math.round(size / 4)
+  const box: CSSProperties = {
+    width: size, height: size, borderRadius: r, flexShrink: 0,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    background: tk.surfaceHigh, border: `1px solid ${tk.line}`, overflow: 'hidden',
+  }
+  if (agent.avatarUrl) {
+    // eslint-disable-next-line @next/next/no-img-element -- data URI / backend blob, not an optimizable static asset
+    return <img src={agent.avatarUrl} alt="" style={{ ...box, objectFit: 'cover' }} />
+  }
+  return <span aria-hidden="true" style={{ ...box, fontSize: Math.round(size * 0.55) }}>{agent.avatarEmoji || '🤖'}</span>
+}
+
+/**
+ * Status pill — icon + text label + color (never color alone; the operator is
+ * red-green colorblind, see DESIGN_SYSTEM v2 / status.ts).
+ */
+export function StatusPill({ status, style }: { status: string; style?: CSSProperties }) {
+  const c = statusColor(status)
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: space.xs,
+      fontSize: text.xs.fontSize, lineHeight: text.xs.lineHeight, fontWeight: 700,
+      color: c, border: `1px solid ${c}`, borderRadius: tk.r.pill, padding: '2px 9px',
+      textTransform: 'capitalize', whiteSpace: 'nowrap', ...style,
+    }}>
+      <span aria-hidden="true">{statusIcon(status)}</span>{status}
+    </span>
+  )
+}
+
+export const ax: Record<string, CSSProperties> = {
+  page: { padding: space.xxl, maxWidth: 1100, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: space.xl },
+  crumbs: { display: 'flex', alignItems: 'center', gap: space.sm, fontSize: text.sm.fontSize, color: tk.muted },
+  crumbLink: { background: 'transparent', border: 'none', color: tk.muted, cursor: 'pointer', fontSize: text.sm.fontSize, padding: 0 },
+  header: { display: 'flex', alignItems: 'center', gap: space.lg, flexWrap: 'wrap' },
+  name: { fontSize: 24, fontWeight: 800, margin: 0, letterSpacing: -0.4, color: tk.text },
+  role: { fontSize: text.sm.fontSize, color: tk.muted, marginTop: 2 },
+  actions: { display: 'flex', alignItems: 'center', gap: space.sm, marginLeft: 'auto', flexWrap: 'wrap' },
+  tabbar: { display: 'flex', gap: space.xl, borderBottom: `1px solid ${tk.line}`, overflowX: 'auto' },
+  tab: { background: 'transparent', border: 'none', borderBottom: '2px solid transparent', color: tk.muted, cursor: 'pointer', fontSize: text.md.fontSize, fontWeight: 600, padding: `${space.sm}px 0`, whiteSpace: 'nowrap' },
+  tabOn: { color: tk.text, borderBottomColor: tk.accent },
+  sectionTitle: { fontSize: text.md.fontSize, fontWeight: 700, color: tk.text, margin: 0 },
+  empty: { color: tk.muted, fontSize: text.sm.fontSize, margin: 0 },
+  err: { background: 'var(--danger-bg)', border: '1px solid var(--danger-line)', color: tk.red, borderRadius: tk.r.md, padding: `${space.sm}px ${space.lg}px`, fontSize: text.md.fontSize },
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -10,7 +10,9 @@ import TaskDrawer from './TaskDrawer'
 import GovernancePanel from './GovernancePanel'
 import Sidebar from './Sidebar'
 import PlaceholderView from './PlaceholderView'
+import AgentDetail from './agent/AgentDetail'
 import { allNavItems, isPlaceholder, isSection, navSectionKey, findNavItem } from '@/lib/navModel'
+import { agentRouteHash, parseAgentRoute, type AgentRoute, type AgentTab } from '@/lib/agentRoute'
 import { useTheme } from '../theme'
 import { CommandPalette, type Command } from './CommandPalette'
 import { statusColor, statusIcon } from './status'
@@ -55,6 +57,9 @@ export default function DashboardPage() {
   const [jiraConnected, setJiraConnected] = useState(false)
   const [usage, setUsage] = useState<UsageStats | null>(null)
   const [tab, setTab] = useState<string>('overview')
+  // AG1 — the agent detail page lives inside the `agents` area and deep-links
+  // through the URL hash (#agents/<id>/<tab>), parsed by the pure lib/agentRoute.
+  const [agentRoute, setAgentRoute] = useState<AgentRoute | null>(null)
   const [loading, setLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
   // Org creation (web onboarding — backend auto-creates Arturito on first org)
@@ -100,6 +105,33 @@ export default function DashboardPage() {
   }, [getToken])
 
   useEffect(() => { if (!isLoaded) return; if (!isSignedIn) { router.push('/'); return }; load() }, [isLoaded, isSignedIn])
+
+  // AG1 — hash → agent route. A deep link (or Back/Forward) lands on the agent
+  // detail page with the Agents area selected; no hash = the agent list.
+  useEffect(() => {
+    const sync = () => {
+      const r = parseAgentRoute(window.location.hash)
+      setAgentRoute(r)
+      if (r) setTab('agents')
+    }
+    sync()
+    window.addEventListener('hashchange', sync)
+    return () => window.removeEventListener('hashchange', sync)
+  }, [])
+
+  const openAgent = useCallback((agentId: string, at: AgentTab = 'dashboard') => {
+    window.location.hash = agentRouteHash(agentId, at)
+  }, [])
+
+  // Leaving the detail page drops the hash without pushing a history entry
+  // (replaceState fires no hashchange, so clear the state ourselves).
+  const closeAgent = useCallback(() => {
+    window.history.replaceState(null, '', window.location.pathname + window.location.search)
+    setAgentRoute(null)
+  }, [])
+
+  // Any nav selection leaves the agent detail page behind.
+  const selectTab = useCallback((t: string) => { closeAgent(); setTab(t) }, [closeAgent])
 
   // Model catalogue for the org-creation picker (data-driven from the backend)
   useEffect(() => {
@@ -289,7 +321,9 @@ export default function DashboardPage() {
   // Paperclip-style nav model (P0a); selecting a "coming soon" area lands on its
   // placeholder view. Epic V extends this list (jump to task/agent/approval).
   const commands: Command[] = [
-    ...allNavItems().map(n => ({ id: `nav-${n.id}`, label: n.kind === 'placeholder' ? `${n.label} (soon)` : n.label, icon: n.icon, group: 'Navigate', keywords: `go to open view tab ${n.paperclip}`, run: () => setTab(n.id) })),
+    ...allNavItems().map(n => ({ id: `nav-${n.id}`, label: n.kind === 'placeholder' ? `${n.label} (soon)` : n.label, icon: n.icon, group: 'Navigate', keywords: `go to open view tab ${n.paperclip}`, run: () => selectTab(n.id) })),
+    // AG1 — jump straight to an agent's detail page.
+    ...agents.map(a => ({ id: `agent-${a.id}`, label: a.name, icon: a.avatarEmoji || '🤖', group: 'Agents', keywords: `agent open ${a.role}`, run: () => openAgent(a.id) })),
     { id: 'theme-light', label: 'Light theme', icon: '☀', group: 'Theme', keywords: 'appearance mode', run: () => setMode('light') },
     { id: 'theme-dark', label: 'Dark theme', icon: '☾', group: 'Theme', keywords: 'appearance mode', run: () => setMode('dark') },
     { id: 'theme-system', label: 'System theme', icon: '🖥', group: 'Theme', keywords: 'appearance mode auto', run: () => setMode('system') },
@@ -299,7 +333,7 @@ export default function DashboardPage() {
     <div className="mc-layout" style={s.layout}>
       <CommandPalette commands={commands} open={paletteOpen} onOpenChange={setPaletteOpen} />
       {/* P0a — Paperclip-style folded, grouped, collapsible nav rail. */}
-      <Sidebar orgName={org.name} selected={tab} onSelect={setTab} onOpenPalette={() => setPaletteOpen(true)} unread={unread} />
+      <Sidebar orgName={org.name} selected={tab} onSelect={selectTab} onOpenPalette={() => setPaletteOpen(true)} unread={unread} />
 
       <main className="mc-main" style={s.main}>
 
@@ -355,13 +389,19 @@ export default function DashboardPage() {
           </div>
         )}
 
-        {tab === 'agents' && (
+        {/* AG1 — the Agents area is either the roster or one agent's detail page. */}
+        {tab === 'agents' && (agentRoute
+          ? <AgentDetail orgId={org.id} agentId={agentRoute.agentId} tab={agentRoute.tab} getToken={getToken}
+              onTab={t => openAgent(agentRoute.agentId, t)} onBack={closeAgent} />
+          : (
           <div style={s.page}>
             <h1 style={s.h1}>Agents ({agents.length})</h1>
             <div style={s.table}>
               <div style={{ ...s.thead, gridTemplateColumns: '2fr 2fr 1.5fr 1fr 1fr' }}><span>Name</span><span>Role</span><span>Model</span><span>Skills</span><span>Status</span></div>
               {agents.map(a => (
-                <div key={a.id} style={{ ...s.trow, gridTemplateColumns: '2fr 2fr 1.5fr 1fr 1fr' }}>
+                <div key={a.id} role="button" tabIndex={0} aria-label={`Open ${a.name}`}
+                  onClick={() => openAgent(a.id)} onKeyDown={e => { if (e.key === 'Enter') openAgent(a.id) }}
+                  style={{ ...s.trow, gridTemplateColumns: '2fr 2fr 1.5fr 1fr 1fr', cursor: 'pointer' }}>
                   <span>{a.avatarEmoji} {a.name}</span><span style={{ color: 'var(--muted)', fontSize: 13 }}>{a.role}</span>
                   <span style={{ color: 'var(--muted)', fontSize: 12 }}>{a.llmModel.split('-').slice(0, 3).join('-')}</span>
                   <span style={{ color: 'var(--muted)', fontSize: 12 }}>{a.skills.length}</span>
@@ -370,7 +410,7 @@ export default function DashboardPage() {
               ))}
             </div>
           </div>
-        )}
+        ))}
 
         {tab === 'tasks' && (
           <div style={s.page}>

--- a/web/lib/agentRoute.test.ts
+++ b/web/lib/agentRoute.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { AGENT_TABS, AGENT_TAB_LABEL, DEFAULT_AGENT_TAB, agentRouteHash, isAgentTab, parseAgentRoute } from './agentRoute.ts'
+
+test('[AG1] the six Paperclip agent tabs are exposed in render order, each with a label', () => {
+  assert.deepEqual([...AGENT_TABS], ['dashboard', 'instructions', 'skills', 'configuration', 'runs', 'budget'])
+  for (const t of AGENT_TABS) assert.ok(AGENT_TAB_LABEL[t], `missing label for ${t}`)
+})
+
+test('[AG1] isAgentTab accepts only known tabs', () => {
+  assert.equal(isAgentTab('runs'), true)
+  assert.equal(isAgentTab('memory'), false)
+  assert.equal(isAgentTab(''), false)
+})
+
+test('[AG1] parseAgentRoute reads #agents/<id>/<tab>', () => {
+  assert.deepEqual(parseAgentRoute('#agents/a-1/skills'), { agentId: 'a-1', tab: 'skills' })
+  assert.deepEqual(parseAgentRoute('agents/a-1/budget'), { agentId: 'a-1', tab: 'budget' })
+})
+
+test('[AG1] a missing or unknown tab falls back to the default tab, never to null', () => {
+  assert.deepEqual(parseAgentRoute('#agents/a-1'), { agentId: 'a-1', tab: DEFAULT_AGENT_TAB })
+  assert.deepEqual(parseAgentRoute('#agents/a-1/'), { agentId: 'a-1', tab: DEFAULT_AGENT_TAB })
+  assert.deepEqual(parseAgentRoute('#agents/a-1/nope'), { agentId: 'a-1', tab: DEFAULT_AGENT_TAB })
+})
+
+test('[AG1] a hash that does not address an agent parses to null (caller shows the list)', () => {
+  assert.equal(parseAgentRoute('#tasks/t-1'), null)
+  assert.equal(parseAgentRoute('#agents'), null)
+  assert.equal(parseAgentRoute('#agents/'), null)
+  assert.equal(parseAgentRoute(''), null)
+  assert.equal(parseAgentRoute(null), null)
+  assert.equal(parseAgentRoute(undefined), null)
+})
+
+test('[AG1] agentRouteHash round-trips through parseAgentRoute', () => {
+  for (const tab of AGENT_TABS) {
+    assert.deepEqual(parseAgentRoute(agentRouteHash('agent-42', tab)), { agentId: 'agent-42', tab })
+  }
+  assert.equal(agentRouteHash('agent-42'), '#agents/agent-42/dashboard')
+})
+
+test('[AG1] ids with URL-unsafe characters survive the round trip', () => {
+  const id = 'agent/with spaces#and?chars'
+  const hash = agentRouteHash(id, 'runs')
+  assert.ok(!hash.includes(' '), 'hash must be encoded')
+  assert.deepEqual(parseAgentRoute(hash), { agentId: id, tab: 'runs' })
+})

--- a/web/lib/agentRoute.ts
+++ b/web/lib/agentRoute.ts
@@ -1,0 +1,53 @@
+// Epic AG / AG1 — agent detail routing (pure, no React).
+//
+// The dashboard is a single Next.js route with a `tab` state (see navModel.ts),
+// so the agent detail page lives inside the `agents` area and deep-links through
+// the URL hash: `#agents/<agentId>/<tab>`. Keeping parse/serialize pure means the
+// routing contract is unit-testable under `node --test` (web has no jest/vitest)
+// and the page only wires it to `location.hash`.
+
+export const AGENT_TABS = ['dashboard', 'instructions', 'skills', 'configuration', 'runs', 'budget'] as const
+
+export type AgentTab = (typeof AGENT_TABS)[number]
+
+/** Tab bar labels, in render order (mirrors the Paperclip agent page). */
+export const AGENT_TAB_LABEL: Record<AgentTab, string> = {
+  dashboard: 'Dashboard',
+  instructions: 'Instructions',
+  skills: 'Skills',
+  configuration: 'Configuration',
+  runs: 'Runs',
+  budget: 'Budget',
+}
+
+export const DEFAULT_AGENT_TAB: AgentTab = 'dashboard'
+
+export interface AgentRoute {
+  agentId: string
+  tab: AgentTab
+}
+
+export function isAgentTab(value: string): value is AgentTab {
+  return (AGENT_TABS as readonly string[]).includes(value)
+}
+
+/**
+ * Parse a location hash into an agent route. Returns null when the hash does not
+ * address an agent (so the caller falls back to the agent list). An unknown or
+ * missing tab segment resolves to the default tab rather than failing — a stale
+ * bookmark should still land on the agent.
+ */
+export function parseAgentRoute(hash: string | null | undefined): AgentRoute | null {
+  const raw = (hash ?? '').replace(/^#/, '')
+  const parts = raw.split('/').filter(Boolean)
+  if (parts[0] !== 'agents') return null
+  const agentId = parts[1]
+  if (!agentId) return null
+  const tab = parts[2]
+  return { agentId: decodeURIComponent(agentId), tab: tab && isAgentTab(tab) ? tab : DEFAULT_AGENT_TAB }
+}
+
+/** Serialize an agent route back to a location hash (inverse of parseAgentRoute). */
+export function agentRouteHash(agentId: string, tab: AgentTab = DEFAULT_AGENT_TAB): string {
+  return `#agents/${encodeURIComponent(agentId)}/${tab}`
+}


### PR DESCRIPTION
**Epic AG — Agents experience**, story 1 of 7. Stages the per-agent detail page mirroring the operator's Paperclip mockups.

## What's in it
- **`web/lib/agentRoute.ts`** — pure routing contract: `#agents/<agentId>/<tab>`. Parse/serialize, unknown-tab fallback (a stale bookmark still lands on the agent), URL-safe ids. **7 new web tests.**
- **`AgentDetail.tsx`** — the shell: breadcrumb, avatar, name, role/title, **colorblind-safe status pill** (icon + text label + color, never color alone), header actions (Assign Task modal → `POST /orgs/:orgId/tasks`, Run Heartbeat → org sweep, Pause/Resume), and the six-tab bar.
- **`agent/shared.tsx`** — `AgentAvatar` renders an uploaded picture when present and falls back to the icon/emoji (AG5 adds the upload), plus shared token-fed styles.
- Roster rows are now keyboard-focusable buttons that open the detail page; the ⌘K palette gains an **Agents** group.

Tab panels are honest stubs — each lands in its own story (AG2 Dashboard, AG3 Instructions, AG4 Skills, AG5 Configuration+avatar, AG6 Runs/Budget, AG7 Staff grid).

## Verify
- `web`: **119 tests pass** (was 112), `tsc --noEmit` clean, `npm run build` ✅
- `backend`: untouched — 934 tests still green.
- Design tokens only (no raw hex); Glassmorphism preserved (reuses `mc-glass` Modal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)