### PR TITLE
feat(AG2): agent Dashboard tab — latest run, 14-day charts, recent tasks, real costs

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -110,6 +110,12 @@ export const tasks = sqliteTable('tasks', {
   kanbanColumn: text('kanban_column').default('todo'),
   llmModel: text('llm_model'),
   tokensUsed: integer('tokens_used'),
+  // Epic AG / AG2 — the token split behind `tokens_used` (which stays the total,
+  // unchanged). Null on tasks that predate the split; the agent Costs strip
+  // shows "—" rather than a fake 0 when nothing carries it.
+  inputTokens: integer('input_tokens'),
+  outputTokens: integer('output_tokens'),
+  cachedTokens: integer('cached_tokens'),
   costUsd: real('cost_usd'),
   durationMs: integer('duration_ms'),
   assignedTo: text('assigned_to'),

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -159,6 +159,12 @@ export async function setupDatabase() {
     `ALTER TABLE agents ADD COLUMN cheap_model TEXT`,
     `ALTER TABLE agents ADD COLUMN cheap_model_enabled INTEGER NOT NULL DEFAULT 0`,
     `ALTER TABLE agents ADD COLUMN reasoning_effort TEXT`,
+    // Epic AG / AG2 — per-task token split for the agent Costs strip. `tokens_used`
+    // remains the total and is untouched; these are nullable so every existing task
+    // stays exactly as it is (null = "recorded before the split", rendered as —).
+    `ALTER TABLE tasks ADD COLUMN input_tokens INTEGER`,
+    `ALTER TABLE tasks ADD COLUMN output_tokens INTEGER`,
+    `ALTER TABLE tasks ADD COLUMN cached_tokens INTEGER`,
   ]
   for (const sql of alterStatements) {
     try { await dbClient.execute(sql) } catch { /* column already exists */ }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import { multiOrgRoutes } from './routes/multi-org'
 import { usageRoutes } from './middleware/ratelimit'
 import { modelRoutes } from './routes/models'
 import { scheduledRoutes, routineTriggerRoutes } from './routes/scheduled'
+import { agentDetailRoutes } from './routes/agent-detail'
 import { webhookRoutes } from './routes/webhooks'
 import { telegramWebhookRoutes } from './routes/telegram-webhook'
 import { arturitaRoutes, arturitaPublicRoutes } from './routes/arturita'
@@ -84,6 +85,7 @@ async function start() {
     secured.addHook('onRoute', (r) => recordRoute('clerk', r.method, r.url))
     await secured.register(orgRoutes)
     await secured.register(agentRoutes)
+    await secured.register(agentDetailRoutes)   // Epic AG — per-agent detail page (org-scoped)
     await secured.register(taskRoutes)
     await secured.register(projectRoutes)
     await secured.register(costRoutes)

--- a/backend/src/routes/agent-detail.ts
+++ b/backend/src/routes/agent-detail.ts
@@ -1,0 +1,64 @@
+// Epic AG — routes behind the per-agent detail page. Everything here is
+// org-scoped (`/api/orgs/:orgId/agents/:agentId/...`) so `requireOrgRole` can
+// actually gate it — the RBAC helper reads `:orgId` from the path and silently
+// no-ops without it, which is why these do NOT live under `/api/agents/:id/...`.
+//
+// Aggregation is pure (`services/agent-overview.ts`); these handlers only fetch
+// rows and hand them over.
+import type { FastifyInstance } from 'fastify'
+import { and, desc, eq } from 'drizzle-orm'
+import { db, schema } from '../db/client'
+import { buildAgentOverview, OVERVIEW_DAYS } from '../services/agent-overview'
+
+/** The agent, but only if it belongs to this org. Null otherwise (→ 404). */
+export async function agentInOrg(orgId: string, agentId: string) {
+  const agent = await db.query.agents.findFirst({
+    where: and(eq(schema.agents.id, agentId), eq(schema.agents.orgId, orgId)),
+  })
+  return agent ?? null
+}
+
+export async function agentDetailRoutes(app: FastifyInstance) {
+  // AG2 — Dashboard tab: latest run, 14-day charts, recent tasks, costs.
+  app.get('/api/orgs/:orgId/agents/:agentId/overview', async (req, reply) => {
+    const { orgId, agentId } = req.params as { orgId: string; agentId: string }
+    const agent = await agentInOrg(orgId, agentId)
+    if (!agent) return reply.code(404).send({ error: 'Agent not found' })
+
+    const windowStart = new Date(Date.now() - OVERVIEW_DAYS * 86_400_000)
+
+    const [runs, tasks] = await Promise.all([
+      db.select().from(schema.agentRuns)
+        .where(and(eq(schema.agentRuns.orgId, orgId), eq(schema.agentRuns.agentId, agentId)))
+        .orderBy(desc(schema.agentRuns.startedAt)).limit(200),
+      db.select().from(schema.tasks)
+        .where(and(eq(schema.tasks.orgId, orgId), eq(schema.tasks.agentId, agentId)))
+        .orderBy(desc(schema.tasks.createdAt)).limit(200),
+    ])
+
+    // Charts cover the window; the Costs strip covers the same window's tasks so
+    // the numbers on screen belong to the period the charts claim to show.
+    const windowTasks = tasks.filter(t => (t.createdAt?.getTime() ?? 0) >= windowStart.getTime())
+
+    return {
+      overview: buildAgentOverview({ agentId, runs, tasks: windowTasks, now: Date.now() }),
+      // Recent tasks are the agent's newest overall, not window-clipped — an idle
+      // agent should still show what it last worked on.
+      recentTasks: buildAgentOverview({ agentId, runs: [], tasks, now: Date.now() }).recentTasks,
+    }
+  })
+
+  // AG2/AG6 — the agent's run history (there was only a per-task runs route).
+  app.get('/api/orgs/:orgId/agents/:agentId/runs', async (req, reply) => {
+    const { orgId, agentId } = req.params as { orgId: string; agentId: string }
+    const { limit } = req.query as { limit?: string }
+    const agent = await agentInOrg(orgId, agentId)
+    if (!agent) return reply.code(404).send({ error: 'Agent not found' })
+
+    const n = Math.min(Math.max(Number(limit) || 50, 1), 200)
+    const runs = await db.select().from(schema.agentRuns)
+      .where(and(eq(schema.agentRuns.orgId, orgId), eq(schema.agentRuns.agentId, agentId)))
+      .orderBy(desc(schema.agentRuns.startedAt)).limit(n)
+    return { runs }
+  })
+}

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -300,6 +300,9 @@ export async function executeAgentTask(opts: {
 
     await db.update(schema.tasks).set({
       output: cleanedOutput, status: 'done', tokensUsed, costUsd,
+      // AG2 — persist the split behind the total so the agent Costs strip is real.
+      inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens,
+      cachedTokens: result.usage.cachedTokens ?? 0,
       durationMs, llmModel: usedModel, completedAt: new Date(),
     }).where(eq(schema.tasks.id, taskId))
     await db.update(schema.agents).set({ status: 'idle' }).where(eq(schema.agents.id, agentId))
@@ -415,7 +418,11 @@ export async function answerAskTask(opts: {
       kind: ASK_ANSWER_KIND, body: answer.slice(0, 8000), createdAt: new Date(),
     }).catch(() => {})
     await db.update(schema.tasks).set({
-      output: answer, status: 'done', tokensUsed, costUsd, durationMs, llmModel: model, completedAt: new Date(),
+      output: answer, status: 'done', tokensUsed, costUsd,
+      // AG2 — same split as the execute path above (ask-mode turns count too).
+      inputTokens: result.usage.inputTokens, outputTokens: result.usage.outputTokens,
+      cachedTokens: result.usage.cachedTokens ?? 0,
+      durationMs, llmModel: model, completedAt: new Date(),
     }).where(eq(schema.tasks.id, taskId))
     await db.update(schema.agents).set({ status: 'idle' }).where(eq(schema.agents.id, agent.id))
 

--- a/backend/src/services/agent-overview.ts
+++ b/backend/src/services/agent-overview.ts
@@ -1,0 +1,202 @@
+// Epic AG / AG2 — per-agent Dashboard tab data, as pure functions.
+//
+// The route hands raw `agent_runs` + `tasks` rows to `buildAgentOverview` and
+// returns the result verbatim, so every aggregation below is unit-testable with
+// no DB. Nothing here queries or mutates.
+//
+// Colorblind-safety note: this layer never picks colors — it returns counts
+// keyed by status/priority and the UI maps them through the design-system status
+// table (icon + label + color, never color alone).
+
+export type Ts = number | string | Date | null | undefined
+
+export interface RunLite {
+  id: string
+  status: string // running | done | failed | orphaned
+  taskId?: string | null
+  logs?: unknown // JSON array of { t, msg } — the last entry is the run summary
+  tokensUsed?: number | null
+  costUsd?: number | null
+  startedAt?: Ts
+  endedAt?: Ts
+}
+
+export interface TaskLite {
+  id: string
+  title: string
+  status: string
+  priority?: string | null
+  createdAt?: Ts
+  tokensUsed?: number | null
+  costUsd?: number | null
+  inputTokens?: number | null
+  outputTokens?: number | null
+  cachedTokens?: number | null
+}
+
+export const OVERVIEW_DAYS = 14
+
+/** Milliseconds since epoch, or null when the value is absent/unparseable. */
+export function toMs(v: Ts): number | null {
+  if (v == null) return null
+  if (v instanceof Date) return Number.isNaN(v.getTime()) ? null : v.getTime()
+  if (typeof v === 'number') return Number.isFinite(v) ? (v < 1e12 ? v * 1000 : v) : null // tolerate seconds
+  const t = Date.parse(v)
+  return Number.isNaN(t) ? null : t
+}
+
+/** UTC day key (YYYY-MM-DD) for a timestamp. */
+export function dayKey(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10)
+}
+
+/** The `days` UTC day keys ending today, oldest first. */
+export function dayKeys(now: number, days: number = OVERVIEW_DAYS): string[] {
+  const out: string[] = []
+  for (let i = days - 1; i >= 0; i--) out.push(dayKey(now - i * 86_400_000))
+  return out
+}
+
+const isSuccess = (status: string) => status === 'done'
+const isFailure = (status: string) => status === 'failed' || status === 'orphaned'
+
+/** Runs per day over the window: total, succeeded, failed (failed includes orphaned). */
+export function runActivity(runs: RunLite[], now: number, days: number = OVERVIEW_DAYS) {
+  const keys = dayKeys(now, days)
+  const index = new Map(keys.map(k => [k, { date: k, total: 0, succeeded: 0, failed: 0 }]))
+  for (const r of runs) {
+    const ms = toMs(r.startedAt)
+    if (ms == null) continue
+    const bucket = index.get(dayKey(ms))
+    if (!bucket) continue // outside the window
+    bucket.total++
+    if (isSuccess(r.status)) bucket.succeeded++
+    else if (isFailure(r.status)) bucket.failed++
+  }
+  return keys.map(k => index.get(k)!)
+}
+
+/**
+ * Success rate per day: succeeded / (succeeded + failed). `pct` is null on a day
+ * with no *settled* run — an empty day is "no data", not 0%, and the UI must
+ * render the gap rather than a zero bar.
+ */
+export function successRate(runs: RunLite[], now: number, days: number = OVERVIEW_DAYS) {
+  return runActivity(runs, now, days).map(d => {
+    const settled = d.succeeded + d.failed
+    return { date: d.date, pct: settled === 0 ? null : Math.round((d.succeeded / settled) * 100), settled }
+  })
+}
+
+/** Counts keyed by a field, descending by count then key (stable output order). */
+export function countBy<T>(items: T[], pick: (item: T) => string | null | undefined, fallback = 'unknown') {
+  const counts = new Map<string, number>()
+  for (const it of items) {
+    const k = pick(it) || fallback
+    counts.set(k, (counts.get(k) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .map(([key, count]) => ({ key, count }))
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key))
+}
+
+/**
+ * Token + cost totals for the Costs strip. The input/output/cached split is
+ * persisted per task from AG2 onward; tasks that predate it carry only the
+ * summed `tokensUsed`, so `totalTokens` stays truthful while the split reads 0.
+ */
+export function costTotals(tasks: TaskLite[]) {
+  let inputTokens = 0, outputTokens = 0, cachedTokens = 0, totalTokens = 0, totalCostUsd = 0
+  for (const t of tasks) {
+    inputTokens += t.inputTokens ?? 0
+    outputTokens += t.outputTokens ?? 0
+    cachedTokens += t.cachedTokens ?? 0
+    totalTokens += t.tokensUsed ?? 0
+    totalCostUsd += t.costUsd ?? 0
+  }
+  return {
+    inputTokens, outputTokens, cachedTokens, totalTokens,
+    // Float noise (0.1 + 0.2) has no business in a money field.
+    totalCostUsd: Math.round(totalCostUsd * 1e6) / 1e6,
+    taskCount: tasks.length,
+    /** False when no task carries the split — the UI shows "—" instead of a fake 0. */
+    hasSplit: inputTokens + outputTokens + cachedTokens > 0,
+  }
+}
+
+/** One-line summary of a run: its last log line, else its status. */
+export function runSummary(run: RunLite, maxLen = 240): string {
+  let logs: unknown = run.logs
+  if (typeof logs === 'string') { try { logs = JSON.parse(logs) } catch { logs = null } }
+  const last = Array.isArray(logs) ? [...logs].reverse().find(l => typeof (l as any)?.msg === 'string' && (l as any).msg.trim()) : null
+  const msg = last ? String((last as any).msg).trim() : ''
+  const text = msg || `Run ${run.status}.`
+  return text.length > maxLen ? `${text.slice(0, maxLen - 1)}…` : text
+}
+
+/** Newest run by startedAt (undated runs sort last). */
+export function latestRun(runs: RunLite[]): RunLite | null {
+  let best: RunLite | null = null
+  let bestMs = -Infinity
+  for (const r of runs) {
+    const ms = toMs(r.startedAt) ?? -Infinity
+    if (ms > bestMs) { best = r; bestMs = ms }
+  }
+  return best
+}
+
+export interface AgentOverview {
+  agentId: string
+  days: number
+  generatedAt: string
+  latestRun: { id: string; status: string; taskId: string | null; summary: string; startedAt: number | null; endedAt: number | null } | null
+  runActivity: { date: string; total: number; succeeded: number; failed: number }[]
+  successRate: { date: string; pct: number | null; settled: number }[]
+  tasksByPriority: { key: string; count: number }[]
+  tasksByStatus: { key: string; count: number }[]
+  recentTasks: { id: string; title: string; status: string; priority: string; createdAt: number | null }[]
+  costs: ReturnType<typeof costTotals>
+}
+
+/**
+ * The whole Dashboard-tab payload. `tasks` are the agent's tasks (newest first
+ * is not assumed — we sort); `runs` are the agent's runs. Both are already
+ * org-scoped by the caller.
+ */
+export function buildAgentOverview(input: {
+  agentId: string
+  runs: RunLite[]
+  tasks: TaskLite[]
+  now: number
+  days?: number
+  recentLimit?: number
+}): AgentOverview {
+  const { agentId, runs, tasks, now } = input
+  const days = input.days ?? OVERVIEW_DAYS
+  const recentLimit = input.recentLimit ?? 6
+
+  const newest = latestRun(runs)
+  const byNewest = [...tasks].sort((a, b) => (toMs(b.createdAt) ?? 0) - (toMs(a.createdAt) ?? 0))
+
+  return {
+    agentId,
+    days,
+    generatedAt: new Date(now).toISOString(),
+    latestRun: newest ? {
+      id: newest.id,
+      status: newest.status,
+      taskId: newest.taskId ?? null,
+      summary: runSummary(newest),
+      startedAt: toMs(newest.startedAt),
+      endedAt: toMs(newest.endedAt),
+    } : null,
+    runActivity: runActivity(runs, now, days),
+    successRate: successRate(runs, now, days),
+    tasksByPriority: countBy(tasks, t => t.priority, 'medium'),
+    tasksByStatus: countBy(tasks, t => t.status, 'pending'),
+    recentTasks: byNewest.slice(0, recentLimit).map(t => ({
+      id: t.id, title: t.title, status: t.status, priority: t.priority || 'medium', createdAt: toMs(t.createdAt),
+    })),
+    costs: costTotals(tasks),
+  }
+}

--- a/backend/src/services/llm-router.ts
+++ b/backend/src/services/llm-router.ts
@@ -26,7 +26,10 @@ export interface LLMStreamOpts {
   reasoningEffort?: 'low' | 'medium' | 'high'
 }
 
-export interface LLMUsage { inputTokens: number; outputTokens: number }
+// AG2: `cachedTokens` = prompt-cache reads, reported by providers that support
+// them (Anthropic today). Optional — absent means "provider does not report it",
+// which the Costs strip renders as — rather than 0.
+export interface LLMUsage { inputTokens: number; outputTokens: number; cachedTokens?: number }
 
 export interface LLMResult {
   output: string
@@ -149,7 +152,13 @@ async function streamAnthropic(opts: LLMStreamOpts): Promise<LLMResult> {
   const final = await stream.finalMessage()
   return {
     output, model: opts.model, provider: 'anthropic',
-    usage: { inputTokens: final.usage.input_tokens, outputTokens: final.usage.output_tokens },
+    // AG2: cache reads are reported separately by Anthropic and are NOT part of
+    // input_tokens — surfaced for the agent Costs strip, not added to the total.
+    usage: {
+      inputTokens: final.usage.input_tokens,
+      outputTokens: final.usage.output_tokens,
+      cachedTokens: (final.usage as any).cache_read_input_tokens ?? 0,
+    },
   }
 }
 

--- a/backend/src/tests/agent-overview.test.ts
+++ b/backend/src/tests/agent-overview.test.ts
@@ -1,0 +1,192 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildAgentOverview, costTotals, countBy, dayKey, dayKeys, latestRun, runActivity, runSummary, successRate, toMs,
+  type RunLite, type TaskLite,
+} from '../services/agent-overview'
+
+// A fixed clock so day bucketing is deterministic.
+const NOW = Date.parse('2026-07-14T12:00:00.000Z')
+const day = (offset: number) => NOW - offset * 86_400_000
+
+const run = (over: Partial<RunLite> = {}): RunLite => ({ id: 'r1', status: 'done', startedAt: new Date(NOW), ...over })
+const task = (over: Partial<TaskLite> = {}): TaskLite => ({ id: 't1', title: 'T', status: 'done', priority: 'medium', createdAt: new Date(NOW), ...over })
+
+describe('[AG2] toMs / dayKey / dayKeys', () => {
+  it('normalises Date, ms, seconds and ISO strings', () => {
+    assert.equal(toMs(new Date(NOW)), NOW)
+    assert.equal(toMs(NOW), NOW)
+    assert.equal(toMs(Math.floor(NOW / 1000)), NOW) // seconds are widened to ms
+    assert.equal(toMs('2026-07-14T12:00:00.000Z'), NOW)
+  })
+
+  it('returns null for absent or unparseable values', () => {
+    assert.equal(toMs(null), null)
+    assert.equal(toMs(undefined), null)
+    assert.equal(toMs('not a date'), null)
+    assert.equal(toMs(new Date('nope')), null)
+  })
+
+  it('dayKeys returns `days` UTC keys ending today, oldest first', () => {
+    const keys = dayKeys(NOW, 14)
+    assert.equal(keys.length, 14)
+    assert.equal(keys[13], '2026-07-14')
+    assert.equal(keys[0], '2026-07-01')
+    assert.equal(dayKey(NOW), '2026-07-14')
+  })
+})
+
+describe('[AG2] runActivity', () => {
+  it('buckets runs per day and splits succeeded vs failed', () => {
+    const runs = [
+      run({ id: 'a', status: 'done', startedAt: new Date(day(0)) }),
+      run({ id: 'b', status: 'failed', startedAt: new Date(day(0)) }),
+      run({ id: 'c', status: 'orphaned', startedAt: new Date(day(0)) }), // orphaned counts as failed
+      run({ id: 'd', status: 'running', startedAt: new Date(day(1)) }),  // counted in total, neither bucket
+      run({ id: 'e', status: 'done', startedAt: new Date(day(3)) }),
+    ]
+    const series = runActivity(runs, NOW, 14)
+    const today = series.at(-1)!
+    assert.deepEqual(today, { date: '2026-07-14', total: 3, succeeded: 1, failed: 2 })
+    assert.deepEqual(series.at(-2), { date: '2026-07-13', total: 1, succeeded: 0, failed: 0 })
+    assert.equal(series.find(d => d.date === '2026-07-11')!.total, 1)
+  })
+
+  it('always emits one entry per day, zero-filled, in chronological order', () => {
+    const series = runActivity([], NOW, 14)
+    assert.equal(series.length, 14)
+    assert.ok(series.every(d => d.total === 0))
+    assert.deepEqual(series.map(d => d.date), dayKeys(NOW, 14))
+  })
+
+  it('drops runs outside the window and runs with no start time', () => {
+    const runs = [run({ startedAt: new Date(day(30)) }), run({ startedAt: null })]
+    assert.equal(runActivity(runs, NOW, 14).reduce((s, d) => s + d.total, 0), 0)
+  })
+})
+
+describe('[AG2] successRate', () => {
+  it('is succeeded / settled, ignoring still-running runs', () => {
+    const runs = [
+      run({ status: 'done', startedAt: new Date(day(0)) }),
+      run({ status: 'done', startedAt: new Date(day(0)) }),
+      run({ status: 'failed', startedAt: new Date(day(0)) }),
+      run({ status: 'running', startedAt: new Date(day(0)) }), // not settled → excluded
+    ]
+    const today = successRate(runs, NOW, 14).at(-1)!
+    assert.equal(today.settled, 3)
+    assert.equal(today.pct, 67)
+  })
+
+  it('reports null (no data) — not 0% — on a day with no settled run', () => {
+    const today = successRate([run({ status: 'running', startedAt: new Date(day(0)) })], NOW, 14).at(-1)!
+    assert.equal(today.pct, null)
+    assert.equal(successRate([], NOW, 14).every(d => d.pct === null), true)
+  })
+})
+
+describe('[AG2] countBy', () => {
+  it('counts by key, descending by count then key', () => {
+    const tasks = [task({ priority: 'high' }), task({ priority: 'low' }), task({ priority: 'high' })]
+    assert.deepEqual(countBy(tasks, t => t.priority), [{ key: 'high', count: 2 }, { key: 'low', count: 1 }])
+  })
+
+  it('folds null/empty keys into the fallback', () => {
+    assert.deepEqual(countBy([task({ priority: null }), task({ priority: '' })], t => t.priority, 'medium'), [{ key: 'medium', count: 2 }])
+  })
+})
+
+describe('[AG2] costTotals', () => {
+  it('sums the token split and the cost, and rounds money to 6dp', () => {
+    const c = costTotals([
+      task({ inputTokens: 100, outputTokens: 40, cachedTokens: 10, tokensUsed: 140, costUsd: 0.1 }),
+      task({ inputTokens: 50, outputTokens: 5, cachedTokens: 0, tokensUsed: 55, costUsd: 0.2 }),
+    ])
+    assert.equal(c.inputTokens, 150)
+    assert.equal(c.outputTokens, 45)
+    assert.equal(c.cachedTokens, 10)
+    assert.equal(c.totalTokens, 195)
+    assert.equal(c.totalCostUsd, 0.3) // not 0.30000000000000004
+    assert.equal(c.taskCount, 2)
+    assert.equal(c.hasSplit, true)
+  })
+
+  it('keeps totals truthful for tasks that predate the split, and flags hasSplit=false', () => {
+    const c = costTotals([task({ tokensUsed: 900, costUsd: 0.5 })]) // legacy row: no split columns
+    assert.equal(c.totalTokens, 900)
+    assert.equal(c.totalCostUsd, 0.5)
+    assert.equal(c.inputTokens, 0)
+    assert.equal(c.hasSplit, false)
+  })
+
+  it('is zero-safe for an agent that has never run', () => {
+    assert.deepEqual(costTotals([]), { inputTokens: 0, outputTokens: 0, cachedTokens: 0, totalTokens: 0, totalCostUsd: 0, taskCount: 0, hasSplit: false })
+  })
+})
+
+describe('[AG2] runSummary / latestRun', () => {
+  it('summarises a run from its last non-empty log line', () => {
+    assert.equal(runSummary(run({ logs: [{ t: 1, msg: 'started' }, { t: 2, msg: 'Verification passed.' }] })), 'Verification passed.')
+  })
+
+  it('parses logs stored as a JSON string, and falls back to the status', () => {
+    assert.equal(runSummary(run({ logs: JSON.stringify([{ t: 1, msg: 'from json' }]) })), 'from json')
+    assert.equal(runSummary(run({ status: 'failed', logs: [] })), 'Run failed.')
+    assert.equal(runSummary(run({ status: 'running', logs: 'not json' })), 'Run running.')
+  })
+
+  it('truncates a long summary', () => {
+    const s = runSummary(run({ logs: [{ t: 1, msg: 'x'.repeat(400) }] }))
+    assert.equal(s.length, 240)
+    assert.ok(s.endsWith('…'))
+  })
+
+  it('latestRun picks the newest by startedAt; null when there are none', () => {
+    const runs = [run({ id: 'old', startedAt: new Date(day(3)) }), run({ id: 'new', startedAt: new Date(day(0)) }), run({ id: 'undated', startedAt: null })]
+    assert.equal(latestRun(runs)?.id, 'new')
+    assert.equal(latestRun([]), null)
+  })
+})
+
+describe('[AG2] buildAgentOverview', () => {
+  it('assembles the whole Dashboard payload', () => {
+    const runs = [
+      run({ id: 'r-new', status: 'done', taskId: 't-2', logs: [{ t: 1, msg: 'All green.' }], startedAt: new Date(day(0)), endedAt: new Date(day(0) + 60_000) }),
+      run({ id: 'r-old', status: 'failed', startedAt: new Date(day(2)) }),
+    ]
+    const tasks = [
+      task({ id: 't-1', title: 'First', status: 'done', priority: 'high', createdAt: new Date(day(5)), tokensUsed: 10, costUsd: 0.01, inputTokens: 8, outputTokens: 2 }),
+      task({ id: 't-2', title: 'Second', status: 'in_progress', priority: 'high', createdAt: new Date(day(1)), tokensUsed: 20, costUsd: 0.02, inputTokens: 15, outputTokens: 5 }),
+    ]
+    const o = buildAgentOverview({ agentId: 'a-1', runs, tasks, now: NOW })
+
+    assert.equal(o.agentId, 'a-1')
+    assert.equal(o.days, 14)
+    assert.equal(o.latestRun?.id, 'r-new')
+    assert.equal(o.latestRun?.summary, 'All green.')
+    assert.equal(o.latestRun?.taskId, 't-2')
+    assert.equal(o.runActivity.length, 14)
+    assert.equal(o.successRate.length, 14)
+    assert.deepEqual(o.tasksByPriority, [{ key: 'high', count: 2 }])
+    assert.deepEqual(o.tasksByStatus, [{ key: 'done', count: 1 }, { key: 'in_progress', count: 1 }])
+    assert.equal(o.costs.totalTokens, 30)
+    assert.equal(o.costs.inputTokens, 23)
+    // Recent tasks are newest-first regardless of input order.
+    assert.deepEqual(o.recentTasks.map(t => t.id), ['t-2', 't-1'])
+  })
+
+  it('is safe for a brand-new agent with no runs and no tasks', () => {
+    const o = buildAgentOverview({ agentId: 'a-new', runs: [], tasks: [], now: NOW })
+    assert.equal(o.latestRun, null)
+    assert.deepEqual(o.recentTasks, [])
+    assert.deepEqual(o.tasksByPriority, [])
+    assert.equal(o.costs.totalCostUsd, 0)
+    assert.equal(o.runActivity.length, 14)
+  })
+
+  it('honours the recentLimit', () => {
+    const tasks = Array.from({ length: 20 }, (_, i) => task({ id: `t-${i}`, createdAt: new Date(day(i)) }))
+    assert.equal(buildAgentOverview({ agentId: 'a', runs: [], tasks, now: NOW }).recentTasks.length, 6)
+    assert.equal(buildAgentOverview({ agentId: 'a', runs: [], tasks, now: NOW, recentLimit: 3 }).recentTasks.length, 3)
+  })
+})

--- a/web/app/dashboard/agent/AgentDetail.tsx
+++ b/web/app/dashboard/agent/AgentDetail.tsx
@@ -9,14 +9,16 @@ import { Button, Card, Skeleton, TextInput } from '../ui'
 import { Modal, ModalTitle, FormLabel } from '../cockpit/shared'
 import { tk, text, space } from '../tokens'
 import { AgentAvatar, StatusPill, ax, type DAgent, type Getter } from './shared'
+import DashboardTab from './DashboardTab'
 
-export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getToken }: {
+export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getToken, onOpenTask }: {
   orgId: string
   agentId: string
   tab: AgentTab
   onTab: (t: AgentTab) => void
   onBack: () => void
   getToken: Getter
+  onOpenTask?: (taskId: string) => void
 }) {
   const [agent, setAgent] = useState<DAgent | null>(null)
   const [err, setErr] = useState<string | null>(null)
@@ -125,7 +127,10 @@ export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getTok
       </div>
 
       <div role="tabpanel" id={`agent-panel-${tab}`} aria-labelledby={`agent-tab-${tab}`}>
-        <TabPanel tab={tab} />
+        {tab === 'dashboard'
+          ? <DashboardTab orgId={orgId} agentId={agentId} getToken={getToken}
+              onViewRuns={() => onTab('runs')} onOpenTask={onOpenTask} />
+          : <TabPanel tab={tab} />}
       </div>
 
       {assignOpen && (
@@ -146,9 +151,9 @@ export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getTok
   )
 }
 
-// AG1 ships the shell; each tab's real panel lands in its own story (AG2–AG6).
+// Each tab's real panel lands in its own story (AG3–AG6); Dashboard shipped in AG2.
 const PENDING: Record<AgentTab, string> = {
-  dashboard: 'Latest run, run activity, tasks by priority/status, success rate, recent tasks and costs.',
+  dashboard: '',
   instructions: 'The agent’s personal markdown files (AGENTS.md, HEARTBEAT.md, SOUL.md, TOOLS.md) with an editor.',
   skills: 'The company skills library — installed vs. available for this agent.',
   configuration: 'Identity, avatar, reports-to, adapter and model.',

--- a/web/app/dashboard/agent/DashboardTab.tsx
+++ b/web/app/dashboard/agent/DashboardTab.tsx
@@ -1,0 +1,263 @@
+'use client'
+// Epic AG / AG2 — the agent Dashboard tab: latest run, four 14-day mini charts,
+// recent tasks, and the costs strip. All numbers come from the backend's pure
+// `buildAgentOverview` — this file only renders.
+//
+// Colorblind rules (DESIGN_SYSTEM v2): every chart series carries a text label
+// and a shape/icon, never color alone; success is accent-purple (not green) and
+// red is reserved for failure.
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+import { Card, Skeleton } from '../ui'
+import { tk, text, space } from '../tokens'
+import { statusColor, statusIcon } from '../status'
+import { ax, type Getter } from './shared'
+
+type Overview = {
+  agentId: string
+  days: number
+  latestRun: { id: string; status: string; taskId: string | null; summary: string; startedAt: number | null; endedAt: number | null } | null
+  runActivity: { date: string; total: number; succeeded: number; failed: number }[]
+  successRate: { date: string; pct: number | null; settled: number }[]
+  tasksByPriority: { key: string; count: number }[]
+  tasksByStatus: { key: string; count: number }[]
+  costs: { inputTokens: number; outputTokens: number; cachedTokens: number; totalTokens: number; totalCostUsd: number; taskCount: number; hasSplit: boolean }
+}
+type RecentTask = { id: string; title: string; status: string; priority: string; createdAt: number | null }
+
+/** "8d ago" / "3h ago" / "just now" — compact and locale-free. */
+function ago(ms: number | null): string {
+  if (ms == null) return '—'
+  const s = Math.max(0, Math.round((Date.now() - ms) / 1000))
+  if (s < 60) return 'just now'
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+const dayLabel = (iso: string) => `${Number(iso.slice(5, 7))}/${Number(iso.slice(8, 10))}`
+
+export default function DashboardTab({ orgId, agentId, getToken, onViewRuns, onOpenTask }: {
+  orgId: string
+  agentId: string
+  getToken: Getter
+  onViewRuns: () => void
+  onOpenTask?: (taskId: string) => void
+}) {
+  const [data, setData] = useState<{ overview: Overview; recentTasks: RecentTask[] } | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setErr(null)
+    try {
+      setData(await api(`/api/orgs/${orgId}/agents/${agentId}/overview`, { token: await getToken() }))
+    } catch (e: any) { setErr(e?.message ?? 'Could not load this agent’s dashboard.') }
+  }, [orgId, agentId, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  if (err) return <div style={ax.err}>{err}</div>
+  if (!data) return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: space.lg }}>
+      <Skeleton h={84} /><Skeleton h={140} /><Skeleton h={120} />
+    </div>
+  )
+
+  const { overview: o, recentTasks } = data
+  const lr = o.latestRun
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: space.xl }}>
+
+      {/* ── Latest run ─────────────────────────────────────────────────── */}
+      <section>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: space.sm }}>
+          <h2 style={ax.sectionTitle}>Latest Run</h2>
+          {lr && <button onClick={onViewRuns} style={linkBtn}>View details →</button>}
+        </div>
+        <Card>
+          {!lr ? <p style={ax.empty}>This agent has not run yet.</p> : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: space.sm }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: space.md, flexWrap: 'wrap' }}>
+                <span style={{ color: statusColor(lr.status), fontWeight: 700, fontSize: text.sm.fontSize }}>
+                  <span aria-hidden="true">{statusIcon(lr.status)}</span> {lr.status}
+                </span>
+                <code style={{ fontSize: text.xs.fontSize, color: tk.muted }}>{lr.id.slice(0, 8)}</code>
+                <span style={{ marginLeft: 'auto', fontSize: text.xs.fontSize, color: tk.muted }}>{ago(lr.startedAt)}</span>
+              </div>
+              <p style={{ margin: 0, fontSize: text.md.fontSize, color: tk.text, lineHeight: 1.5 }}>{lr.summary}</p>
+            </div>
+          )}
+        </Card>
+      </section>
+
+      {/* ── Mini charts ────────────────────────────────────────────────── */}
+      <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: space.lg }}>
+        <ChartCard title="Run Activity" days={o.days}>
+          <Columns
+            bars={o.runActivity.map(d => ({ label: dayLabel(d.date), value: d.total, title: `${d.date}: ${d.total} run(s), ${d.succeeded} succeeded, ${d.failed} failed` }))} />
+          <Legend items={[
+            { icon: '✓', label: 'Succeeded', color: tk.green, value: o.runActivity.reduce((s, d) => s + d.succeeded, 0) },
+            { icon: '✕', label: 'Failed', color: tk.red, value: o.runActivity.reduce((s, d) => s + d.failed, 0) },
+          ]} />
+        </ChartCard>
+
+        <ChartCard title="Tasks by Priority" days={o.days}>
+          <Distribution rows={o.tasksByPriority} empty="No tasks in this window." tone={k => PRIORITY_TONE[k] ?? tk.muted} />
+        </ChartCard>
+
+        <ChartCard title="Tasks by Status" days={o.days}>
+          <Distribution rows={o.tasksByStatus} empty="No tasks in this window." tone={k => statusColor(k)} icon={k => statusIcon(k)} />
+        </ChartCard>
+
+        <ChartCard title="Success Rate" days={o.days}>
+          <Columns max={100}
+            bars={o.successRate.map(d => ({
+              label: dayLabel(d.date),
+              value: d.pct ?? 0,
+              muted: d.pct == null, // no settled run that day = no data, not 0%
+              title: d.pct == null ? `${d.date}: no settled runs` : `${d.date}: ${d.pct}% of ${d.settled} run(s)`,
+            }))} />
+          <Legend items={[{ icon: '⬡', label: 'Settled runs', color: tk.accent, value: o.successRate.reduce((s, d) => s + d.settled, 0) }]} />
+        </ChartCard>
+      </section>
+
+      {/* ── Recent tasks ───────────────────────────────────────────────── */}
+      <section>
+        <h2 style={{ ...ax.sectionTitle, marginBottom: space.sm }}>Recent Tasks</h2>
+        <Card style={{ padding: 0, overflow: 'hidden' }}>
+          {recentTasks.length === 0 && <p style={{ ...ax.empty, padding: space.lg }}>No tasks assigned to this agent yet.</p>}
+          {recentTasks.map((t, i) => (
+            <div key={t.id} role={onOpenTask ? 'button' : undefined} tabIndex={onOpenTask ? 0 : undefined}
+              onClick={() => onOpenTask?.(t.id)}
+              onKeyDown={e => { if (e.key === 'Enter') onOpenTask?.(t.id) }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: space.lg, padding: `${space.md}px ${space.lg}px`,
+                borderTop: i === 0 ? 'none' : `1px solid ${tk.line}`, cursor: onOpenTask ? 'pointer' : 'default',
+              }}>
+              <code style={{ fontSize: text.xs.fontSize, color: tk.muted, flexShrink: 0 }}>{t.id.slice(0, 6)}</code>
+              <span style={{ flex: 1, minWidth: 0, fontSize: text.md.fontSize, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t.title}</span>
+              <span style={{ color: statusColor(t.status), fontSize: text.xs.fontSize, fontWeight: 700, flexShrink: 0 }}>
+                <span aria-hidden="true">{statusIcon(t.status)}</span> {t.status}
+              </span>
+            </div>
+          ))}
+        </Card>
+      </section>
+
+      {/* ── Costs ──────────────────────────────────────────────────────── */}
+      <section>
+        <h2 style={{ ...ax.sectionTitle, marginBottom: space.sm }}>Costs</h2>
+        <Card style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: space.lg }}>
+          {/* The split is null for tasks recorded before AG2 — show — not a fake 0. */}
+          <Stat label="Input tokens" value={o.costs.hasSplit ? o.costs.inputTokens.toLocaleString() : '—'} />
+          <Stat label="Output tokens" value={o.costs.hasSplit ? o.costs.outputTokens.toLocaleString() : '—'} />
+          <Stat label="Cached tokens" value={o.costs.hasSplit ? o.costs.cachedTokens.toLocaleString() : '—'} />
+          <Stat label="Total tokens" value={o.costs.totalTokens.toLocaleString()} />
+          <Stat label="Total cost" value={`$${o.costs.totalCostUsd.toFixed(2)}`} accent />
+        </Card>
+        {!o.costs.hasSplit && o.costs.totalTokens > 0 && (
+          <p style={{ ...ax.empty, marginTop: space.sm, fontSize: text.xs.fontSize }}>
+            The input/output/cached split is recorded from this release onward; earlier tasks carry only the total.
+          </p>
+        )}
+      </section>
+    </div>
+  )
+}
+
+// ─── chart primitives ────────────────────────────────────────────────────────
+
+const PRIORITY_TONE: Record<string, string> = {
+  critical: 'var(--danger-text)', high: 'var(--warning-text)', medium: 'var(--accent)', low: 'var(--muted)',
+}
+
+function ChartCard({ title, days, children }: { title: string; days: number; children: React.ReactNode }) {
+  return (
+    <Card style={{ display: 'flex', flexDirection: 'column', gap: space.sm }}>
+      <div>
+        <div style={{ fontSize: text.sm.fontSize, fontWeight: 700, color: tk.text }}>{title}</div>
+        <div style={{ fontSize: text.xs.fontSize, color: tk.muted }}>Last {days} days</div>
+      </div>
+      {children}
+    </Card>
+  )
+}
+
+/** 14 day columns. `muted` marks a no-data day so it never reads as a real zero. */
+function Columns({ bars, max }: { bars: { label: string; value: number; title: string; muted?: boolean }[]; max?: number }) {
+  const peak = max ?? Math.max(1, ...bars.map(b => b.value))
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'flex-end', gap: 2, height: 68 }} role="img"
+        aria-label={bars.map(b => b.title).join('; ')}>
+        {bars.map((b, i) => (
+          <div key={i} title={b.title} style={{ flex: 1, height: '100%', display: 'flex', alignItems: 'flex-end' }}>
+            <div style={{
+              width: '100%',
+              height: `${Math.max((b.value / peak) * 100, b.value > 0 ? 6 : 0)}%`,
+              minHeight: b.muted ? 2 : 0,
+              background: b.muted ? tk.line : tk.accent,
+              borderRadius: 2,
+            }} />
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: space.xs, fontSize: text.xs.fontSize, color: tk.muted }}>
+        <span>{bars[0]?.label}</span><span>{bars[Math.floor(bars.length / 2)]?.label}</span><span>{bars.at(-1)?.label}</span>
+      </div>
+    </div>
+  )
+}
+
+/** Distribution rows: label + count + proportional bar (label always present). */
+function Distribution({ rows, empty, tone, icon }: {
+  rows: { key: string; count: number }[]
+  empty: string
+  tone: (key: string) => string
+  icon?: (key: string) => string
+}) {
+  if (rows.length === 0) return <p style={{ ...ax.empty, fontSize: text.xs.fontSize }}>{empty}</p>
+  const peak = Math.max(...rows.map(r => r.count))
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: space.sm }}>
+      {rows.map(r => (
+        <div key={r.key} style={{ display: 'flex', alignItems: 'center', gap: space.sm }}>
+          <span style={{ fontSize: text.xs.fontSize, color: tone(r.key), fontWeight: 700, width: 92, textTransform: 'capitalize', flexShrink: 0 }}>
+            {icon && <span aria-hidden="true">{icon(r.key)} </span>}{r.key.replace('_', ' ')}
+          </span>
+          <div style={{ flex: 1, height: 8, background: tk.surfaceHigh, borderRadius: 4, overflow: 'hidden' }}>
+            <div style={{ width: `${Math.max((r.count / peak) * 100, 4)}%`, height: '100%', background: tone(r.key), borderRadius: 4 }} />
+          </div>
+          <span style={{ fontSize: text.xs.fontSize, color: tk.textDim, width: 22, textAlign: 'right', flexShrink: 0 }}>{r.count}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Legend({ items }: { items: { icon: string; label: string; color: string; value: number }[] }) {
+  return (
+    <div style={{ display: 'flex', gap: space.lg, flexWrap: 'wrap' }}>
+      {items.map(it => (
+        <span key={it.label} style={{ fontSize: text.xs.fontSize, color: tk.muted }}>
+          <span aria-hidden="true" style={{ color: it.color, fontWeight: 700 }}>{it.icon}</span> {it.label} <strong style={{ color: tk.textDim }}>{it.value}</strong>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function Stat({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <span style={{ fontSize: text.xs.fontSize, color: tk.muted }}>{label}</span>
+      <span style={{ fontSize: 20, fontWeight: 800, color: accent ? tk.accent : tk.text, lineHeight: 1.2 }}>{value}</span>
+    </div>
+  )
+}
+
+const linkBtn: React.CSSProperties = {
+  background: 'transparent', border: 'none', color: tk.accent, cursor: 'pointer',
+  fontSize: text.sm.fontSize, fontWeight: 600, padding: 0,
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -392,7 +392,7 @@ export default function DashboardPage() {
         {/* AG1 — the Agents area is either the roster or one agent's detail page. */}
         {tab === 'agents' && (agentRoute
           ? <AgentDetail orgId={org.id} agentId={agentRoute.agentId} tab={agentRoute.tab} getToken={getToken}
-              onTab={t => openAgent(agentRoute.agentId, t)} onBack={closeAgent} />
+              onTab={t => openAgent(agentRoute.agentId, t)} onBack={closeAgent} onOpenTask={setOpenTaskId} />
           : (
           <div style={s.page}>
             <h1 style={s.h1}>Agents ({agents.length})</h1>


### PR DESCRIPTION
**Epic AG**, story 2 of 7 — the Dashboard tab of the agent detail page (mockup: Paperclip R2D2 dashboard).

## Backend
- **`services/agent-overview.ts`** — pure aggregation, zero DB: UTC day bucketing, run activity, success rate, count-by, cost totals, run summary from the last log line. **20 new tests.**
- **`routes/agent-detail.ts`** (new, org-scoped) — `GET /orgs/:orgId/agents/:agentId/overview` and `GET …/runs`. There was **no per-agent runs endpoint** before, only per-task. Routes live under `/orgs/:orgId/...` on purpose: `requireOrgRole` reads `:orgId` from the path and silently no-ops without it, so `/api/agents/:id/...` cannot be owner-gated.
- **Per-task token split** — `input_tokens` / `output_tokens` / `cached_tokens` as idempotent **nullable** ALTERs. `tokens_used` remains the total and every existing task is byte-for-byte unchanged. The executor writes the split on both the execute and ask paths, and the Anthropic router now captures `cache_read_input_tokens`. Without this the Costs strip would have been decorative.

## Web
`DashboardTab.tsx`: Latest Run card (status · run id · summary · *View details →*), four 14-day mini charts, Recent Tasks (click → task drawer), Costs strip (input/output/cached/total tokens + total cost).

**Honesty details:** Success Rate shows *no data* (a muted hairline), not 0%, on a day with no settled run. The Costs strip shows **—**, not a fake 0, for tasks recorded before the split, with a one-line note.

## Verify
- backend: **954 tests pass** (was 934), `tsc --noEmit` clean, **evals 11/11**
- web: 119 tests, `npm run build` ✅
- Design tokens only; every chart series carries an icon + text label (never color alone); success = accent-purple, red reserved for failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)