### PR TITLE
feat(AG4): Skills tab — company library as a checkbox list, with a real uninstall

### DIFF
--- a/backend/src/routes/agent-detail.ts
+++ b/backend/src/routes/agent-detail.ts
@@ -14,6 +14,7 @@ import { buildAgentOverview, OVERVIEW_DAYS } from '../services/agent-overview'
 import {
   MAX_EXTRA_FILES, isManaged, listBundle, normalizeFileName, readFile, validateContent,
 } from '../services/agent-files'
+import { resolveSelection, splitSkills } from '../services/agent-skills'
 
 /** The agent, but only if it belongs to this org. Null otherwise (→ 404). */
 export async function agentInOrg(orgId: string, agentId: string) {
@@ -148,5 +149,48 @@ export async function agentDetailRoutes(app: FastifyInstance) {
     await db.delete(schema.agentFiles)
       .where(and(eq(schema.agentFiles.agentId, agentId), eq(schema.agentFiles.orgId, orgId), eq(schema.agentFiles.path, path)))
     return reply.code(204).send()
+  })
+
+  // ─── AG4 — Skills: the company library, split by what this agent has ───────
+
+  // Read is member-visible (the roster shows skill counts already).
+  app.get('/api/orgs/:orgId/agents/:agentId/skills', async (req, reply) => {
+    const { orgId, agentId } = req.params as { orgId: string; agentId: string }
+    const agent = await agentInOrg(orgId, agentId)
+    if (!agent) return reply.code(404).send({ error: 'Agent not found' })
+
+    const library = await db.select().from(schema.skills)
+    const split = splitSkills(library, (agent.skills as string[]) ?? [])
+    return {
+      ...split,
+      // Footer of the mockup: which adapter these skills get applied to.
+      adapter: agent.runtime,
+      model: agent.primaryModel || agent.llmModel,
+    }
+  })
+
+  // Write the WHOLE selection. Install and uninstall are the same idempotent call,
+  // which is what the checkbox list actually means — and it's the only uninstall
+  // path that exists (the legacy route could only append).
+  app.put('/api/orgs/:orgId/agents/:agentId/skills', { preHandler: requireOrgRole('owner') }, async (req, reply) => {
+    const { orgId, agentId } = req.params as { orgId: string; agentId: string }
+    const agent = await agentInOrg(orgId, agentId)
+    if (!agent) return reply.code(404).send({ error: 'Agent not found' })
+
+    const library = await db.select().from(schema.skills)
+    const resolved = resolveSelection(library, (req.body as { skills?: unknown })?.skills)
+    if (resolved.ok === false) return reply.code(400).send({ error: resolved.error })
+
+    await db.update(schema.agents).set({ skills: resolved.names }).where(eq(schema.agents.id, agentId))
+    const after = await agentInOrg(orgId, agentId)
+
+    // Same audit trail as any other config change (MCA-GOV2 S4.1).
+    await db.insert(schema.configRevisions).values({
+      id: randomUUID(), orgId, entity: 'agent', entityId: agentId,
+      before: JSON.stringify(agent), after: JSON.stringify(after),
+      actor: (req as any).userId ?? 'human', createdAt: new Date(),
+    }).catch(() => {})
+
+    return { ...splitSkills(library, resolved.names), adapter: agent.runtime, model: agent.primaryModel || agent.llmModel }
   })
 }

--- a/backend/src/services/agent-skills.ts
+++ b/backend/src/services/agent-skills.ts
@@ -1,0 +1,79 @@
+// Epic AG / AG4 — the Skills tab: the company skills library split into what is
+// installed on this agent and what isn't. Pure; the route does the I/O.
+//
+// Storage reality: `agents.skills` is a JSON array of skill NAMES (not ids), and
+// there was no uninstall path at all — only an append-by-id route. So the tab
+// works on a whole SELECTION (the checkbox list you see), which makes install and
+// uninstall the same idempotent operation and can't drift into a half-applied set.
+
+export interface SkillLike {
+  id: string
+  name: string
+  description?: string | null
+  domain?: string | null
+  source?: string | null
+}
+
+export interface SkillView extends SkillLike {
+  installed: boolean
+}
+
+/**
+ * Split the library for display. `installed` preserves the agent's stored order
+ * (that is the order the agent sees them in); `other` is alphabetical.
+ *
+ * A name stored on the agent that no longer exists in the library is surfaced as
+ * `orphaned` rather than silently dropped — it still counts as installed, and the
+ * UI can tell the operator the skill went away.
+ */
+export function splitSkills(library: SkillLike[], installedNames: string[]) {
+  const byName = new Map(library.map(s => [s.name, s]))
+  const wanted = dedupe(installedNames)
+
+  const installed: SkillView[] = []
+  const orphaned: string[] = []
+  for (const name of wanted) {
+    const s = byName.get(name)
+    if (s) installed.push({ ...s, installed: true })
+    else orphaned.push(name)
+  }
+
+  const installedSet = new Set(installed.map(s => s.name))
+  const other: SkillView[] = library
+    .filter(s => !installedSet.has(s.name))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(s => ({ ...s, installed: false }))
+
+  return { installed, other, orphaned, selectedCount: installed.length + orphaned.length }
+}
+
+/**
+ * Resolve a requested selection (skill names) against the library.
+ * Unknown names are reported, not written — the agent's skill list may only ever
+ * contain names the library actually has.
+ */
+export function resolveSelection(library: SkillLike[], requested: unknown): { ok: true; names: string[] } | { ok: false; error: string } {
+  if (!Array.isArray(requested)) return { ok: false, error: 'skills must be an array of skill names' }
+  if (!requested.every(n => typeof n === 'string')) return { ok: false, error: 'skills must be an array of skill names' }
+
+  const names = dedupe(requested as string[])
+  const known = new Set(library.map(s => s.name))
+  const unknown = names.filter(n => !known.has(n))
+  if (unknown.length) return { ok: false, error: `Unknown skill(s): ${unknown.join(', ')}` }
+
+  // Keep library order so the stored array is stable regardless of click order.
+  const order = new Map(library.map((s, i) => [s.name, i]))
+  return { ok: true, names: names.sort((a, b) => (order.get(a) ?? 0) - (order.get(b) ?? 0)) }
+}
+
+function dedupe(names: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const raw of names) {
+    const n = (raw ?? '').trim()
+    if (!n || seen.has(n)) continue
+    seen.add(n)
+    out.push(n)
+  }
+  return out
+}

--- a/backend/src/tests/agent-skills.test.ts
+++ b/backend/src/tests/agent-skills.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveSelection, splitSkills, type SkillLike } from '../services/agent-skills'
+
+const library: SkillLike[] = [
+  { id: '1', name: 'paperclip', description: 'Control plane API' },
+  { id: '2', name: 'paperclip-board', description: 'Board member' },
+  { id: '3', name: 'para-memory-files', description: 'PARA memory' },
+]
+
+describe('[AG4] splitSkills', () => {
+  it('splits the library into installed and other', () => {
+    const r = splitSkills(library, ['paperclip'])
+    assert.deepEqual(r.installed.map(s => s.name), ['paperclip'])
+    assert.deepEqual(r.other.map(s => s.name), ['paperclip-board', 'para-memory-files'])
+    assert.equal(r.selectedCount, 1)
+    assert.ok(r.installed.every(s => s.installed))
+    assert.ok(r.other.every(s => !s.installed))
+  })
+
+  it('lists "other" alphabetically and keeps the agent’s stored order for installed', () => {
+    const r = splitSkills(library, ['para-memory-files', 'paperclip'])
+    assert.deepEqual(r.installed.map(s => s.name), ['para-memory-files', 'paperclip'])
+    assert.deepEqual(r.other.map(s => s.name), ['paperclip-board'])
+  })
+
+  it('reports a skill that vanished from the library as orphaned, not silently dropped', () => {
+    const r = splitSkills(library, ['paperclip', 'deleted-skill'])
+    assert.deepEqual(r.orphaned, ['deleted-skill'])
+    assert.deepEqual(r.installed.map(s => s.name), ['paperclip'])
+    assert.equal(r.selectedCount, 2) // an orphan is still selected on the agent
+  })
+
+  it('handles an agent with no skills and an empty library', () => {
+    const none = splitSkills(library, [])
+    assert.deepEqual(none.installed, [])
+    assert.equal(none.other.length, 3)
+    assert.equal(none.selectedCount, 0)
+
+    const empty = splitSkills([], ['ghost'])
+    assert.deepEqual(empty.other, [])
+    assert.deepEqual(empty.orphaned, ['ghost'])
+  })
+
+  it('de-duplicates a name stored twice', () => {
+    const r = splitSkills(library, ['paperclip', 'paperclip'])
+    assert.equal(r.installed.length, 1)
+    assert.equal(r.selectedCount, 1)
+  })
+})
+
+describe('[AG4] resolveSelection', () => {
+  it('accepts a valid selection and returns it in library order', () => {
+    const r = resolveSelection(library, ['para-memory-files', 'paperclip'])
+    assert.deepEqual(r, { ok: true, names: ['paperclip', 'para-memory-files'] })
+  })
+
+  it('accepts the empty selection (uninstalling everything is legitimate)', () => {
+    assert.deepEqual(resolveSelection(library, []), { ok: true, names: [] })
+  })
+
+  it('refuses to store a name the library does not have', () => {
+    const r = resolveSelection(library, ['paperclip', 'not-a-skill'])
+    assert.equal(r.ok, false)
+    assert.match((r as any).error, /not-a-skill/)
+  })
+
+  it('rejects a non-array or non-string payload', () => {
+    for (const bad of [null, undefined, 'paperclip', { a: 1 }, [1, 2]]) {
+      assert.equal(resolveSelection(library, bad).ok, false)
+    }
+  })
+
+  it('de-duplicates and trims', () => {
+    assert.deepEqual(resolveSelection(library, ['paperclip', ' paperclip ', '']), { ok: true, names: ['paperclip'] })
+  })
+})

--- a/web/app/dashboard/agent/AgentDetail.tsx
+++ b/web/app/dashboard/agent/AgentDetail.tsx
@@ -11,8 +11,9 @@ import { tk, text, space } from '../tokens'
 import { AgentAvatar, StatusPill, ax, type DAgent, type Getter } from './shared'
 import DashboardTab from './DashboardTab'
 import InstructionsTab from './InstructionsTab'
+import SkillsTab from './SkillsTab'
 
-export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getToken, onOpenTask }: {
+export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getToken, onOpenTask, onOpenLibrary }: {
   orgId: string
   agentId: string
   tab: AgentTab
@@ -20,6 +21,8 @@ export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getTok
   onBack: () => void
   getToken: Getter
   onOpenTask?: (taskId: string) => void
+  /** AG4 — jump to the company skills library area. */
+  onOpenLibrary?: () => void
 }) {
   const [agent, setAgent] = useState<DAgent | null>(null)
   const [err, setErr] = useState<string | null>(null)
@@ -131,7 +134,8 @@ export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getTok
         {tab === 'dashboard' && <DashboardTab orgId={orgId} agentId={agentId} getToken={getToken}
           onViewRuns={() => onTab('runs')} onOpenTask={onOpenTask} />}
         {tab === 'instructions' && <InstructionsTab orgId={orgId} agentId={agentId} getToken={getToken} />}
-        {tab !== 'dashboard' && tab !== 'instructions' && <TabPanel tab={tab} />}
+        {tab === 'skills' && <SkillsTab orgId={orgId} agentId={agentId} getToken={getToken} onOpenLibrary={onOpenLibrary} />}
+        {tab !== 'dashboard' && tab !== 'instructions' && tab !== 'skills' && <TabPanel tab={tab} />}
       </div>
 
       {assignOpen && (
@@ -156,7 +160,7 @@ export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getTok
 const PENDING: Record<AgentTab, string> = {
   dashboard: '',
   instructions: '',
-  skills: 'The company skills library — installed vs. available for this agent.',
+  skills: '',
   configuration: 'Identity, avatar, reports-to, adapter and model.',
   runs: 'Run history with per-run logs.',
   budget: 'This agent’s budget and spend.',

--- a/web/app/dashboard/agent/SkillsTab.tsx
+++ b/web/app/dashboard/agent/SkillsTab.tsx
@@ -1,0 +1,135 @@
+'use client'
+// Epic AG / AG4 — Skills tab: the company skills library as a checkbox list,
+// split into Installed and Other, with the adapter + selected count in the footer.
+// Toggling writes the WHOLE selection (install and uninstall are one idempotent
+// call), so the list on screen is always what the agent actually has.
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+import { Card, Skeleton } from '../ui'
+import { sx } from '../cockpit/shared'
+import { tk, text, space } from '../tokens'
+import { ax, type Getter } from './shared'
+
+type Skill = { id: string; name: string; description?: string | null; domain?: string | null; source?: string | null; installed: boolean }
+type Payload = { installed: Skill[]; other: Skill[]; orphaned: string[]; selectedCount: number; adapter: string; model: string }
+
+const ADAPTER_LABEL: Record<string, string> = {
+  internal: 'Internal (7Ei executor)', openclaw: 'OpenClaw', cursor: 'Cursor', claude_code: 'Claude Code', custom: 'Custom runtime',
+}
+
+export default function SkillsTab({ orgId, agentId, getToken, onOpenLibrary }: {
+  orgId: string
+  agentId: string
+  getToken: Getter
+  onOpenLibrary?: () => void
+}) {
+  const [data, setData] = useState<Payload | null>(null)
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const base = `/api/orgs/${orgId}/agents/${agentId}/skills`
+
+  const load = useCallback(async () => {
+    setErr(null)
+    try { setData(await api<Payload>(base, { token: await getToken() })) }
+    catch (e: any) { setErr(e?.message ?? 'Could not load skills.') }
+  }, [base, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  const toggle = async (name: string) => {
+    if (!data) return
+    const current = [...data.installed.map(s => s.name), ...data.orphaned]
+    const next = current.includes(name) ? current.filter(n => n !== name) : [...current, name]
+    setBusy(true); setErr(null)
+    try { setData(await api<Payload>(base, { token: await getToken(), method: 'PUT', body: JSON.stringify({ skills: next }) })) }
+    catch (e: any) { setErr(e?.message ?? 'Could not update this agent’s skills.') }
+    setBusy(false)
+  }
+
+  if (err && !data) return <div style={ax.err}>{err}</div>
+  if (!data) return <div style={{ display: 'flex', flexDirection: 'column', gap: space.lg }}><Skeleton h={40} /><Skeleton h={180} /></div>
+
+  const row = (s: Skill) => (
+    <div key={s.id} style={{ display: 'flex', gap: space.md, padding: `${space.md}px ${space.lg}px`, borderTop: `1px solid ${tk.line}` }}>
+      <input type="checkbox" checked={s.installed} disabled={busy} onChange={() => toggle(s.name)}
+        aria-label={`${s.installed ? 'Uninstall' : 'Install'} ${s.name}`}
+        style={{ marginTop: 3, accentColor: tk.accent, cursor: busy ? 'default' : 'pointer', flexShrink: 0 }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: space.sm }}>
+          <span style={{ fontSize: text.md.fontSize, fontWeight: 600 }}>{s.name}</span>
+          {s.domain && <span style={sx.badge}>{s.domain}</span>}
+        </div>
+        {s.description && (
+          <p style={{
+            margin: `${space.xs}px 0 0`, fontSize: text.sm.fontSize, color: tk.muted, lineHeight: 1.55,
+            ...(expanded === s.id ? {} : { display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }),
+          }}>{s.description}</p>
+        )}
+      </div>
+      <button onClick={() => setExpanded(e => e === s.id ? null : s.id)}
+        style={{ background: 'transparent', border: 'none', color: tk.accent, cursor: 'pointer', fontSize: text.sm.fontSize, fontWeight: 600, alignSelf: 'flex-start', flexShrink: 0 }}>
+        {expanded === s.id ? 'Hide' : 'View'}
+      </button>
+    </div>
+  )
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: space.lg }}>
+      {onOpenLibrary && (
+        <button onClick={onOpenLibrary} style={{ background: 'transparent', border: 'none', color: tk.accent, cursor: 'pointer', fontSize: text.sm.fontSize, fontWeight: 600, padding: 0, alignSelf: 'flex-start' }}>
+          View company skills library →
+        </button>
+      )}
+      {err && <div style={ax.err}>{err}</div>}
+
+      <Card style={{ padding: 0, overflow: 'hidden' }}>
+        <SectionHead>Installed skills</SectionHead>
+        {data.installed.length === 0 && data.orphaned.length === 0
+          ? <p style={{ ...ax.empty, padding: `${space.lg}px` }}>No company-library skills installed on this agent.</p>
+          : data.installed.map(row)}
+        {/* A name stored on the agent that no longer exists in the library — say so
+            rather than quietly dropping it. */}
+        {data.orphaned.map(name => (
+          <div key={name} style={{ display: 'flex', alignItems: 'center', gap: space.md, padding: `${space.md}px ${space.lg}px`, borderTop: `1px solid ${tk.line}` }}>
+            <input type="checkbox" checked disabled={busy} onChange={() => toggle(name)} aria-label={`Remove ${name}`} style={{ accentColor: tk.accent }} />
+            <span style={{ fontSize: text.md.fontSize, fontWeight: 600 }}>{name}</span>
+            <span style={{ ...sx.tag, color: tk.amber, border: `1px solid ${tk.amber}` }}>⚠ no longer in the library</span>
+          </div>
+        ))}
+      </Card>
+
+      <Card style={{ padding: 0, overflow: 'hidden' }}>
+        <SectionHead>Other skills</SectionHead>
+        {data.other.length === 0
+          ? <p style={{ ...ax.empty, padding: `${space.lg}px` }}>Every library skill is installed on this agent.</p>
+          : data.other.map(row)}
+      </Card>
+
+      <Card style={{ display: 'flex', gap: space.xl, flexWrap: 'wrap', alignItems: 'center' }}>
+        <Foot label="Adapter" value={ADAPTER_LABEL[data.adapter] ?? data.adapter} />
+        <Foot label="Model" value={data.model} />
+        <Foot label="Selected skills" value={String(data.selectedCount)} />
+        <span style={{ marginLeft: 'auto', fontSize: text.xs.fontSize, color: tk.muted }}>Skills are applied when the agent runs.</span>
+      </Card>
+    </div>
+  )
+}
+
+function SectionHead({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ padding: `${space.md}px ${space.lg}px`, background: tk.surfaceHigh, fontSize: text.sm.fontSize, fontWeight: 700, color: tk.textDim }}>
+      {children}
+    </div>
+  )
+}
+
+function Foot({ label, value }: { label: string; value: string }) {
+  return (
+    <span style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <span style={{ fontSize: text.xs.fontSize, color: tk.muted }}>{label}</span>
+      <span style={{ fontSize: text.sm.fontSize, fontWeight: 700, color: tk.text }}>{value}</span>
+    </span>
+  )
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -392,7 +392,8 @@ export default function DashboardPage() {
         {/* AG1 — the Agents area is either the roster or one agent's detail page. */}
         {tab === 'agents' && (agentRoute
           ? <AgentDetail orgId={org.id} agentId={agentRoute.agentId} tab={agentRoute.tab} getToken={getToken}
-              onTab={t => openAgent(agentRoute.agentId, t)} onBack={closeAgent} onOpenTask={setOpenTaskId} />
+              onTab={t => openAgent(agentRoute.agentId, t)} onBack={closeAgent} onOpenTask={setOpenTaskId}
+              onOpenLibrary={() => selectTab('skills')} />
           : (
           <div style={s.page}>
             <h1 style={s.h1}>Agents ({agents.length})</h1>


### PR DESCRIPTION
**Epic AG**, story 4 of 7 — the Skills tab.

## Backend
- **`services/agent-skills.ts`** (pure, **10 tests**) — `splitSkills` (installed vs other; installed keeps the agent's stored order, other is alphabetical) and `resolveSelection` (a name the library doesn't have is **refused, never written**).
- **`GET /orgs/:orgId/agents/:agentId/skills`** (read) + owner-gated **`PUT …/skills`**, which writes the **whole selection**. That makes install and uninstall the same idempotent call and matches what a checkbox list actually means. **There was no uninstall path before** — the only existing route could append a skill by id. Writes a `configRevisions` snapshot like every other config change.

Storage reality worth flagging: `agents.skills` is a JSON array of skill **names**, not ids. A name that no longer exists in the library is reported as **orphaned** and shown with a warning row rather than quietly disappearing.

## Web
`SkillsTab.tsx` — *View company skills library →*, **Installed skills** + **Other skills** as a checkbox list with View/Hide for each description, and the mockup's footer: **Adapter · Model · Selected skills** count.

## Verify
- backend: **987 tests pass** (was 977), `tsc --noEmit` clean, **evals 11/11**
- web: 128 tests, `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)