### PR TITLE
feat(AG6): Runs + Budget tabs — the agent detail page is complete

### DIFF
--- a/backend/src/routes/agent-detail.ts
+++ b/backend/src/routes/agent-detail.ts
@@ -17,6 +17,8 @@ import {
 import { resolveSelection, splitSkills } from '../services/agent-skills'
 import { validateConfigPatch } from '../services/agent-config'
 import { buildAvatarDataUri } from '../services/agent-avatar'
+import { summariseAgentBudget } from '../services/agent-budget'
+import { spendForScope } from '../services/budget'
 
 /** The agent, but only if it belongs to this org. Null otherwise (→ 404). */
 export async function agentInOrg(orgId: string, agentId: string) {
@@ -260,5 +262,65 @@ export async function agentDetailRoutes(app: FastifyInstance) {
     await db.update(schema.agents).set({ avatarUrl: null }).where(eq(schema.agents.id, agentId))
     await snapshot(orgId, agentId, { avatarUrl: agent.avatarUrl }, { avatarUrl: null }, req)
     return reply.code(204).send()
+  })
+
+  // ─── AG6 — Budget: this agent's cap + spend ───────────────────────────────
+  // A per-agent cap is just a scoped budget policy (scope:'agent'), which the
+  // existing `enforceAgentBudget` hard-stop already honours — no parallel store.
+
+  const agentBudget = async (orgId: string, agentId: string) => {
+    const [policies, tasks] = await Promise.all([
+      db.select().from(schema.budgetPolicies).where(eq(schema.budgetPolicies.orgId, orgId)),
+      db.select({ costUsd: schema.tasks.costUsd, agentId: schema.tasks.agentId })
+        .from(schema.tasks).where(eq(schema.tasks.orgId, orgId)),
+    ])
+    const policy = policies.find(p => p.scope === 'agent' && p.scopeId === agentId) ?? null
+    const spend = spendForScope(tasks as any, 'agent', agentId)
+    return summariseAgentBudget(policy as any, spend)
+  }
+
+  app.get('/api/orgs/:orgId/agents/:agentId/budget', async (req, reply) => {
+    const { orgId, agentId } = req.params as { orgId: string; agentId: string }
+    const agent = await agentInOrg(orgId, agentId)
+    if (!agent) return reply.code(404).send({ error: 'Agent not found' })
+    return { agentId, agentName: agent.name, budget: await agentBudget(orgId, agentId) }
+  })
+
+  // Set (or clear) the cap. `limitUsd: null | 0` removes the policy → unlimited.
+  app.put('/api/orgs/:orgId/agents/:agentId/budget', { preHandler: requireOrgRole('owner') }, async (req, reply) => {
+    const { orgId, agentId } = req.params as { orgId: string; agentId: string }
+    const agent = await agentInOrg(orgId, agentId)
+    if (!agent) return reply.code(404).send({ error: 'Agent not found' })
+
+    const body = (req.body ?? {}) as { limitUsd?: unknown; hardStop?: unknown; warnPct?: unknown }
+    const raw = body.limitUsd
+    if (raw !== null && raw !== undefined && typeof raw !== 'number') return reply.code(400).send({ error: 'limitUsd must be a number or null' })
+    const limitUsd = typeof raw === 'number' ? raw : null
+    if (limitUsd != null && (!Number.isFinite(limitUsd) || limitUsd < 0)) return reply.code(400).send({ error: 'limitUsd must be zero or more' })
+
+    const existing = (await db.select().from(schema.budgetPolicies).where(eq(schema.budgetPolicies.orgId, orgId)))
+      .find(p => p.scope === 'agent' && p.scopeId === agentId)
+
+    if (limitUsd == null || limitUsd === 0) {
+      // No cap: drop the policy rather than storing a 0 that would read as
+      // "budget exhausted" to every consumer of the scoped-budget machinery.
+      if (existing) await db.delete(schema.budgetPolicies).where(eq(schema.budgetPolicies.id, existing.id))
+    } else if (existing) {
+      await db.update(schema.budgetPolicies).set({
+        limitUsd,
+        ...(typeof body.hardStop === 'boolean' ? { hardStop: body.hardStop } : {}),
+        ...(typeof body.warnPct === 'number' ? { warnPct: body.warnPct } : {}),
+      }).where(eq(schema.budgetPolicies.id, existing.id))
+    } else {
+      await db.insert(schema.budgetPolicies).values({
+        id: randomUUID(), orgId, scope: 'agent', scopeId: agentId, limitUsd,
+        warnPct: typeof body.warnPct === 'number' ? body.warnPct : 0.8,
+        hardStop: typeof body.hardStop === 'boolean' ? body.hardStop : true,
+        createdAt: new Date(),
+      } as any)
+    }
+
+    await snapshot(orgId, agentId, { budgetLimitUsd: existing?.limitUsd ?? null }, { budgetLimitUsd: limitUsd }, req)
+    return { agentId, agentName: agent.name, budget: await agentBudget(orgId, agentId) }
   })
 }

--- a/backend/src/services/agent-budget.ts
+++ b/backend/src/services/agent-budget.ts
@@ -1,0 +1,58 @@
+// Epic AG / AG6 — the agent Budget tab.
+//
+// Reuses the existing scoped-budget machinery (`services/budget.ts`): a per-agent
+// cap is just a `budgetPolicies` row with `scope:'agent', scopeId:<agentId>`, and
+// the hard-stop enforcement in `enforceAgentBudget` already honours it. This file
+// only shapes that data for the tab. Pure.
+
+import { evaluatePolicy, isHardStop, type BudgetPolicy, type BudgetState } from './budget'
+
+export interface AgentBudgetView {
+  /** Observed spend for this agent, all-time (the same number the Costs tab shows). */
+  observedUsd: number
+  /** Null when no cap is configured — spend is unlimited, not "0 budget". */
+  limitUsd: number | null
+  policyId: string | null
+  hardStop: boolean
+  warnPct: number
+  state: BudgetState
+  /** Percent of the cap used; null when there is no cap. */
+  pct: number | null
+  /** Cap minus spend; null when there is no cap (i.e. unlimited). */
+  remainingUsd: number | null
+  /** Health chip: healthy until a cap exists AND is being approached/breached. */
+  health: 'healthy' | 'warning' | 'breached'
+}
+
+/**
+ * Shape an agent's budget for display. With no policy the tab reports "Disabled /
+ * Unlimited" rather than pretending the cap is zero — a missing budget must never
+ * read as an exhausted one.
+ */
+export function summariseAgentBudget(policy: BudgetPolicy | null | undefined, observedUsd: number): AgentBudgetView {
+  const spend = round(observedUsd)
+
+  if (!policy || !(policy.limitUsd > 0)) {
+    return {
+      observedUsd: spend, limitUsd: null, policyId: (policy as { id?: string } | null | undefined)?.id ?? null,
+      hardStop: policy ? isHardStop(policy) : true,
+      warnPct: policy?.warnPct ?? 0.8,
+      state: 'ok', pct: null, remainingUsd: null, health: 'healthy',
+    }
+  }
+
+  const { state, pct } = evaluatePolicy(policy, spend)
+  return {
+    observedUsd: spend,
+    limitUsd: policy.limitUsd,
+    policyId: (policy as { id?: string }).id ?? null,
+    hardStop: isHardStop(policy),
+    warnPct: policy.warnPct ?? 0.8,
+    state,
+    pct,
+    remainingUsd: round(Math.max(policy.limitUsd - spend, 0)),
+    health: state === 'breach' ? 'breached' : state === 'warn' ? 'warning' : 'healthy',
+  }
+}
+
+const round = (n: number) => Math.round((n || 0) * 1e6) / 1e6

--- a/backend/src/tests/agent-budget.test.ts
+++ b/backend/src/tests/agent-budget.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { summariseAgentBudget } from '../services/agent-budget'
+import type { BudgetPolicy } from '../services/budget'
+
+const policy = (over: Partial<BudgetPolicy> & { id?: string } = {}): BudgetPolicy & { id: string } => ({
+  id: 'p1', scope: 'agent', scopeId: 'a1', limitUsd: 100, warnPct: 0.8, hardStop: true, ...over,
+} as any)
+
+describe('[AG6] summariseAgentBudget', () => {
+  it('reports no cap as unlimited — never as an exhausted zero budget', () => {
+    const v = summariseAgentBudget(null, 12.5)
+    assert.equal(v.limitUsd, null)
+    assert.equal(v.pct, null)
+    assert.equal(v.remainingUsd, null)
+    assert.equal(v.state, 'ok')
+    assert.equal(v.health, 'healthy')
+    assert.equal(v.observedUsd, 12.5)
+  })
+
+  it('treats a zero/negative limit as no cap', () => {
+    assert.equal(summariseAgentBudget(policy({ limitUsd: 0 }), 5).limitUsd, null)
+    assert.equal(summariseAgentBudget(policy({ limitUsd: -1 }), 5).health, 'healthy')
+  })
+
+  it('computes remaining, pct and healthy state under the cap', () => {
+    const v = summariseAgentBudget(policy({ limitUsd: 100 }), 25)
+    assert.equal(v.limitUsd, 100)
+    assert.equal(v.remainingUsd, 75)
+    assert.equal(v.pct, 0.25)
+    assert.equal(v.state, 'ok')
+    assert.equal(v.health, 'healthy')
+  })
+
+  it('warns at the soft threshold and breaches at the cap', () => {
+    assert.equal(summariseAgentBudget(policy(), 85).health, 'warning')  // 85% ≥ warnPct 0.8
+    assert.equal(summariseAgentBudget(policy(), 100).health, 'breached')
+    assert.equal(summariseAgentBudget(policy(), 140).health, 'breached')
+  })
+
+  it('never reports negative remaining once the cap is blown', () => {
+    assert.equal(summariseAgentBudget(policy(), 140).remainingUsd, 0)
+  })
+
+  it('carries the hard-stop flag and the policy id through', () => {
+    const v = summariseAgentBudget(policy({ id: 'pol-9', hardStop: false }), 10)
+    assert.equal(v.policyId, 'pol-9')
+    assert.equal(v.hardStop, false)
+  })
+
+  it('rounds money to 6dp instead of leaking float noise', () => {
+    assert.equal(summariseAgentBudget(null, 0.1 + 0.2).observedUsd, 0.3)
+  })
+
+  it('is safe for an agent that has never spent anything', () => {
+    const v = summariseAgentBudget(null, 0)
+    assert.equal(v.observedUsd, 0)
+    assert.equal(v.health, 'healthy')
+  })
+})

--- a/web/app/dashboard/agent/AgentDetail.tsx
+++ b/web/app/dashboard/agent/AgentDetail.tsx
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { api } from '@/lib/api'
 import { AGENT_TABS, AGENT_TAB_LABEL, type AgentTab } from '@/lib/agentRoute'
-import { Button, Card, Skeleton, TextInput } from '../ui'
+import { Button, Skeleton, TextInput } from '../ui'
 import { Modal, ModalTitle, FormLabel } from '../cockpit/shared'
 import { tk, text, space } from '../tokens'
 import { AgentAvatar, StatusPill, ax, type DAgent, type Getter } from './shared'
@@ -13,6 +13,8 @@ import DashboardTab from './DashboardTab'
 import InstructionsTab from './InstructionsTab'
 import SkillsTab from './SkillsTab'
 import ConfigurationTab from './ConfigurationTab'
+import RunsTab from './RunsTab'
+import BudgetTab from './BudgetTab'
 
 export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getToken, onOpenTask, onOpenLibrary }: {
   orgId: string
@@ -137,7 +139,8 @@ export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getTok
         {tab === 'instructions' && <InstructionsTab orgId={orgId} agentId={agentId} getToken={getToken} />}
         {tab === 'skills' && <SkillsTab orgId={orgId} agentId={agentId} getToken={getToken} onOpenLibrary={onOpenLibrary} />}
         {tab === 'configuration' && <ConfigurationTab orgId={orgId} agentId={agentId} getToken={getToken} onSaved={load} />}
-        {(tab === 'runs' || tab === 'budget') && <TabPanel tab={tab} />}
+        {tab === 'runs' && <RunsTab orgId={orgId} agentId={agentId} getToken={getToken} onOpenTask={onOpenTask} />}
+        {tab === 'budget' && <BudgetTab orgId={orgId} agentId={agentId} agentName={agent.name} getToken={getToken} />}
       </div>
 
       {assignOpen && (
@@ -158,21 +161,3 @@ export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getTok
   )
 }
 
-// Each tab's real panel lands in its own story (AG3–AG6); Dashboard shipped in AG2.
-const PENDING: Record<AgentTab, string> = {
-  dashboard: '',
-  instructions: '',
-  skills: '',
-  configuration: '',
-  runs: 'Run history with per-run logs.',
-  budget: 'This agent’s budget and spend.',
-}
-
-function TabPanel({ tab }: { tab: AgentTab }) {
-  return (
-    <Card style={{ display: 'flex', flexDirection: 'column', gap: space.sm }}>
-      <h2 style={ax.sectionTitle}>{AGENT_TAB_LABEL[tab]}</h2>
-      <p style={{ ...ax.empty, fontSize: text.sm.fontSize }}>Coming in this wave — {PENDING[tab]}</p>
-    </Card>
-  )
-}

--- a/web/app/dashboard/agent/BudgetTab.tsx
+++ b/web/app/dashboard/agent/BudgetTab.tsx
@@ -1,0 +1,137 @@
+'use client'
+// Epic AG / AG6 — Budget tab: this agent's cap and spend. A per-agent cap is a
+// scoped budget policy, so the hard-stop the executor already enforces is the
+// same number shown here — nothing new to keep in sync.
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+import { Button, Card, Skeleton, TextInput } from '../ui'
+import { tk, text, space } from '../tokens'
+import { ax, type Getter } from './shared'
+
+type Budget = {
+  observedUsd: number
+  limitUsd: number | null
+  hardStop: boolean
+  warnPct: number
+  state: 'ok' | 'warn' | 'breach'
+  pct: number | null
+  remainingUsd: number | null
+  health: 'healthy' | 'warning' | 'breached'
+}
+
+// Health chip: icon + label + color — the color never carries the meaning alone.
+const HEALTH: Record<Budget['health'], { icon: string; label: string; color: string }> = {
+  healthy: { icon: '✓', label: 'HEALTHY', color: 'var(--ok)' },
+  warning: { icon: '⚠', label: 'APPROACHING CAP', color: 'var(--warn)' },
+  breached: { icon: '⛔', label: 'OVER BUDGET', color: 'var(--danger-text)' },
+}
+
+export default function BudgetTab({ orgId, agentId, agentName, getToken }: {
+  orgId: string
+  agentId: string
+  agentName: string
+  getToken: Getter
+}) {
+  const [budget, setBudget] = useState<Budget | null>(null)
+  const [draft, setDraft] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const base = `/api/orgs/${orgId}/agents/${agentId}/budget`
+
+  const load = useCallback(async () => {
+    setErr(null)
+    try {
+      const { budget: b } = await api<{ budget: Budget }>(base, { token: await getToken() })
+      setBudget(b)
+      setDraft(b.limitUsd != null ? String(b.limitUsd) : '')
+    } catch (e: any) { setErr(e?.message ?? 'Could not load the budget.') }
+  }, [base, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  const save = async () => {
+    const trimmed = draft.trim()
+    const limitUsd = trimmed === '' ? null : Number(trimmed)
+    if (limitUsd != null && (!Number.isFinite(limitUsd) || limitUsd < 0)) { setErr('Enter a positive amount, or leave it blank for no cap.'); return }
+    setBusy(true); setErr(null); setSaved(false)
+    try {
+      const { budget: b } = await api<{ budget: Budget }>(base, { token: await getToken(), method: 'PUT', body: JSON.stringify({ limitUsd }) })
+      setBudget(b); setSaved(true)
+      setDraft(b.limitUsd != null ? String(b.limitUsd) : '')
+    } catch (e: any) { setErr(e?.message ?? 'Could not set the budget.') }
+    setBusy(false)
+  }
+
+  if (err && !budget) return <div style={ax.err}>{err}</div>
+  if (!budget) return <Skeleton h={220} />
+
+  const h = HEALTH[budget.health]
+  const pct = budget.pct == null ? 0 : Math.min(budget.pct * 100, 100)
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: space.xl }}>
+      {err && <div style={ax.err}>{err}</div>}
+
+      <Card style={{ display: 'flex', flexDirection: 'column', gap: space.lg }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start' }}>
+          <div>
+            <div style={{ fontSize: text.xs.fontSize, color: tk.muted, letterSpacing: 0.6, textTransform: 'uppercase' }}>Agent</div>
+            <div style={{ fontSize: 18, fontWeight: 800, color: tk.text }}>{agentName}</div>
+            <div style={{ fontSize: text.sm.fontSize, color: tk.muted, marginTop: 2 }}>All-time spend against this agent’s cap</div>
+          </div>
+          <span style={{
+            marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: space.xs,
+            fontSize: text.xs.fontSize, fontWeight: 700, letterSpacing: 0.6,
+            color: h.color, border: `1px solid ${h.color}`, borderRadius: tk.r.pill, padding: '2px 9px',
+          }}>
+            <span aria-hidden="true">{h.icon}</span>{h.label}
+          </span>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: space.xl }}>
+          <div>
+            <div style={{ fontSize: text.xs.fontSize, color: tk.muted, letterSpacing: 0.6, textTransform: 'uppercase' }}>Observed</div>
+            <div style={{ fontSize: 26, fontWeight: 800, color: tk.text, lineHeight: 1.2 }}>${budget.observedUsd.toFixed(2)}</div>
+            <div style={{ fontSize: text.xs.fontSize, color: tk.muted }}>{budget.limitUsd == null ? 'No cap configured' : `of $${budget.limitUsd.toFixed(2)}`}</div>
+          </div>
+          <div>
+            <div style={{ fontSize: text.xs.fontSize, color: tk.muted, letterSpacing: 0.6, textTransform: 'uppercase' }}>Budget</div>
+            {/* No policy = unlimited, NOT a zero budget. Say so plainly. */}
+            <div style={{ fontSize: 26, fontWeight: 800, color: budget.limitUsd == null ? tk.muted : tk.text, lineHeight: 1.2 }}>
+              {budget.limitUsd == null ? 'Disabled' : `$${budget.limitUsd.toFixed(2)}`}
+            </div>
+            <div style={{ fontSize: text.xs.fontSize, color: tk.muted }}>
+              {budget.limitUsd == null ? 'Spend is not capped for this agent' : `Soft alert at ${Math.round(budget.warnPct * 100)}%${budget.hardStop ? ' · hard stop at the cap' : ''}`}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: text.xs.fontSize, color: tk.muted, marginBottom: space.xs }}>
+            <span>Remaining</span>
+            <span>{budget.remainingUsd == null ? 'Unlimited' : `$${budget.remainingUsd.toFixed(2)}`}</span>
+          </div>
+          <div style={{ height: 6, background: tk.surfaceHigh, borderRadius: 3, overflow: 'hidden' }}>
+            <div style={{ width: `${pct}%`, height: '100%', background: h.color, borderRadius: 3 }} />
+          </div>
+        </div>
+      </Card>
+
+      <Card style={{ display: 'flex', flexDirection: 'column', gap: space.md }}>
+        <label style={{ fontSize: text.xs.fontSize, color: tk.muted, letterSpacing: 0.6, textTransform: 'uppercase' }} htmlFor="agent-budget">Budget (USD)</label>
+        <div style={{ display: 'flex', gap: space.md, alignItems: 'center', flexWrap: 'wrap' }}>
+          <TextInput id="agent-budget" value={draft} placeholder="0.00" inputMode="decimal" style={{ flex: 1, minWidth: 180 }}
+            onChange={e => setDraft(e.target.value)} onKeyDown={e => { if (e.key === 'Enter') save() }} />
+          <Button variant="primary" onClick={save} disabled={busy}>{busy ? 'Saving…' : 'Set budget'}</Button>
+          {saved && <span style={{ color: tk.green, fontSize: text.sm.fontSize }}>✓ Saved</span>}
+        </div>
+        <p style={{ ...ax.empty, fontSize: text.xs.fontSize }}>
+          Leave blank (or set 0) for no cap. With a cap and hard-stop on, the agent is paused and its queued tasks are
+          parked when the cap is reached — the same enforcement the executor already applies.
+        </p>
+      </Card>
+    </div>
+  )
+}

--- a/web/app/dashboard/agent/RunsTab.tsx
+++ b/web/app/dashboard/agent/RunsTab.tsx
@@ -1,0 +1,160 @@
+'use client'
+// Epic AG / AG6 — Runs tab: the agent's run history (left) and the selected run's
+// detail + log (right), reusing the AG2 `GET …/agents/:id/runs` endpoint.
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+import { Card, Skeleton } from '../ui'
+import { sx } from '../cockpit/shared'
+import { tk, text, space } from '../tokens'
+import { statusColor, statusIcon } from '../status'
+import { ax, type Getter } from './shared'
+
+type Run = {
+  id: string
+  status: string
+  taskId: string | null
+  logs: unknown
+  tokensUsed: number | null
+  costUsd: number | null
+  startedAt: string | number | null
+  endedAt: string | number | null
+}
+type LogLine = { t?: number | string; msg?: string }
+
+const ms = (v: string | number | null): number | null => {
+  if (v == null) return null
+  const n = typeof v === 'number' ? (v < 1e12 ? v * 1000 : v) : Date.parse(v)
+  return Number.isNaN(n) ? null : n
+}
+
+const ago = (v: string | number | null) => {
+  const t = ms(v)
+  if (t == null) return '—'
+  const s = Math.max(0, Math.round((Date.now() - t) / 1000))
+  if (s < 60) return 'just now'
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+const clock = (v: string | number | null) => {
+  const t = ms(v)
+  return t == null ? '—' : new Date(t).toISOString().slice(11, 19)
+}
+
+const duration = (a: string | number | null, b: string | number | null) => {
+  const s = ms(a), e = ms(b)
+  if (s == null || e == null) return null
+  const secs = Math.max(0, Math.round((e - s) / 1000))
+  return secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`
+}
+
+function parseLogs(logs: unknown): LogLine[] {
+  let v: unknown = logs
+  if (typeof v === 'string') { try { v = JSON.parse(v) } catch { return [] } }
+  return Array.isArray(v) ? (v as LogLine[]).filter(l => typeof l?.msg === 'string') : []
+}
+
+export default function RunsTab({ orgId, agentId, getToken, onOpenTask }: {
+  orgId: string
+  agentId: string
+  getToken: Getter
+  onOpenTask?: (taskId: string) => void
+}) {
+  const [runs, setRuns] = useState<Run[] | null>(null)
+  const [selected, setSelected] = useState<string | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setErr(null)
+    try {
+      const { runs: r } = await api<{ runs: Run[] }>(`/api/orgs/${orgId}/agents/${agentId}/runs?limit=50`, { token: await getToken() })
+      setRuns(r)
+      setSelected(cur => cur && r.some(x => x.id === cur) ? cur : (r[0]?.id ?? null))
+    } catch (e: any) { setErr(e?.message ?? 'Could not load runs.') }
+  }, [orgId, agentId, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  if (err && !runs) return <div style={ax.err}>{err}</div>
+  if (!runs) return <div style={{ display: 'flex', gap: space.lg }}><Skeleton w={280} h={220} /><Skeleton h={220} /></div>
+  if (runs.length === 0) return <Card><p style={ax.empty}>This agent has not run yet. Assign it a task, or run a heartbeat.</p></Card>
+
+  const run = runs.find(r => r.id === selected) ?? runs[0]
+  const logs = parseLogs(run.logs)
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'minmax(240px, 320px) 1fr', gap: space.lg, alignItems: 'start' }}>
+
+      {/* ── Run list ─────────────────────────────────────────────────────── */}
+      <Card style={{ padding: 0, overflow: 'hidden', maxHeight: 560, overflowY: 'auto' }}>
+        {runs.map((r, i) => {
+          const on = r.id === run.id
+          return (
+            <button key={r.id} onClick={() => setSelected(r.id)} aria-current={on}
+              style={{
+                display: 'flex', flexDirection: 'column', gap: 2, width: '100%', textAlign: 'left', cursor: 'pointer',
+                padding: `${space.md}px ${space.lg}px`, background: on ? 'var(--accent-dim)' : 'transparent',
+                border: 'none', borderTop: i === 0 ? 'none' : `1px solid ${tk.line}`,
+                borderLeft: `2px solid ${on ? tk.accent : 'transparent'}`,
+              }}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: space.sm, width: '100%' }}>
+                <span aria-hidden="true" style={{ color: statusColor(r.status), fontWeight: 700, fontSize: text.xs.fontSize }}>{statusIcon(r.status)}</span>
+                <code style={{ fontSize: text.xs.fontSize, color: tk.textDim }}>{r.id.slice(0, 8)}</code>
+                <span style={{ marginLeft: 'auto', fontSize: text.xs.fontSize, color: tk.muted }}>{ago(r.startedAt)}</span>
+              </span>
+              <span style={{ fontSize: text.xs.fontSize, color: tk.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: '100%' }}>
+                {parseLogs(r.logs).at(-1)?.msg ?? `Run ${r.status}.`}
+              </span>
+            </button>
+          )
+        })}
+      </Card>
+
+      {/* ── Run detail ───────────────────────────────────────────────────── */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: space.lg }}>
+        <Card style={{ display: 'flex', flexDirection: 'column', gap: space.md }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: space.md, flexWrap: 'wrap' }}>
+            <span style={{ color: statusColor(run.status), fontWeight: 700, fontSize: text.sm.fontSize }}>
+              <span aria-hidden="true">{statusIcon(run.status)}</span> {run.status}
+            </span>
+            <code style={{ ...sx.code }}>{run.id}</code>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(110px, 1fr))', gap: space.lg }}>
+            <Meta label="Started" value={clock(run.startedAt)} />
+            <Meta label="Ended" value={clock(run.endedAt)} />
+            <Meta label="Duration" value={duration(run.startedAt, run.endedAt) ?? (run.status === 'running' ? 'running…' : '—')} />
+            <Meta label="Tokens" value={run.tokensUsed?.toLocaleString() ?? '—'} />
+            <Meta label="Cost" value={run.costUsd != null ? `$${run.costUsd.toFixed(4)}` : '—'} />
+          </div>
+          {run.taskId && onOpenTask && (
+            <button onClick={() => onOpenTask(run.taskId!)}
+              style={{ background: 'transparent', border: 'none', color: tk.accent, cursor: 'pointer', fontSize: text.sm.fontSize, fontWeight: 600, padding: 0, alignSelf: 'flex-start' }}>
+              Open the task this run worked on →
+            </button>
+          )}
+        </Card>
+
+        <Card style={{ display: 'flex', flexDirection: 'column', gap: space.sm }}>
+          <h3 style={{ ...ax.sectionTitle, fontSize: text.sm.fontSize }}>Log ({logs.length})</h3>
+          {logs.length === 0
+            ? <p style={ax.empty}>This run recorded no log lines.</p>
+            : (
+              <pre style={{ ...sx.pre, margin: 0, maxHeight: 380, overflow: 'auto' }}>
+                {logs.map((l, i) => `${l.t ? `${clock(l.t as any)}  ` : ''}${l.msg}`).join('\n')}
+              </pre>
+            )}
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <span style={{ fontSize: text.xs.fontSize, color: tk.muted }}>{label}</span>
+      <span style={{ fontSize: text.sm.fontSize, fontWeight: 700, color: tk.text, fontFamily: 'monospace' }}>{value}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
**Epic AG**, story 6 of 7. All six tabs are now real — the placeholder scaffolding is deleted.

## Backend
- **`services/agent-budget.ts`** (pure, **8 tests**) — shapes an agent's cap + spend for the tab. Two honesty properties: a **missing cap reports Disabled / Unlimited**, never a zero budget that would read as *exhausted*; and **remaining never goes negative** once the cap is blown.
- **`GET/PUT /orgs/:orgId/agents/:agentId/budget`** (PUT owner-gated + snapshotted). A per-agent cap is just a scoped `budgetPolicies` row (`scope:'agent'`), which `enforceAgentBudget` **already** honours — so the number on screen is the number that actually pauses the agent. No parallel store. Clearing the cap **deletes the policy** rather than storing a `0` that every consumer of the budget machinery would read as "exhausted".

## Web
- **`RunsTab.tsx`** — run history list + per-run detail (status · id · started/ended · duration · tokens · cost · log lines), reusing the runs endpoint added in AG2. Links straight to the task the run worked on.
- **`BudgetTab.tsx`** — Observed vs Budget, remaining bar, cap editor, and a **colorblind-safe health chip** (icon + text label + color).

## Verify
- backend: **1014 tests pass** (was 1006), `tsc --noEmit` clean, **evals 11/11**
- web: 135 tests, `npm run build` ✅

Next: AG7 — the Staff grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)