### PR TITLE
feat(AG7): Staff grid — the agent card grid from the operator's mockup

### DIFF
--- a/backend/src/routes/agent-detail.ts
+++ b/backend/src/routes/agent-detail.ts
@@ -18,6 +18,7 @@ import { resolveSelection, splitSkills } from '../services/agent-skills'
 import { validateConfigPatch } from '../services/agent-config'
 import { buildAvatarDataUri } from '../services/agent-avatar'
 import { summariseAgentBudget } from '../services/agent-budget'
+import { buildStaffCards } from '../services/staff-grid'
 import { spendForScope } from '../services/budget'
 
 /** The agent, but only if it belongs to this org. Null otherwise (→ 404). */
@@ -29,6 +30,21 @@ export async function agentInOrg(orgId: string, agentId: string) {
 }
 
 export async function agentDetailRoutes(app: FastifyInstance) {
+  // ─── AG7 — Staff grid: one card per agent, for the Agents area ─────────────
+  // Everything is derived from rows we already have (agents + tasks); the grid
+  // added no columns of its own.
+  app.get('/api/orgs/:orgId/staff', async (req) => {
+    const { orgId } = req.params as { orgId: string }
+    const [agents, tasks] = await Promise.all([
+      db.select().from(schema.agents).where(eq(schema.agents.orgId, orgId)),
+      db.select({
+        agentId: schema.tasks.agentId, status: schema.tasks.status, costUsd: schema.tasks.costUsd,
+        tokensUsed: schema.tasks.tokensUsed, createdAt: schema.tasks.createdAt, completedAt: schema.tasks.completedAt,
+      }).from(schema.tasks).where(eq(schema.tasks.orgId, orgId)),
+    ])
+    return { staff: buildStaffCards({ agents: agents as any, tasks: tasks as any, now: Date.now() }), generatedAt: new Date().toISOString() }
+  })
+
   // AG2 — Dashboard tab: latest run, 14-day charts, recent tasks, costs.
   app.get('/api/orgs/:orgId/agents/:agentId/overview', async (req, reply) => {
     const { orgId, agentId } = req.params as { orgId: string; agentId: string }

--- a/backend/src/services/agent-config.ts
+++ b/backend/src/services/agent-config.ts
@@ -12,6 +12,9 @@
 export const CONFIG_FIELDS = [
   'name', 'title', 'role', 'jobDescription', 'avatarEmoji',
   'reportsTo', 'runtime', 'llmProvider', 'llmModel', 'primaryModel',
+  // AG7 — the email shown under the agent's name on the staff grid. Reuses the
+  // existing contact channel rather than adding a column that means the same thing.
+  'contactChannel',
 ] as const
 
 export type ConfigField = (typeof CONFIG_FIELDS)[number]
@@ -81,6 +84,10 @@ export function validateConfigPatch(
       case 'jobDescription':
         if (value && value.length > 4000) return { ok: false, error: 'Description must be 4000 characters or fewer.' }
         fields.jobDescription = value || null
+        break
+      case 'contactChannel':
+        if (value && value.length > 200) return { ok: false, error: 'Contact must be 200 characters or fewer.' }
+        fields.contactChannel = value || null
         break
       case 'avatarEmoji':
         // An emoji, not an essay — this is the fallback icon when there's no picture.

--- a/backend/src/services/staff-grid.ts
+++ b/backend/src/services/staff-grid.ts
@@ -1,0 +1,149 @@
+// Epic AG / AG7 — the Staff grid: one card per agent, as the operator's mockup
+// shows them (avatar · name · handle · status dot · Tasks Active / Token Cost
+// today / Last active).
+//
+// Pure: the route fetches agents + tasks and hands them over. Everything here is
+// derived from data we already store — no new columns for the grid itself.
+
+export type Ts = number | string | Date | null | undefined
+
+export interface StaffAgent {
+  id: string
+  name: string
+  role: string
+  title?: string | null
+  status: string                    // idle | active | paused | terminated
+  heartbeatStatus?: string | null   // green | amber | stale | unknown
+  avatarEmoji?: string | null
+  avatarUrl?: string | null
+  contactChannel?: string | null    // an email address, when the operator set one
+  runtime?: string | null
+  lastHeartbeatAt?: Ts
+}
+
+export interface StaffTask {
+  agentId: string
+  status: string
+  costUsd?: number | null
+  tokensUsed?: number | null
+  createdAt?: Ts
+  completedAt?: Ts
+}
+
+/**
+ * The three states the grid dot can carry. Colour is NEVER the only signal — each
+ * one ships a shape and a label, because the operator is red-green colorblind
+ * (DESIGN_SYSTEM v2, colorblind rule 3).
+ */
+export type StaffState = 'running' | 'attention' | 'ok'
+
+export interface StaffCard {
+  id: string
+  name: string
+  role: string
+  title: string | null
+  handle: string
+  avatarEmoji: string | null
+  avatarUrl: string | null
+  runtime: string | null
+  status: string
+  state: StaffState
+  /** Human-readable reason for the state — the label rendered next to the dot. */
+  stateLabel: string
+  activeTasks: number
+  costTodayUsd: number
+  tokensToday: number
+  lastActiveAt: number | null
+}
+
+const ACTIVE_TASK_STATES = new Set(['assigned', 'in_progress'])
+const ATTENTION_TASK_STATES = new Set(['blocked', 'failed'])
+
+export function toMs(v: Ts): number | null {
+  if (v == null) return null
+  if (v instanceof Date) return Number.isNaN(v.getTime()) ? null : v.getTime()
+  if (typeof v === 'number') return Number.isFinite(v) ? (v < 1e12 ? v * 1000 : v) : null
+  const t = Date.parse(v)
+  return Number.isNaN(t) ? null : t
+}
+
+const dayKey = (ms: number) => new Date(ms).toISOString().slice(0, 10)
+
+/**
+ * The email/handle under the agent's name. Uses the contact channel when the
+ * operator set a real email; otherwise a derived @handle — we do NOT invent an
+ * email address that does not exist and cannot receive mail.
+ */
+export function staffHandle(agent: Pick<StaffAgent, 'name' | 'contactChannel'>): string {
+  const channel = (agent.contactChannel ?? '').trim()
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(channel)) return channel
+  const slug = agent.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'agent'
+  return `@${slug}`
+}
+
+/**
+ * Which dot the card shows. Precedence: attention > running > ok — an agent that
+ * is busy AND has a blocked task still needs a human, so the card must say so
+ * rather than showing a reassuring "running".
+ */
+export function staffState(agent: StaffAgent, tasks: StaffTask[]): { state: StaffState; stateLabel: string } {
+  if (agent.status === 'paused') return { state: 'attention', stateLabel: 'Paused' }
+  if (agent.status === 'terminated') return { state: 'attention', stateLabel: 'Terminated' }
+  if (agent.heartbeatStatus === 'stale') return { state: 'attention', stateLabel: 'Heartbeat stale' }
+  if (tasks.some(t => ATTENTION_TASK_STATES.has(t.status))) return { state: 'attention', stateLabel: 'Needs attention' }
+  if (agent.status === 'active' || tasks.some(t => t.status === 'in_progress')) return { state: 'running', stateLabel: 'Running' }
+  return { state: 'ok', stateLabel: 'Idle' }
+}
+
+/** Cost + tokens booked today (UTC), by when the task finished (else when it was created). */
+export function todaySpend(tasks: StaffTask[], now: number): { costTodayUsd: number; tokensToday: number } {
+  const today = dayKey(now)
+  let costTodayUsd = 0, tokensToday = 0
+  for (const t of tasks) {
+    const at = toMs(t.completedAt) ?? toMs(t.createdAt)
+    if (at == null || dayKey(at) !== today) continue
+    costTodayUsd += t.costUsd ?? 0
+    tokensToday += t.tokensUsed ?? 0
+  }
+  return { costTodayUsd: Math.round(costTodayUsd * 1e6) / 1e6, tokensToday }
+}
+
+/** When this agent last did something: its heartbeat, or its most recent finished task. */
+export function lastActive(agent: StaffAgent, tasks: StaffTask[]): number | null {
+  const stamps = [toMs(agent.lastHeartbeatAt), ...tasks.map(t => toMs(t.completedAt))].filter((n): n is number => n != null)
+  return stamps.length ? Math.max(...stamps) : null
+}
+
+export function buildStaffCards(input: { agents: StaffAgent[]; tasks: StaffTask[]; now: number }): StaffCard[] {
+  const { agents, tasks, now } = input
+
+  const byAgent = new Map<string, StaffTask[]>()
+  for (const t of tasks) {
+    const list = byAgent.get(t.agentId)
+    if (list) list.push(t)
+    else byAgent.set(t.agentId, [t])
+  }
+
+  return agents.map(a => {
+    const mine = byAgent.get(a.id) ?? []
+    const { state, stateLabel } = staffState(a, mine)
+    const { costTodayUsd, tokensToday } = todaySpend(mine, now)
+    return {
+      id: a.id,
+      name: a.name,
+      role: a.role,
+      title: a.title ?? null,
+      handle: staffHandle(a),
+      avatarEmoji: a.avatarEmoji ?? null,
+      avatarUrl: a.avatarUrl ?? null,
+      runtime: a.runtime ?? null,
+      status: a.status,
+      state,
+      stateLabel,
+      activeTasks: mine.filter(t => ACTIVE_TASK_STATES.has(t.status)).length,
+      costTodayUsd,
+      tokensToday,
+      lastActiveAt: lastActive(a, mine),
+    }
+  })
+}

--- a/backend/src/tests/staff-grid.test.ts
+++ b/backend/src/tests/staff-grid.test.ts
@@ -1,0 +1,130 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildStaffCards, lastActive, staffHandle, staffState, todaySpend, type StaffAgent, type StaffTask } from '../services/staff-grid'
+
+const NOW = Date.parse('2026-07-14T12:00:00.000Z')
+const hoursAgo = (h: number) => new Date(NOW - h * 3_600_000)
+
+const agent = (over: Partial<StaffAgent> = {}): StaffAgent => ({ id: 'a1', name: 'Arturito', role: 'Chief of Staff', status: 'idle', ...over })
+const task = (over: Partial<StaffTask> = {}): StaffTask => ({ agentId: 'a1', status: 'done', ...over })
+
+describe('[AG7] staffHandle', () => {
+  it('uses the contact channel when it is a real email', () => {
+    assert.equal(staffHandle({ name: 'Arturito', contactChannel: 'arturito@7ei.ai' }), 'arturito@7ei.ai')
+  })
+
+  it('derives an @handle rather than inventing an email that cannot receive mail', () => {
+    assert.equal(staffHandle({ name: 'Arturito', contactChannel: null }), '@arturito')
+    assert.equal(staffHandle({ name: '7 Dev Bot', contactChannel: '' }), '@7-dev-bot')
+    assert.equal(staffHandle({ name: 'Arturito', contactChannel: '12345678' }), '@arturito') // a telegram chat id is not an email
+  })
+
+  it('is safe for a name with no usable characters', () => {
+    assert.equal(staffHandle({ name: '???', contactChannel: null }), '@agent')
+  })
+})
+
+describe('[AG7] staffState — colour is never the only signal, so every state carries a label', () => {
+  it('is running when the agent is active or has a task in progress', () => {
+    assert.deepEqual(staffState(agent({ status: 'active' }), []), { state: 'running', stateLabel: 'Running' })
+    assert.deepEqual(staffState(agent(), [task({ status: 'in_progress' })]), { state: 'running', stateLabel: 'Running' })
+  })
+
+  it('is ok when idle with nothing wrong', () => {
+    assert.deepEqual(staffState(agent(), [task({ status: 'done' })]), { state: 'ok', stateLabel: 'Idle' })
+  })
+
+  it('is attention when paused, terminated, stale, or holding a blocked/failed task', () => {
+    assert.equal(staffState(agent({ status: 'paused' }), []).state, 'attention')
+    assert.equal(staffState(agent({ status: 'terminated' }), []).state, 'attention')
+    assert.equal(staffState(agent({ heartbeatStatus: 'stale' }), []).state, 'attention')
+    assert.equal(staffState(agent(), [task({ status: 'blocked' })]).state, 'attention')
+    assert.equal(staffState(agent(), [task({ status: 'failed' })]).state, 'attention')
+  })
+
+  it('lets attention beat running — a busy agent with a blocked task still needs a human', () => {
+    const s = staffState(agent({ status: 'active' }), [task({ status: 'in_progress' }), task({ status: 'blocked' })])
+    assert.equal(s.state, 'attention')
+    assert.equal(s.stateLabel, 'Needs attention')
+  })
+})
+
+describe('[AG7] todaySpend', () => {
+  it('counts only today (UTC), by completion time', () => {
+    const r = todaySpend([
+      task({ completedAt: hoursAgo(2), costUsd: 0.5, tokensUsed: 100 }),
+      task({ completedAt: hoursAgo(1), costUsd: 0.25, tokensUsed: 50 }),
+      task({ completedAt: new Date(NOW - 3 * 86_400_000), costUsd: 9, tokensUsed: 9000 }), // 3 days ago
+    ], NOW)
+    assert.equal(r.costTodayUsd, 0.75)
+    assert.equal(r.tokensToday, 150)
+  })
+
+  it('falls back to createdAt for a task that has not completed', () => {
+    const r = todaySpend([task({ status: 'in_progress', createdAt: hoursAgo(3), costUsd: 0.1, tokensUsed: 10 })], NOW)
+    assert.equal(r.costTodayUsd, 0.1)
+    assert.equal(r.tokensToday, 10)
+  })
+
+  it('is zero for an agent with no work today, and drops float noise', () => {
+    assert.deepEqual(todaySpend([], NOW), { costTodayUsd: 0, tokensToday: 0 })
+    assert.equal(todaySpend([task({ completedAt: hoursAgo(1), costUsd: 0.1 }), task({ completedAt: hoursAgo(1), costUsd: 0.2 })], NOW).costTodayUsd, 0.3)
+  })
+})
+
+describe('[AG7] lastActive', () => {
+  it('is the most recent of the heartbeat and the last finished task', () => {
+    const hb = hoursAgo(5)
+    const done = hoursAgo(2)
+    assert.equal(lastActive(agent({ lastHeartbeatAt: hb }), [task({ completedAt: done })]), done.getTime())
+    assert.equal(lastActive(agent({ lastHeartbeatAt: hoursAgo(1) }), [task({ completedAt: hoursAgo(9) })]), hoursAgo(1).getTime())
+  })
+
+  it('is null for an agent that has never done anything', () => {
+    assert.equal(lastActive(agent(), []), null)
+  })
+})
+
+describe('[AG7] buildStaffCards', () => {
+  const agents = [agent({ id: 'a1', name: 'Arturito', contactChannel: 'arturito@7ei.ai' }), agent({ id: 'a2', name: '7Dev', status: 'active' })]
+  const tasks: StaffTask[] = [
+    task({ agentId: 'a1', status: 'assigned' }),
+    task({ agentId: 'a1', status: 'done', completedAt: hoursAgo(1), costUsd: 0.4, tokensUsed: 400 }),
+    task({ agentId: 'a2', status: 'in_progress' }),
+  ]
+
+  it('builds one card per agent with its own tasks only', () => {
+    const cards = buildStaffCards({ agents, tasks, now: NOW })
+    assert.equal(cards.length, 2)
+
+    const a1 = cards.find(c => c.id === 'a1')!
+    assert.equal(a1.handle, 'arturito@7ei.ai')
+    assert.equal(a1.activeTasks, 1)           // the assigned one; done doesn't count
+    assert.equal(a1.costTodayUsd, 0.4)
+    assert.equal(a1.state, 'ok')
+
+    const a2 = cards.find(c => c.id === 'a2')!
+    assert.equal(a2.handle, '@7dev')
+    assert.equal(a2.activeTasks, 1)           // in_progress
+    assert.equal(a2.state, 'running')
+    assert.equal(a2.costTodayUsd, 0)          // no completed work today
+  })
+
+  it('gives a brand-new agent an honest empty card rather than failing', () => {
+    const [card] = buildStaffCards({ agents: [agent({ id: 'new', name: 'Fresh' })], tasks: [], now: NOW })
+    assert.deepEqual(
+      { activeTasks: card.activeTasks, costTodayUsd: card.costTodayUsd, lastActiveAt: card.lastActiveAt, state: card.state },
+      { activeTasks: 0, costTodayUsd: 0, lastActiveAt: null, state: 'ok' },
+    )
+  })
+
+  it('carries the uploaded avatar through, with the emoji as the fallback', () => {
+    const [withPic] = buildStaffCards({ agents: [agent({ avatarUrl: 'data:image/webp;base64,AAA', avatarEmoji: '🤖' })], tasks: [], now: NOW })
+    assert.equal(withPic.avatarUrl, 'data:image/webp;base64,AAA')
+    assert.equal(withPic.avatarEmoji, '🤖')
+
+    const [noPic] = buildStaffCards({ agents: [agent({ avatarEmoji: '🦎' })], tasks: [], now: NOW })
+    assert.equal(noPic.avatarUrl, null)
+    assert.equal(noPic.avatarEmoji, '🦎')
+  })
+})

--- a/web/app/dashboard/agent/ConfigurationTab.tsx
+++ b/web/app/dashboard/agent/ConfigurationTab.tsx
@@ -30,7 +30,7 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
   const [agent, setAgent] = useState<DAgent | null>(null)
   const [roster, setRoster] = useState<Roster[]>([])
   const [models, setModels] = useState<ModelOption[]>([])
-  const [form, setForm] = useState({ name: '', title: '', role: '', jobDescription: '', avatarEmoji: '', reportsTo: '', runtime: 'internal', model: '' })
+  const [form, setForm] = useState({ name: '', title: '', role: '', jobDescription: '', avatarEmoji: '', reportsTo: '', runtime: 'internal', model: '', contactChannel: '' })
   const [busy, setBusy] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -52,6 +52,7 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
         jobDescription: a.jobDescription ?? '', avatarEmoji: a.avatarEmoji ?? '',
         reportsTo: a.reportsTo ?? '', runtime: a.runtime ?? 'internal',
         model: a.primaryModel || a.llmModel || '',
+        contactChannel: a.contactChannel ?? '',
       })
       try {
         const { models: m } = await api<{ models: ModelOption[] }>(`/api/orgs/${orgId}/available-models`, { token })
@@ -71,7 +72,7 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
         body: JSON.stringify({
           name: form.name, title: form.title, role: form.role,
           jobDescription: form.jobDescription, avatarEmoji: form.avatarEmoji,
-          reportsTo: form.reportsTo, runtime: form.runtime,
+          reportsTo: form.reportsTo, runtime: form.runtime, contactChannel: form.contactChannel,
           ...(form.model ? { llmModel: form.model, primaryModel: form.model, ...(chosen ? { llmProvider: chosen.provider } : {}) } : {}),
         }),
       })
@@ -162,6 +163,10 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
               <TextInput value={form.title} placeholder="e.g. VP of Engineering" onChange={e => setForm({ ...form, title: e.target.value })} />
             </FormLabel>
           </div>
+          <FormLabel>Email <span style={{ fontWeight: 400, color: tk.muted }}>· shown on the staff grid; blank falls back to an @handle</span>
+            <TextInput value={form.contactChannel} placeholder="agent@7ei.ai" inputMode="email"
+              onChange={e => setForm({ ...form, contactChannel: e.target.value })} />
+          </FormLabel>
           <FormLabel>Description
             <TextArea value={form.jobDescription} placeholder="Describe what this agent can do…"
               onChange={e => setForm({ ...form, jobDescription: e.target.value })} style={{ minHeight: 78 }} />

--- a/web/app/dashboard/agent/StaffGrid.tsx
+++ b/web/app/dashboard/agent/StaffGrid.tsx
@@ -1,0 +1,155 @@
+'use client'
+// Epic AG / AG7 — the Staff grid: a card per agent (avatar · name · handle ·
+// status dot · Tasks Active / Token Cost today / Last active), matching the
+// operator's mockup with design tokens only (glass fill + purple accent ring —
+// no raw hex).
+//
+// Colorblind-safety (DESIGN_SYSTEM v2 rule 3): the dot is never the only signal.
+// Each card renders shape + text label next to the colour, and the whole card
+// carries an aria-label saying the state out loud.
+import { useCallback, useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+import { Skeleton } from '../ui'
+import { tk, text, space } from '../tokens'
+import { AgentAvatar, ax, type Getter } from './shared'
+
+export type StaffCard = {
+  id: string
+  name: string
+  role: string
+  title: string | null
+  handle: string
+  avatarEmoji: string | null
+  avatarUrl: string | null
+  runtime: string | null
+  status: string
+  state: 'running' | 'attention' | 'ok'
+  stateLabel: string
+  activeTasks: number
+  costTodayUsd: number
+  tokensToday: number
+  lastActiveAt: number | null
+}
+
+// Shape + colour per state. Blue = running, yellow = attention, green = idle-ok —
+// the mockup's palette, mapped onto theme tokens.
+const STATE: Record<StaffCard['state'], { color: string; icon: string }> = {
+  running: { color: 'var(--info)', icon: '⬡' },
+  attention: { color: 'var(--warn)', icon: '⚠' },
+  ok: { color: 'var(--ok)', icon: '✓' },
+}
+
+const ago = (ms: number | null): string => {
+  if (ms == null) return 'never'
+  const s = Math.max(0, Math.round((Date.now() - ms) / 1000))
+  if (s < 60) return 'just now'
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`
+  return `${Math.floor(s / 86400)}d ago`
+}
+
+const money = (n: number) => (n === 0 ? '$0.00' : n < 0.01 ? `$${n.toFixed(4)}` : `$${n.toFixed(2)}`)
+
+export default function StaffGrid({ orgId, getToken, onOpenAgent }: {
+  orgId: string
+  getToken: Getter
+  onOpenAgent: (agentId: string) => void
+}) {
+  const [staff, setStaff] = useState<StaffCard[] | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setErr(null)
+    try {
+      const { staff: s } = await api<{ staff: StaffCard[] }>(`/api/orgs/${orgId}/staff`, { token: await getToken() })
+      setStaff(s)
+    } catch (e: any) { setErr(e?.message ?? 'Could not load the staff.') }
+  }, [orgId, getToken])
+
+  useEffect(() => { load() }, [load])
+
+  if (err && !staff) return <div style={ax.err}>{err}</div>
+  if (!staff) return (
+    <div style={grid}>
+      {[0, 1, 2, 3, 4, 5].map(i => <Skeleton key={i} h={280} style={{ borderRadius: 16 }} />)}
+    </div>
+  )
+  if (staff.length === 0) return <p style={ax.empty}>No agents yet — hire one from the Operations cockpit.</p>
+
+  return (
+    <div style={grid}>
+      {staff.map(a => {
+        const st = STATE[a.state]
+        return (
+          <article key={a.id} className="mc-glass" role="button" tabIndex={0}
+            aria-label={`${a.name}, ${a.title || a.role}. ${a.stateLabel}. ${a.activeTasks} active task${a.activeTasks === 1 ? '' : 's'}.`}
+            onClick={() => onOpenAgent(a.id)}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOpenAgent(a.id) } }}
+            style={{
+              display: 'flex', flexDirection: 'column', gap: space.lg, cursor: 'pointer',
+              border: `1px solid var(--accent-line)`, borderRadius: 16, padding: space.xl,
+              boxShadow: `0 0 0 1px var(--accent-glow)`, position: 'relative', overflow: 'hidden',
+            }}>
+
+            {/* Name + handle + status dot */}
+            <header style={{ display: 'flex', alignItems: 'flex-start', gap: space.md }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <h3 style={{ margin: 0, fontSize: 20, fontWeight: 800, letterSpacing: -0.3, color: tk.text, textTransform: 'uppercase', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {a.name}
+                </h3>
+                <div style={{ fontSize: text.sm.fontSize, color: tk.muted, marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis' }}>{a.handle}</div>
+              </div>
+              {/* Dot + shape + label — never colour alone. */}
+              <span title={a.stateLabel} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, flexShrink: 0 }}>
+                <span aria-hidden="true" style={{
+                  width: 22, height: 22, borderRadius: '50%', background: st.color,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  color: 'var(--s0)', fontSize: 12, fontWeight: 800, lineHeight: 1,
+                }}>{st.icon}</span>
+                <span style={{ fontSize: 9, fontWeight: 700, color: st.color, letterSpacing: 0.4, textTransform: 'uppercase', whiteSpace: 'nowrap' }}>
+                  {a.stateLabel}
+                </span>
+              </span>
+            </header>
+
+            {/* Avatar — the uploaded picture, else the icon/emoji */}
+            <div style={{ display: 'flex', justifyContent: 'center', padding: `${space.sm}px 0` }}>
+              <AgentAvatar agent={a} size={132} radius={14} />
+            </div>
+
+            <div style={{ fontSize: text.xs.fontSize, color: tk.muted, textAlign: 'center', marginTop: -space.sm }}>
+              {a.title || a.role}
+            </div>
+
+            {/* Metric chips */}
+            <footer style={{ display: 'flex', gap: space.sm, flexWrap: 'wrap', marginTop: 'auto' }}>
+              <Chip label="Tasks Active" value={String(a.activeTasks)} tone={a.activeTasks > 0 ? 'var(--accent)' : tk.muted} />
+              <Chip label="Token Cost today" value={money(a.costTodayUsd)} tone={a.costTodayUsd > 0 ? 'var(--accent)' : tk.muted} />
+              <Chip label="Last active" value={ago(a.lastActiveAt)} tone={tk.muted} />
+            </footer>
+          </article>
+        )
+      })}
+    </div>
+  )
+}
+
+function Chip({ label, value, tone }: { label: string; value: string; tone: string }) {
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: space.xs,
+      border: `1px solid ${tk.line}`, borderRadius: tk.r.pill, padding: `3px ${space.md}px`,
+      background: tk.surfaceHigh, fontSize: text.xs.fontSize, whiteSpace: 'nowrap',
+    }}>
+      <span aria-hidden="true" style={{ width: 8, height: 8, borderRadius: '50%', background: tone, flexShrink: 0 }} />
+      <span style={{ color: tk.muted }}>{label}</span>
+      <strong style={{ color: tk.text }}>{value}</strong>
+    </span>
+  )
+}
+
+const grid: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+  gap: space.xl,
+}

--- a/web/app/dashboard/agent/shared.tsx
+++ b/web/app/dashboard/agent/shared.tsx
@@ -27,6 +27,8 @@ export type DAgent = {
   lastHeartbeatAt?: number | null
   termsOfReference?: string | null
   jobDescription?: string | null
+  /** AG7 — the email shown on the staff card (blank → a derived @handle). */
+  contactChannel?: string | null
 }
 
 /**

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import GovernancePanel from './GovernancePanel'
 import Sidebar from './Sidebar'
 import PlaceholderView from './PlaceholderView'
 import AgentDetail from './agent/AgentDetail'
+import StaffGrid from './agent/StaffGrid'
 import { allNavItems, isPlaceholder, isSection, navSectionKey, findNavItem } from '@/lib/navModel'
 import { agentRouteHash, parseAgentRoute, type AgentRoute, type AgentTab } from '@/lib/agentRoute'
 import { useTheme } from '../theme'
@@ -60,6 +61,8 @@ export default function DashboardPage() {
   // AG1 — the agent detail page lives inside the `agents` area and deep-links
   // through the URL hash (#agents/<id>/<tab>), parsed by the pure lib/agentRoute.
   const [agentRoute, setAgentRoute] = useState<AgentRoute | null>(null)
+  // AG7 — the Agents roster renders as the Staff card grid by default, or a dense table.
+  const [agentView, setAgentView] = useState<'staff' | 'table'>('staff')
   const [loading, setLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
   // Org creation (web onboarding — backend auto-creates Arturito on first org)
@@ -396,20 +399,39 @@ export default function DashboardPage() {
               onOpenLibrary={() => selectTab('skills')} />
           : (
           <div style={s.page}>
-            <h1 style={s.h1}>Agents ({agents.length})</h1>
-            <div style={s.table}>
-              <div style={{ ...s.thead, gridTemplateColumns: '2fr 2fr 1.5fr 1fr 1fr' }}><span>Name</span><span>Role</span><span>Model</span><span>Skills</span><span>Status</span></div>
-              {agents.map(a => (
-                <div key={a.id} role="button" tabIndex={0} aria-label={`Open ${a.name}`}
-                  onClick={() => openAgent(a.id)} onKeyDown={e => { if (e.key === 'Enter') openAgent(a.id) }}
-                  style={{ ...s.trow, gridTemplateColumns: '2fr 2fr 1.5fr 1fr 1fr', cursor: 'pointer' }}>
-                  <span>{a.avatarEmoji} {a.name}</span><span style={{ color: 'var(--muted)', fontSize: 13 }}>{a.role}</span>
-                  <span style={{ color: 'var(--muted)', fontSize: 12 }}>{a.llmModel.split('-').slice(0, 3).join('-')}</span>
-                  <span style={{ color: 'var(--muted)', fontSize: 12 }}>{a.skills.length}</span>
-                  <span style={{ color: statusColor(a.status), fontSize: 13, fontWeight: 600, textTransform: 'capitalize' }}>{statusIcon(a.status)} {a.status}</span>
-                </div>
-              ))}
+            {/* AG7 — Staff (card grid, the default) vs the dense table. */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+              <h1 style={s.h1}>Agents ({agents.length})</h1>
+              <div role="tablist" aria-label="Agent view" style={{ display: 'flex', gap: 4, marginLeft: 'auto' }}>
+                {([['staff', 'Staff'], ['table', 'Table']] as const).map(([v, label]) => (
+                  <button key={v} role="tab" aria-selected={agentView === v} onClick={() => setAgentView(v)}
+                    style={{
+                      background: agentView === v ? 'var(--accent-dim)' : 'transparent',
+                      border: `1px solid ${agentView === v ? 'var(--accent-line)' : 'var(--line-strong)'}`,
+                      color: agentView === v ? 'var(--accent)' : 'var(--muted)',
+                      borderRadius: 8, padding: '6px 14px', cursor: 'pointer', fontSize: 12.5, fontWeight: 700,
+                    }}>{label}</button>
+                ))}
+              </div>
             </div>
+
+            {agentView === 'staff'
+              ? <StaffGrid orgId={org.id} getToken={getToken} onOpenAgent={openAgent} />
+              : (
+                <div style={s.table}>
+                  <div style={{ ...s.thead, gridTemplateColumns: '2fr 2fr 1.5fr 1fr 1fr' }}><span>Name</span><span>Role</span><span>Model</span><span>Skills</span><span>Status</span></div>
+                  {agents.map(a => (
+                    <div key={a.id} role="button" tabIndex={0} aria-label={`Open ${a.name}`}
+                      onClick={() => openAgent(a.id)} onKeyDown={e => { if (e.key === 'Enter') openAgent(a.id) }}
+                      style={{ ...s.trow, gridTemplateColumns: '2fr 2fr 1.5fr 1fr 1fr', cursor: 'pointer' }}>
+                      <span>{a.avatarEmoji} {a.name}</span><span style={{ color: 'var(--muted)', fontSize: 13 }}>{a.role}</span>
+                      <span style={{ color: 'var(--muted)', fontSize: 12 }}>{a.llmModel.split('-').slice(0, 3).join('-')}</span>
+                      <span style={{ color: 'var(--muted)', fontSize: 12 }}>{a.skills.length}</span>
+                      <span style={{ color: statusColor(a.status), fontSize: 13, fontWeight: 600, textTransform: 'capitalize' }}>{statusIcon(a.status)} {a.status}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
           </div>
         ))}
 


### PR DESCRIPTION
**Epic AG**, story 7 of 7 — Part A of the brief. The Agents area now opens on a **Staff card grid** (with a Grid | Table toggle); clicking a card opens that agent's detail page.

## Backend
- **`services/staff-grid.ts`** (pure, **15 tests**) + **`GET /orgs/:orgId/staff`**. Every number is derived from rows we already store — **the grid added no columns of its own**.
  - **`staffState`** — precedence is **attention > running > ok**: a busy agent that is holding a blocked task reads as *"Needs attention"*, not a reassuring *"Running"*.
  - **`staffHandle`** — uses the contact email when the operator set one; otherwise a derived **`@handle`**. It does **not** fabricate an `agent@company.com` that cannot receive mail.
  - **`todaySpend` / `lastActive`** — today's cost + tokens (UTC), and the most recent of the heartbeat or a finished task.
- **`contactChannel`** added to the AG5 config allowlist, so the operator can set the email the card shows. Reuses the existing column rather than adding one that means the same thing.

## Web
**`StaffGrid.tsx`** — the mockup's card, in design tokens only (no raw hex): glass fill + purple accent ring, large avatar (**uploaded picture → icon/emoji fallback**), name, handle, status dot, and the three footer chips — **Tasks Active · Token Cost today · Last active**. Responsive `auto-fill` grid; cards are keyboard-operable.

**Colorblind-safe:** the dot never carries the meaning alone — it always ships a **shape and a text label** (⬡ RUNNING / ⚠ NEEDS ATTENTION / ✓ IDLE), and each card has an `aria-label` stating its state.

## Verify
- backend: **1029 tests pass** (was 1014), `tsc --noEmit` clean, **evals 11/11**
- web: 135 tests, `npm run build` ✅

Epic AG complete: staff grid + a six-tab agent detail page. Docs/trackers land next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)