### PR TITLE
fix(AG): CORS blocked every PUT/DELETE — Instructions save + avatar remove

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config'
 import Fastify, { type FastifyError } from 'fastify'
 import cors from '@fastify/cors'
+import { corsOptions } from './middleware/cors'
 import helmet from '@fastify/helmet'
 import websocket from '@fastify/websocket'
 import multipart from '@fastify/multipart'
@@ -60,15 +61,9 @@ async function start() {
     crossOriginEmbedderPolicy: false,
   })
 
-  await app.register(cors, {
-    origin: process.env.ALLOWED_ORIGINS?.split(',') ?? [
-      'http://localhost:3000',
-      'http://localhost:8081',
-      'https://7ei.ai',
-      'https://app.7ei.ai',
-    ],
-    credentials: true,
-  })
+  // Method list is explicit — the @fastify/cors default is GET,HEAD,POST, which
+  // silently breaks every PUT/PATCH/DELETE from the dashboard. See middleware/cors.ts.
+  await app.register(cors, corsOptions())
 
   await app.register(websocket)
   await app.register(multipart, { limits: { fileSize: 25 * 1024 * 1024 } })  // 25 MB document uploads

--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -1,0 +1,34 @@
+// CORS policy for the browser-facing API.
+//
+// Extracted from index.ts so it can be asserted in a test. The reason it exists
+// as its own module is a bug it caused: @fastify/cors v11 defaults
+// `methods` to 'GET,HEAD,POST'. Any route the dashboard reaches with PUT,
+// PATCH or DELETE therefore failed its preflight in the browser — the request
+// was never sent, fetch rejected, and `web/lib/api.ts` reported the transport
+// failure as "Network error — backend unreachable". That is what broke the AG
+// Instructions save (PUT), the avatar Remove (DELETE) and the Skills checkboxes
+// (PUT), while the avatar upload (POST) kept working.
+//
+// The method list must therefore cover every verb the routes actually register.
+// `boot.test.ts` walks the route table and fails if a verb is missing here.
+
+/** Every HTTP verb the API exposes to a browser. */
+export const CORS_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const
+
+export const DEFAULT_ORIGINS = [
+  'http://localhost:3000',
+  'http://localhost:8081',
+  'https://7ei.ai',
+  'https://app.7ei.ai',
+]
+
+export function corsOptions(env: NodeJS.ProcessEnv = process.env) {
+  return {
+    origin: env.ALLOWED_ORIGINS?.split(',').map(o => o.trim()).filter(Boolean) ?? DEFAULT_ORIGINS,
+    methods: [...CORS_METHODS],
+    // The dashboard sends the Clerk bearer token and JSON bodies; multipart
+    // avatar uploads let the browser set their own Content-Type boundary.
+    allowedHeaders: ['Authorization', 'Content-Type'],
+    credentials: true,
+  }
+}

--- a/backend/src/tests/cors.test.ts
+++ b/backend/src/tests/cors.test.ts
@@ -1,0 +1,97 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import Fastify from 'fastify'
+import cors from '@fastify/cors'
+
+// Regression guard for the bug that broke the Agents pages in production:
+// @fastify/cors v11 defaults `methods` to 'GET,HEAD,POST'. The AG routes are
+// PUT (Instructions save, Skills selection, Config) and DELETE (avatar remove,
+// file delete), so the browser's preflight was answered with an
+// Access-Control-Allow-Methods that did not list the verb, the real request was
+// never sent, and the dashboard surfaced it as "Network error — backend
+// unreachable". The routes themselves were fine and deployed.
+//
+// These tests exercise the actual preflight, not the options object, so a future
+// upgrade that changes the default cannot reintroduce the failure silently.
+
+import { CORS_METHODS, DEFAULT_ORIGINS, corsOptions } from '../middleware/cors'
+import { agentDetailRoutes } from '../routes/agent-detail'
+
+const ORIGIN = 'https://app.7ei.ai'
+
+async function appWithCors(env: NodeJS.ProcessEnv = {} as NodeJS.ProcessEnv) {
+  const app = Fastify({ logger: false })
+  await app.register(cors, corsOptions(env))
+  await app.register(agentDetailRoutes)
+  await app.ready()
+  return app
+}
+
+const preflight = (app: Awaited<ReturnType<typeof appWithCors>>, method: string, url: string) =>
+  app.inject({
+    method: 'OPTIONS',
+    url,
+    headers: {
+      origin: ORIGIN,
+      'access-control-request-method': method,
+      'access-control-request-headers': 'authorization,content-type',
+    },
+  })
+
+test('[AGFIX1] preflight allows every verb the dashboard uses', async () => {
+  const app = await appWithCors()
+  const cases: [string, string][] = [
+    ['PUT', '/api/orgs/o1/agents/a1/files'],       // BUG 1 — Instructions save
+    ['DELETE', '/api/orgs/o1/agents/a1/avatar'],   // BUG 2 — avatar remove
+    ['PUT', '/api/orgs/o1/agents/a1/skills'],      // Skills checkboxes
+    ['PUT', '/api/orgs/o1/agents/a1/config'],
+    ['PUT', '/api/orgs/o1/agents/a1/budget'],
+    ['DELETE', '/api/orgs/o1/agents/a1/files'],
+    ['POST', '/api/orgs/o1/agents/a1/avatar'],     // upload — worked before, must keep working
+  ]
+
+  for (const [method, url] of cases) {
+    const res = await preflight(app, method, url)
+    assert.ok(res.statusCode < 300, `${method} ${url}: preflight status ${res.statusCode}`)
+    const allowed = String(res.headers['access-control-allow-methods'] ?? '')
+      .split(',').map(s => s.trim().toUpperCase())
+    assert.ok(allowed.includes(method), `${method} ${url}: allow-methods was "${allowed.join(',')}"`)
+    assert.equal(res.headers['access-control-allow-origin'], ORIGIN)
+  }
+  await app.close()
+})
+
+test('[AGFIX1] CORS_METHODS covers every verb the agent routes register', async () => {
+  const app = Fastify({ logger: false })
+  const seen = new Set<string>()
+  app.addHook('onRoute', r => {
+    for (const m of ([] as string[]).concat(r.method as string | string[])) seen.add(m.toUpperCase())
+  })
+  await app.register(agentDetailRoutes)
+  await app.ready()
+
+  const allowed = new Set<string>(CORS_METHODS)
+  for (const m of seen) {
+    assert.ok(allowed.has(m), `route verb ${m} is registered but missing from CORS_METHODS — the browser cannot call it`)
+  }
+  // Sanity: the guard is only meaningful if it actually saw the verbs at issue.
+  assert.ok(seen.has('PUT') && seen.has('DELETE'))
+  await app.close()
+})
+
+test('[AGFIX1] allowed origins come from ALLOWED_ORIGINS, trimmed', () => {
+  assert.deepEqual(corsOptions({} as NodeJS.ProcessEnv).origin, DEFAULT_ORIGINS)
+  const o = corsOptions({ ALLOWED_ORIGINS: 'https://a.7ei.ai, https://b.7ei.ai' } as NodeJS.ProcessEnv)
+  assert.deepEqual(o.origin, ['https://a.7ei.ai', 'https://b.7ei.ai'])
+})
+
+test('[AGFIX1] an origin that is not allow-listed gets no CORS grant', async () => {
+  const app = await appWithCors()
+  const res = await app.inject({
+    method: 'OPTIONS',
+    url: '/api/orgs/o1/agents/a1/files',
+    headers: { origin: 'https://evil.example', 'access-control-request-method': 'PUT' },
+  })
+  assert.equal(res.headers['access-control-allow-origin'], undefined)
+  await app.close()
+})

--- a/web/app/dashboard/agent/InstructionsTab.tsx
+++ b/web/app/dashboard/agent/InstructionsTab.tsx
@@ -63,7 +63,12 @@ export default function InstructionsTab({ orgId, agentId, getToken }: { orgId: s
       await api(`${base}`, { token: await getToken(), method: 'PUT', body: JSON.stringify({ path, content: body }) })
       setContent(body); setStored(true); setEditing(false)
       await loadFiles()
-    } catch (e: any) { setErr(e?.message ?? 'Could not save that file.') }
+    } catch (e: any) {
+      // Name the file. "Could not save" with four files on screen is not an
+      // error message, it's a riddle — and the edit is still in the draft, so
+      // say that too rather than let the operator think the work is gone.
+      setErr(`Could not save ${path} — ${e?.message ?? 'the request failed'}. Your changes are still in the editor.`)
+    }
     setBusy(false)
   }
 
@@ -82,7 +87,7 @@ export default function InstructionsTab({ orgId, agentId, getToken }: { orgId: s
       await api(`${base}?path=${encodeURIComponent(path)}`, { token: await getToken(), method: 'DELETE' })
       setSelected(null)
       await loadFiles()
-    } catch (e: any) { setErr(e?.message ?? 'Could not delete that file.') }
+    } catch (e: any) { setErr(`Could not delete ${path} — ${e?.message ?? 'the request failed'}.`) }
     setBusy(false)
   }
 

--- a/web/lib/api.test.ts
+++ b/web/lib/api.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { transportError } from './api.ts'
+
+// The message the operator actually reads when a write fails before it leaves
+// the browser. It used to be a bare "Network error — backend unreachable" for
+// every case, which sent us hunting a dead backend while the real cause was a
+// CORS policy that did not allow PUT/DELETE.
+
+test('[AGFIX1] a failed write names the method and path, and points at CORS', () => {
+  const msg = transportError('PUT', '/api/orgs/o1/agents/a1/files')
+  assert.match(msg, /PUT \/api\/orgs\/o1\/agents\/a1\/files/)
+  assert.match(msg, /CORS/)
+})
+
+test('[AGFIX1] a failed read stays a plain unreachable message', () => {
+  const msg = transportError('GET', '/api/orgs/o1/agents/a1/files')
+  assert.match(msg, /could not reach the backend/)
+  assert.doesNotMatch(msg, /CORS/)
+})
+
+test('[AGFIX1] the method is normalised', () => {
+  assert.match(transportError('delete', '/x'), /DELETE \/x/)
+})

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -11,8 +11,25 @@ export const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'
 
 export type ApiInit = RequestInit & { token?: string | null }
 
+/**
+ * What a rejected fetch actually means. A bare "backend unreachable" hid a real
+ * bug for a week: the backend was up and the route was deployed, but its CORS
+ * policy did not allow PUT/DELETE, so the browser refused to send the request
+ * and fetch rejected exactly as it does when the host is down. Name the two
+ * cases apart — a failed write to a reachable API is a very different bug from a
+ * dead backend, and the operator should not have to open devtools to tell.
+ */
+export function transportError(method: string, path: string): string {
+  const m = method.toUpperCase()
+  const where = `${m} ${path}`
+  return m === 'GET' || m === 'HEAD'
+    ? `Network error — could not reach the backend (${where}). Check your connection.`
+    : `Network error — the browser could not send ${where}. The backend is either unreachable or is refusing this request before it arrives (a CORS policy that does not allow ${m} does exactly this).`
+}
+
 export async function api<T>(path: string, init?: ApiInit): Promise<T> {
   const { token, ...opts } = init ?? {}
+  const method = (opts.method ?? 'GET').toUpperCase()
   let res: Response
   try {
     res = await fetch(`${API}${path}`, {
@@ -20,8 +37,9 @@ export async function api<T>(path: string, init?: ApiInit): Promise<T> {
       headers: { ...(token ? { Authorization: `Bearer ${token}` } : {}), 'Content-Type': 'application/json', ...(opts.headers ?? {}) },
     })
   } catch {
-    // fetch rejects (TypeError) only on network-level failure
-    throw new Error('Network error — backend unreachable')
+    // fetch rejects (TypeError) on network-level failure AND on a blocked
+    // preflight — the browser gives JS no way to tell them apart.
+    throw new Error(transportError(method, path))
   }
   if (res.status === 204) return {} as T
   const j = await res.json().catch(() => ({}))


### PR DESCRIPTION
## Root cause (one bug, three symptoms)

`@fastify/cors` v11 defaults `methods` to **`GET,HEAD,POST`**. `src/index.ts` registered CORS without a method list, so the deployed backend answered every preflight with:

```
access-control-allow-methods: GET,HEAD,POST
```

The browser therefore refused to send **any** PUT/PATCH/DELETE. `fetch` rejects on a blocked preflight exactly as it does on a dead host, and `web/lib/api.ts` collapsed that to *"Network error — backend unreachable"* — which sent us looking for an undeployed route. The routes were deployed and healthy all along (verified: unauthenticated `PUT …/files` returns 401, not 404).

Verified against prod before the fix:

```
$ curl -X OPTIONS https://7ei-backend.fly.dev/api/orgs/o1/agents/a1/files \
    -H 'Origin: https://app.7ei.ai' -H 'Access-Control-Request-Method: PUT'
access-control-allow-methods: GET,HEAD,POST     <- PUT not allowed
```

This explains **BUG 1** (Instructions save, PUT), **BUG 2** (avatar Remove is a DELETE; upload is a POST, which is why upload worked), and why the **Skills checkboxes** looked read-only — the toggle was already wired to a PUT that could never leave the browser.

## Fix

- **`backend/src/middleware/cors.ts`** — explicit `CORS_METHODS`, extracted from `index.ts` so it is testable.
- **Tests** — inject a real OPTIONS preflight for each verb the dashboard uses, plus a guard that walks `agentDetailRoutes`' route table and fails if any registered verb is missing from `CORS_METHODS`. A future dependency default cannot silently reintroduce this.
- **`web/lib/api.ts`** — a rejected write now names the method and path and names CORS as a cause; reads keep the plain unreachable message. The Instructions tab names the failing file and tells the operator the draft is still in the editor.

## Verify

- backend `npm test` -> **1033 pass, 0 fail** · `npm run evals` -> **11/11** · `typecheck` clean
- web `npm test` -> **138 pass** (3 new) · `npm run build` -> passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)