### PR TITLE
feat(AG): Skills tab — editable, persisted, and no longer blocked by orphans

### DIFF
--- a/backend/src/routes/agent-detail.ts
+++ b/backend/src/routes/agent-detail.ts
@@ -198,7 +198,10 @@ export async function agentDetailRoutes(app: FastifyInstance) {
     if (!agent) return reply.code(404).send({ error: 'Agent not found' })
 
     const library = await db.select().from(schema.skills)
-    const resolved = resolveSelection(library, (req.body as { skills?: unknown })?.skills)
+    // Pass what the agent already has: an orphaned skill (library row deleted
+    // underneath it) is echoed back by the checkbox list and must not be treated
+    // as an unknown name, or every toggle on that agent fails.
+    const resolved = resolveSelection(library, (req.body as { skills?: unknown })?.skills, (agent.skills as string[]) ?? [])
     if (resolved.ok === false) return reply.code(400).send({ error: resolved.error })
 
     await db.update(schema.agents).set({ skills: resolved.names }).where(eq(schema.agents.id, agentId))

--- a/backend/src/services/agent-skills.ts
+++ b/backend/src/services/agent-skills.ts
@@ -49,21 +49,34 @@ export function splitSkills(library: SkillLike[], installedNames: string[]) {
 
 /**
  * Resolve a requested selection (skill names) against the library.
- * Unknown names are reported, not written — the agent's skill list may only ever
- * contain names the library actually has.
+ *
+ * A name the library does not have is refused — the agent's skill list may only
+ * ever gain names the library actually has. The exception is a name the agent is
+ * ALREADY carrying (an orphan: the library row was deleted underneath it). The
+ * checkbox list resends the whole selection, orphans included, so refusing those
+ * made every toggle 400 on any agent that had one — the tab was unusable and
+ * looked read-only. An orphan the operator kept ticked is kept; unticking it
+ * drops it, which is the only way to get rid of one.
  */
-export function resolveSelection(library: SkillLike[], requested: unknown): { ok: true; names: string[] } | { ok: false; error: string } {
+export function resolveSelection(
+  library: SkillLike[],
+  requested: unknown,
+  stored: string[] = [],
+): { ok: true; names: string[] } | { ok: false; error: string } {
   if (!Array.isArray(requested)) return { ok: false, error: 'skills must be an array of skill names' }
   if (!requested.every(n => typeof n === 'string')) return { ok: false, error: 'skills must be an array of skill names' }
 
   const names = dedupe(requested as string[])
   const known = new Set(library.map(s => s.name))
-  const unknown = names.filter(n => !known.has(n))
+  const alreadyOn = new Set(dedupe(stored))
+  const unknown = names.filter(n => !known.has(n) && !alreadyOn.has(n))
   if (unknown.length) return { ok: false, error: `Unknown skill(s): ${unknown.join(', ')}` }
 
   // Keep library order so the stored array is stable regardless of click order.
+  // Orphans have no library index; park them after the known ones.
   const order = new Map(library.map((s, i) => [s.name, i]))
-  return { ok: true, names: names.sort((a, b) => (order.get(a) ?? 0) - (order.get(b) ?? 0)) }
+  const idx = (n: string) => order.get(n) ?? Number.MAX_SAFE_INTEGER
+  return { ok: true, names: names.sort((a, b) => idx(a) - idx(b)) }
 }
 
 function dedupe(names: string[]): string[] {

--- a/backend/src/tests/agent-detail-routes.test.ts
+++ b/backend/src/tests/agent-detail-routes.test.ts
@@ -1,0 +1,201 @@
+// Route-level tests for the AG write paths — the ones the operator hit as bugs.
+//
+// The unit tests cover the pure services and `cors.test.ts` covers the transport,
+// but neither would have caught a handler that accepts the request and persists
+// nothing. These drive the REAL handlers against a REAL SQLite file through the
+// REAL owner gate, then read the row back. A save that does not survive a
+// re-read is not a save.
+//
+// DATABASE_URL is pointed at a temp file BEFORE db/client is imported (it reads
+// the env at module load), so this never touches the operator's dev.db or Turso.
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+const tmp = mkdtempSync(join(tmpdir(), 'ag-routes-'))
+process.env.DATABASE_URL = `file:${join(tmp, 'test.db')}`
+delete process.env.DATABASE_AUTH_TOKEN
+
+const { db, schema } = await import('../db/client')
+const { setupDatabase } = await import('../db/setup')
+const { agentDetailRoutes } = await import('../routes/agent-detail')
+const { eq } = await import('drizzle-orm')
+
+const ORG = 'org-ag', OWNER = 'user-owner', MEMBER = 'user-member', AGENT = 'agent-ag'
+
+let app: FastifyInstance
+
+/** The app as the secured scope builds it: Clerk resolved to a userId on req.auth. */
+function appAs(userId: string) {
+  const a = Fastify({ logger: false })
+  a.addHook('onRequest', async (req) => { (req as any).auth = { userId }; (req as any).userId = userId })
+  a.register(agentDetailRoutes)
+  return a
+}
+
+const agentRow = async () => db.query.agents.findFirst({ where: eq(schema.agents.id, AGENT) })
+
+before(async () => {
+  await setupDatabase()
+  const now = new Date()
+  await db.insert(schema.organisations).values({ id: ORG, name: 'Sevenei', ownerId: OWNER, createdAt: now } as any)
+  await db.insert(schema.orgMembers).values([
+    { id: randomUUID(), orgId: ORG, userId: OWNER, role: 'owner', createdAt: now },
+    { id: randomUUID(), orgId: ORG, userId: MEMBER, role: 'member', createdAt: now },
+  ] as any)
+  await db.insert(schema.agents).values({
+    id: AGENT, orgId: ORG, name: 'Vera', role: 'Analyst', skills: ['research'],
+    avatarUrl: 'data:image/png;base64,SEED', runtime: 'internal', createdAt: now,
+  } as any)
+  await db.insert(schema.skills).values([
+    { id: 's1', name: 'research', description: 'reads things', domain: 'analysis', content: '# research', createdAt: now },
+    { id: 's2', name: 'writing', description: 'writes things', domain: 'comms', content: '# writing', createdAt: now },
+  ] as any)
+  app = appAs(OWNER)
+  await app.ready()
+})
+
+after(async () => {
+  await app?.close()
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+// ─── BUG 1 — Instructions save ───────────────────────────────────────────────
+
+test('[AGFIX1] saving an instruction file persists it and reads back', async () => {
+  const res = await app.inject({
+    method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/files`,
+    payload: { path: 'AGENTS.md', content: '# Vera\n\nYou analyse things.\n' },
+  })
+  assert.equal(res.statusCode, 200, res.body)
+  assert.equal(res.json().file.stored, true)
+
+  const read = await app.inject({ method: 'GET', url: `/api/orgs/${ORG}/agents/${AGENT}/files/content?path=AGENTS.md` })
+  assert.equal(read.statusCode, 200)
+  assert.equal(read.json().content, '# Vera\n\nYou analyse things.\n')
+  assert.equal(read.json().stored, true)
+})
+
+test('[AGFIX1] saving the same file again updates it rather than duplicating', async () => {
+  await app.inject({ method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/files`, payload: { path: 'AGENTS.md', content: 'v2' } })
+  const rows = await db.select().from(schema.agentFiles).where(eq(schema.agentFiles.agentId, AGENT))
+  assert.equal(rows.filter(r => r.path === 'AGENTS.md').length, 1)
+  assert.equal(rows.find(r => r.path === 'AGENTS.md')!.content, 'v2')
+})
+
+test('[AGFIX1] a bad file name is a specific 400, not a mystery', async () => {
+  const res = await app.inject({
+    method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/files`,
+    payload: { path: '../../etc/passwd', content: 'x' },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.match(res.json().error, /bare \.md filename/i)
+})
+
+test('[AGFIX1] a non-owner cannot save an instruction file', async () => {
+  const member = appAs(MEMBER)
+  await member.ready()
+  const res = await member.inject({
+    method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/files`, payload: { path: 'AGENTS.md', content: 'nope' },
+  })
+  assert.equal(res.statusCode, 403)
+  await member.close()
+})
+
+// ─── BUG 2 — avatar remove ───────────────────────────────────────────────────
+
+test('[AGFIX2] removing the avatar clears avatar_url so the icon takes over', async () => {
+  assert.ok((await agentRow())!.avatarUrl, 'fixture should start with a picture')
+
+  const res = await app.inject({ method: 'DELETE', url: `/api/orgs/${ORG}/agents/${AGENT}/avatar` })
+  assert.equal(res.statusCode, 204, res.body)
+  assert.equal((await agentRow())!.avatarUrl, null)
+})
+
+test('[AGFIX2] removing an avatar that is already gone is not an error', async () => {
+  const res = await app.inject({ method: 'DELETE', url: `/api/orgs/${ORG}/agents/${AGENT}/avatar` })
+  assert.equal(res.statusCode, 204)
+  assert.equal((await agentRow())!.avatarUrl, null)
+})
+
+test('[AGFIX2] a non-owner cannot remove the avatar', async () => {
+  const member = appAs(MEMBER)
+  await member.ready()
+  const res = await member.inject({ method: 'DELETE', url: `/api/orgs/${ORG}/agents/${AGENT}/avatar` })
+  assert.equal(res.statusCode, 403)
+  await member.close()
+})
+
+// ─── Feature 3 — skills tick / untick ────────────────────────────────────────
+
+test('[AG-SK] ticking a skill installs it and it survives a re-read', async () => {
+  const res = await app.inject({
+    method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/skills`, payload: { skills: ['research', 'writing'] },
+  })
+  assert.equal(res.statusCode, 200, res.body)
+  assert.deepEqual(res.json().installed.map((s: any) => s.name), ['research', 'writing'])
+  assert.equal(res.json().selectedCount, 2)
+  assert.deepEqual((await agentRow())!.skills, ['research', 'writing'])
+})
+
+test('[AG-SK] unticking uninstalls it — the whole point of the tab', async () => {
+  const res = await app.inject({
+    method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/skills`, payload: { skills: ['writing'] },
+  })
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.json().installed.map((s: any) => s.name), ['writing'])
+  assert.deepEqual(res.json().other.map((s: any) => s.name), ['research'])
+  assert.equal(res.json().selectedCount, 1)
+  assert.deepEqual((await agentRow())!.skills, ['writing'])
+})
+
+test('[AG-SK] an orphaned skill does not block toggling the others', async () => {
+  // The library row goes away underneath the agent — exactly what produced a 400
+  // on EVERY toggle before, because the checkbox list resends the orphan.
+  await db.update(schema.agents).set({ skills: ['writing', 'legacy-scraper'] }).where(eq(schema.agents.id, AGENT))
+
+  const res = await app.inject({
+    method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/skills`,
+    payload: { skills: ['writing', 'legacy-scraper', 'research'] },
+  })
+  assert.equal(res.statusCode, 200, res.body)
+  assert.deepEqual(res.json().orphaned, ['legacy-scraper'])
+  assert.equal(res.json().selectedCount, 3)
+  assert.deepEqual((await agentRow())!.skills.sort(), ['legacy-scraper', 'research', 'writing'])
+})
+
+test('[AG-SK] unticking an orphan is how you get rid of it', async () => {
+  const res = await app.inject({
+    method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/skills`, payload: { skills: ['research'] },
+  })
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(res.json().orphaned, [])
+  assert.deepEqual((await agentRow())!.skills, ['research'])
+})
+
+test('[AG-SK] a skill that was never in the library is still refused', async () => {
+  const res = await app.inject({
+    method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/skills`, payload: { skills: ['research', 'not-a-skill'] },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.match(res.json().error, /not-a-skill/)
+  assert.deepEqual((await agentRow())!.skills, ['research'], 'a rejected selection must not partially apply')
+})
+
+test('[AG-SK] a non-owner cannot change the skills', async () => {
+  const member = appAs(MEMBER)
+  await member.ready()
+  const res = await member.inject({ method: 'PUT', url: `/api/orgs/${ORG}/agents/${AGENT}/skills`, payload: { skills: [] } })
+  assert.equal(res.statusCode, 403)
+  assert.deepEqual((await agentRow())!.skills, ['research'], 'the refused write must not have landed')
+  await member.close()
+})
+
+test('[AG-SK] every skills write leaves a config revision behind', async () => {
+  const revs = await db.select().from(schema.configRevisions).where(eq(schema.configRevisions.entityId, AGENT))
+  assert.ok(revs.length > 0, 'skills changes must be auditable like any other config change')
+})

--- a/backend/src/tests/agent-skills.test.ts
+++ b/backend/src/tests/agent-skills.test.ts
@@ -74,4 +74,24 @@ describe('[AG4] resolveSelection', () => {
   it('de-duplicates and trims', () => {
     assert.deepEqual(resolveSelection(library, ['paperclip', ' paperclip ', '']), { ok: true, names: ['paperclip'] })
   })
+
+  // The checkbox list resends the whole selection, orphans included. Refusing a
+  // name the agent ALREADY carries made every toggle on such an agent a 400 —
+  // which is what made the tab look read-only.
+  it('keeps an orphan the agent already has instead of failing the whole write', () => {
+    const r = resolveSelection(library, ['paperclip', 'gone-from-library'], ['paperclip', 'gone-from-library'])
+    assert.equal(r.ok, true)
+    assert.ok((r as { names: string[] }).names.includes('gone-from-library'))
+  })
+
+  it('still refuses a name that is neither in the library nor already on the agent', () => {
+    const r = resolveSelection(library, ['paperclip', 'invented'], ['paperclip'])
+    assert.equal(r.ok, false)
+    assert.match((r as { error: string }).error, /invented/)
+  })
+
+  it('unticking an orphan drops it', () => {
+    const r = resolveSelection(library, ['paperclip'], ['paperclip', 'gone-from-library'])
+    assert.deepEqual(r, { ok: true, names: ['paperclip'] })
+  })
 })

--- a/web/app/dashboard/agent/SkillsTab.tsx
+++ b/web/app/dashboard/agent/SkillsTab.tsx
@@ -5,13 +5,11 @@
 // call), so the list on screen is always what the agent actually has.
 import { useCallback, useEffect, useState } from 'react'
 import { api } from '@/lib/api'
+import { nextSelection, optimisticSplit, selectionOf, type SkillView as Skill, type SkillsPayload as Payload } from '@/lib/agentSkills'
 import { Card, Skeleton } from '../ui'
 import { sx } from '../cockpit/shared'
 import { tk, text, space } from '../tokens'
 import { ax, type Getter } from './shared'
-
-type Skill = { id: string; name: string; description?: string | null; domain?: string | null; source?: string | null; installed: boolean }
-type Payload = { installed: Skill[]; other: Skill[]; orphaned: string[]; selectedCount: number; adapter: string; model: string }
 
 const ADAPTER_LABEL: Record<string, string> = {
   internal: 'Internal (7Ei executor)', openclaw: 'OpenClaw', cursor: 'Cursor', claude_code: 'Claude Code', custom: 'Custom runtime',
@@ -25,7 +23,7 @@ export default function SkillsTab({ orgId, agentId, getToken, onOpenLibrary }: {
 }) {
   const [data, setData] = useState<Payload | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
-  const [busy, setBusy] = useState(false)
+  const [pending, setPending] = useState<string | null>(null)
   const [err, setErr] = useState<string | null>(null)
 
   const base = `/api/orgs/${orgId}/agents/${agentId}/skills`
@@ -38,14 +36,24 @@ export default function SkillsTab({ orgId, agentId, getToken, onOpenLibrary }: {
 
   useEffect(() => { load() }, [load])
 
+  // Tick = install, untick = uninstall. Both write the WHOLE selection, so there
+  // is no half-applied state to reconcile. The checkbox flips immediately and
+  // the server's answer replaces it; a failure rolls the box back and says why,
+  // so what you see is never a change that didn't land.
   const toggle = async (name: string) => {
-    if (!data) return
-    const current = [...data.installed.map(s => s.name), ...data.orphaned]
-    const next = current.includes(name) ? current.filter(n => n !== name) : [...current, name]
-    setBusy(true); setErr(null)
-    try { setData(await api<Payload>(base, { token: await getToken(), method: 'PUT', body: JSON.stringify({ skills: next }) })) }
-    catch (e: any) { setErr(e?.message ?? 'Could not update this agent’s skills.') }
-    setBusy(false)
+    if (!data || pending) return
+    const next = nextSelection(selectionOf(data), name)
+    const before = data
+    setPending(name); setErr(null)
+    setData(optimisticSplit(data, next))
+    try {
+      setData(await api<Payload>(base, { token: await getToken(), method: 'PUT', body: JSON.stringify({ skills: next }) }))
+    } catch (e: any) {
+      setData(before)
+      const verb = selectionOf(before).includes(name) ? 'uninstall' : 'install'
+      setErr(`Could not ${verb} “${name}” — ${e?.message ?? 'the request failed'}. Nothing changed.`)
+    }
+    setPending(null)
   }
 
   if (err && !data) return <div style={ax.err}>{err}</div>
@@ -53,13 +61,16 @@ export default function SkillsTab({ orgId, agentId, getToken, onOpenLibrary }: {
 
   const row = (s: Skill) => (
     <div key={s.id} style={{ display: 'flex', gap: space.md, padding: `${space.md}px ${space.lg}px`, borderTop: `1px solid ${tk.line}` }}>
-      <input type="checkbox" checked={s.installed} disabled={busy} onChange={() => toggle(s.name)}
+      <input type="checkbox" checked={s.installed} disabled={!!pending} onChange={() => toggle(s.name)}
         aria-label={`${s.installed ? 'Uninstall' : 'Install'} ${s.name}`}
-        style={{ marginTop: 3, accentColor: tk.accent, cursor: busy ? 'default' : 'pointer', flexShrink: 0 }} />
+        aria-busy={pending === s.name}
+        style={{ marginTop: 3, accentColor: tk.accent, cursor: pending ? 'default' : 'pointer', flexShrink: 0 }} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: space.sm }}>
           <span style={{ fontSize: text.md.fontSize, fontWeight: 600 }}>{s.name}</span>
           {s.domain && <span style={sx.badge}>{s.domain}</span>}
+          {/* Progress is stated in words, not colour alone. */}
+          {pending === s.name && <span style={{ fontSize: text.xs.fontSize, color: tk.muted }}>Saving…</span>}
         </div>
         {s.description && (
           <p style={{
@@ -93,9 +104,11 @@ export default function SkillsTab({ orgId, agentId, getToken, onOpenLibrary }: {
             rather than quietly dropping it. */}
         {data.orphaned.map(name => (
           <div key={name} style={{ display: 'flex', alignItems: 'center', gap: space.md, padding: `${space.md}px ${space.lg}px`, borderTop: `1px solid ${tk.line}` }}>
-            <input type="checkbox" checked disabled={busy} onChange={() => toggle(name)} aria-label={`Remove ${name}`} style={{ accentColor: tk.accent }} />
+            <input type="checkbox" checked disabled={!!pending} onChange={() => toggle(name)} aria-label={`Remove ${name}`}
+              aria-busy={pending === name} style={{ accentColor: tk.accent, cursor: pending ? 'default' : 'pointer' }} />
             <span style={{ fontSize: text.md.fontSize, fontWeight: 600 }}>{name}</span>
             <span style={{ ...sx.tag, color: tk.amber, border: `1px solid ${tk.amber}` }}>⚠ no longer in the library</span>
+            {pending === name && <span style={{ fontSize: text.xs.fontSize, color: tk.muted }}>Saving…</span>}
           </div>
         ))}
       </Card>
@@ -111,7 +124,9 @@ export default function SkillsTab({ orgId, agentId, getToken, onOpenLibrary }: {
         <Foot label="Adapter" value={ADAPTER_LABEL[data.adapter] ?? data.adapter} />
         <Foot label="Model" value={data.model} />
         <Foot label="Selected skills" value={String(data.selectedCount)} />
-        <span style={{ marginLeft: 'auto', fontSize: text.xs.fontSize, color: tk.muted }}>Skills are applied when the agent runs.</span>
+        <span style={{ marginLeft: 'auto', fontSize: text.xs.fontSize, color: tk.muted }}>
+          Tick to install, untick to uninstall — saved as you go. Skills are applied when the agent runs.
+        </span>
       </Card>
     </div>
   )

--- a/web/lib/agentSkills.test.ts
+++ b/web/lib/agentSkills.test.ts
@@ -1,0 +1,80 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { nextSelection, optimisticSplit, selectionOf, type SkillsPayload } from './agentSkills.ts'
+
+const sk = (name: string, installed: boolean) => ({ id: name, name, installed })
+
+const payload = (installed: string[], other: string[], orphaned: string[] = []): SkillsPayload => ({
+  installed: installed.map(n => sk(n, true)),
+  other: other.map(n => sk(n, false)),
+  orphaned,
+  selectedCount: installed.length + orphaned.length,
+  adapter: 'internal',
+  model: 'claude-sonnet-4-20250514',
+})
+
+test('[AG-SK] selection is the installed library skills plus any orphans', () => {
+  assert.deepEqual(selectionOf(payload(['research'], ['writing'], ['gone'])), ['research', 'gone'])
+})
+
+test('[AG-SK] ticking adds, unticking removes', () => {
+  assert.deepEqual(nextSelection(['research'], 'writing'), ['research', 'writing'])
+  assert.deepEqual(nextSelection(['research', 'writing'], 'research'), ['writing'])
+})
+
+test('[AG-SK] installing moves the skill across and bumps the count', () => {
+  const before = payload(['research'], ['writing'])
+  const after = optimisticSplit(before, nextSelection(selectionOf(before), 'writing'))
+
+  assert.deepEqual(after.installed.map(s => s.name), ['research', 'writing'])
+  assert.deepEqual(after.other.map(s => s.name), [])
+  assert.equal(after.selectedCount, 2)
+  assert.ok(after.installed.every(s => s.installed))
+})
+
+test('[AG-SK] uninstalling moves it back to Other and drops the count', () => {
+  const before = payload(['research', 'writing'], [])
+  const after = optimisticSplit(before, nextSelection(selectionOf(before), 'research'))
+
+  assert.deepEqual(after.installed.map(s => s.name), ['writing'])
+  assert.deepEqual(after.other.map(s => s.name), ['research'])
+  assert.equal(after.selectedCount, 1)
+  assert.equal(after.other[0].installed, false)
+})
+
+test('[AG-SK] Other stays alphabetical after an uninstall', () => {
+  const before = payload(['beta'], ['alpha', 'gamma'])
+  const after = optimisticSplit(before, [])
+  assert.deepEqual(after.other.map(s => s.name), ['alpha', 'beta', 'gamma'])
+})
+
+test('[AG-SK] an orphan stays installed and keeps counting until it is unticked', () => {
+  const before = payload(['research'], ['writing'], ['gone'])
+  assert.equal(before.selectedCount, 2)
+
+  // Toggling something else must not disturb the orphan.
+  const kept = optimisticSplit(before, nextSelection(selectionOf(before), 'writing'))
+  assert.deepEqual(kept.orphaned, ['gone'])
+  assert.equal(kept.selectedCount, 3)
+
+  // Unticking the orphan is the only way to be rid of it.
+  const dropped = optimisticSplit(before, nextSelection(selectionOf(before), 'gone'))
+  assert.deepEqual(dropped.orphaned, [])
+  assert.equal(dropped.selectedCount, 1)
+})
+
+test('[AG-SK] the optimistic split matches what the server would send back', () => {
+  // Same fixture, same expectation as the backend's splitSkills — if these two
+  // ever disagree the checkbox would flip and then visibly flip back.
+  const before = payload(['research'], ['writing', 'analysis'])
+  const after = optimisticSplit(before, ['research', 'analysis'])
+  assert.deepEqual(after.installed.map(s => s.name), ['research', 'analysis'])
+  assert.deepEqual(after.other.map(s => s.name), ['writing'])
+  assert.equal(after.selectedCount, 2)
+})
+
+test('[AG-SK] uninstalling everything is legitimate and leaves nothing selected', () => {
+  const after = optimisticSplit(payload(['a', 'b'], []), [])
+  assert.equal(after.selectedCount, 0)
+  assert.deepEqual(after.other.map(s => s.name), ['a', 'b'])
+})

--- a/web/lib/agentSkills.ts
+++ b/web/lib/agentSkills.ts
@@ -1,0 +1,64 @@
+// Epic AG / Skills tab — the pure half of ticking a skill on or off.
+//
+// The tab writes the WHOLE selection on every toggle (install and uninstall are
+// the same idempotent PUT), so all the UI has to do is compute the next
+// selection and predict the split the server will send back. Keeping that
+// prediction here, rather than inline in the component, is what lets the
+// checkbox flip instantly and still be provably the same answer the server gives.
+
+export interface SkillView {
+  id: string
+  name: string
+  description?: string | null
+  domain?: string | null
+  source?: string | null
+  installed: boolean
+}
+
+export interface SkillsPayload {
+  installed: SkillView[]
+  other: SkillView[]
+  /** names stored on the agent whose library row is gone */
+  orphaned: string[]
+  selectedCount: number
+  adapter: string
+  model: string
+}
+
+/** Everything the agent currently has: library skills + orphans. */
+export function selectionOf(p: Pick<SkillsPayload, 'installed' | 'orphaned'>): string[] {
+  return [...p.installed.map(s => s.name), ...p.orphaned]
+}
+
+/** Tick → add, untick → remove. */
+export function nextSelection(current: string[], name: string): string[] {
+  return current.includes(name) ? current.filter(n => n !== name) : [...current, name]
+}
+
+/**
+ * Predict the server's split for a selection, so the checkbox can flip before
+ * the round-trip. Mirrors `splitSkills` on the backend: installed keeps the
+ * selection's order, `other` stays alphabetical, and a selected name with no
+ * library row stays an orphan (it is still installed, and still counts).
+ */
+export function optimisticSplit(p: SkillsPayload, selection: string[]): SkillsPayload {
+  const library = [...p.installed, ...p.other]
+  const byName = new Map(library.map(s => [s.name, s]))
+  const wanted = [...new Set(selection.map(n => n.trim()).filter(Boolean))]
+
+  const installed: SkillView[] = []
+  const orphaned: string[] = []
+  for (const name of wanted) {
+    const s = byName.get(name)
+    if (s) installed.push({ ...s, installed: true })
+    else orphaned.push(name)
+  }
+
+  const on = new Set(installed.map(s => s.name))
+  const other = library
+    .filter(s => !on.has(s.name))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(s => ({ ...s, installed: false }))
+
+  return { ...p, installed, other, orphaned, selectedCount: installed.length + orphaned.length }
+}


### PR DESCRIPTION
Feature 3. Also lands the route-level tests that BUG 1 and BUG 2 asked for.

## What was actually wrong

The tick/untick UI already existed and already wrote the whole selection. Two things stopped it:

1. **CORS refused the PUT** (fixed in #235) — every tick failed as "Network error".
2. **An orphan poisoned every toggle.** `resolveSelection` refused any name not in the library. The checkbox list resends the *whole* selection, orphans included — so on any agent carrying an orphaned skill (its library row was deleted underneath it), **every** toggle returned `400 Unknown skill(s)`. Reproduced before fixing:

```
stored:   ['research', 'legacy-scraper']   # legacy-scraper no longer in the library
PUT body: ['research', 'legacy-scraper', 'writing']
backend:  {"ok":false,"error":"Unknown skill(s): legacy-scraper"}
```

## What the operator gets

Tick a skill in **Other skills** to install it; untick one in **Installed skills** to uninstall. It saves as you go — no Save button. The box flips immediately and is replaced by the server's answer; if the write fails the box rolls back and the error names the skill and why (nothing is left looking changed when it isn't). The **Selected skills** count and the installed/other split are recomputed from the server's response, so they always reflect reality. Owner-gated; every change leaves a config revision.

An orphan stays ticked and keeps counting until you untick it — which is now the only way to remove one.

## Changes

- `resolveSelection(library, requested, stored)` — an already-carried orphan is allowed through; a genuinely unknown name is still refused, and a rejected selection never partially applies.
- `web/lib/agentSkills.ts` — selection maths as pure functions; the optimistic split is tested to agree with the server's.
- `SkillsTab` — optimistic toggle, per-row pending, "Saving…" in words not colour alone (colourblind-safe), tokens only.
- **`agent-detail-routes.test.ts`** — the AG write paths driven end-to-end against a real SQLite file through the real owner gate: instruction save persists and reads back (BUG 1), avatar remove clears `avatar_url` (BUG 2), skills tick/untick survives a re-read, member → 403 with nothing written.

## Verify

- backend `npm test` -> **1050 pass, 0 fail** (17 new) · `evals` -> **11/11** · typecheck clean
- web `npm test` -> **146 pass** (8 new) · `npm run build` -> passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)