### PR TITLE
feat(AG): Configuration → custom adapter (NVIDIA / OpenAI-standard), used on real runs

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -29,6 +29,7 @@ import { arturitaVoiceRoutes } from './routes/arturita-voice'
 import { arturitaConverseRoutes } from './routes/arturita-converse'
 import { arturitaPipelineRoutes } from './routes/arturita-pipeline'
 import { arturitaCustomModelRoutes } from './routes/arturita-custom-model'
+import { customModelRoutes } from './routes/custom-models'
 import { agentApiRoutes } from './routes/agent-api'
 import { ensureIndex } from './services/vector-search'
 import { auditLogPlugin } from './middleware/audit-log'
@@ -106,6 +107,7 @@ async function start() {
     await secured.register(arturitaConverseRoutes) // Arturita conversational front door — answer vs delegate (J1)
     await secured.register(arturitaPipelineRoutes) // Arturita free-first pipeline chains (LLM/STT/TTS) config (J2)
     await secured.register(arturitaCustomModelRoutes) // Arturita custom operator-defined LLM insertion (J2+)
+    await secured.register(customModelRoutes)         // Epic AG — custom adapters/models for agents
   })
 
   // ─── Public / externally-called routes ──────────────────────────────────

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -17,6 +17,7 @@ import { parseTrustMode, parseBoundary, serializeBoundary, TRUST_MODES } from '.
 import { secureRegistration } from '../services/code-executor'
 import { resolveModelProfile, buildModelProfilePatch, flattenModelOptions, parseReasoningEffort } from '../services/model-profile'
 import { parseLlmChain } from '../services/arturita-pipeline'
+import { parseCustomModels } from '../services/custom-model'
 import { requireOrgRole } from '../middleware/rbac'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
@@ -176,13 +177,27 @@ export async function agentRoutes(app: FastifyInstance) {
       resolved: resolveModelProfile(a),
     }
   })
-  // Selectable model list for the config UI: the built-in catalogue + operator
-  // custom-model entries (S8 `arturita_llm_chain`). Read-only; org-scoped (Clerk).
+  // Selectable model list for the config UI: the built-in catalogue + every
+  // operator-defined model, from BOTH doors — Arturita's LLM chain (S8
+  // `arturita_llm_chain`) and the agent catalogue (`custom_models`). A model
+  // added at either door is selectable at both. Read-only; org-scoped (Clerk).
   app.get('/api/orgs/:orgId/available-models', async (req) => {
     const { orgId } = req.params as any
     const org = await db.query.organisations.findFirst({ where: eq(schema.organisations.id, orgId), columns: { deployConfig: true } })
-    const custom = parseLlmChain(org?.deployConfig as any).filter((e: any) => e.custom)
-    return { models: flattenModelOptions(custom.map((e: any) => ({ provider: e.provider, model: e.model, label: e.label }))) }
+    const cfg = org?.deployConfig as any
+    const custom = [
+      ...parseLlmChain(cfg).filter((e: any) => e.custom),
+      ...parseCustomModels(cfg),
+    ]
+    // Same slug+model registered at both doors → one option, not two.
+    const seen = new Set<string>()
+    const unique = custom.filter((e: any) => {
+      const k = `${e.provider}::${e.model}`
+      if (seen.has(k)) return false
+      seen.add(k)
+      return true
+    })
+    return { models: flattenModelOptions(unique.map((e: any) => ({ provider: e.provider, model: e.model, label: e.label }))) }
   })
 
   // MCA-GOV2 S4.1 — execution policies (action → requires approval).

--- a/backend/src/routes/arturita-custom-model.ts
+++ b/backend/src/routes/arturita-custom-model.ts
@@ -17,7 +17,7 @@ import { documentEndpoint } from '../services/openapi'
 import { parseLlmChain } from '../services/arturita-pipeline'
 import {
   validateCustomModel, applyCustomModel, removeCustomModel,
-  resolveLlmCreds, hasStoredKey,
+  resolveLlmCreds, hasStoredKey, probeEndpoint,
 } from '../services/custom-model'
 
 const CustomModelBody = z.object({
@@ -36,42 +36,6 @@ const TestBody = z.object({
   /** existing slug — test with the stored key when apiKey is omitted. */
   provider: z.string().optional(),
 })
-
-/** Reachability probe for an OpenAI-compatible endpoint. Tries GET /models, then
- *  a 1-token POST /chat/completions. Never logs the key. Returns a plain result. */
-async function probeEndpoint(input: { baseUrl: string; apiKey?: string; model: string }, timeoutMs = 6000): Promise<{ ok: boolean; status: number | null; detail: string }> {
-  const base = input.baseUrl.replace(/\/$/, '')
-  const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' }
-  if (input.apiKey) authHeaders.Authorization = `Bearer ${input.apiKey}`
-  const withTimeout = async (fn: (signal: AbortSignal) => Promise<Response>): Promise<Response> => {
-    const ctrl = new AbortController()
-    const t = setTimeout(() => ctrl.abort(), timeoutMs)
-    try { return await fn(ctrl.signal) } finally { clearTimeout(t) }
-  }
-  // 1) GET /models — cheapest liveness + auth check.
-  try {
-    const res = await withTimeout(s => fetch(`${base}/models`, { headers: authHeaders, signal: s }))
-    if (res.ok) return { ok: true, status: res.status, detail: 'reachable (GET /models)' }
-    if (res.status === 401 || res.status === 403) return { ok: false, status: res.status, detail: 'authentication failed — check the API key' }
-    // 404/405 → server may not expose /models; fall through to a chat probe.
-  } catch (e: any) {
-    if (e?.name !== 'AbortError') return { ok: false, status: null, detail: `unreachable — ${e?.message ?? 'network error'}` }
-  }
-  // 2) POST /chat/completions with a 1-token request.
-  try {
-    const res = await withTimeout(s => fetch(`${base}/chat/completions`, {
-      method: 'POST', headers: authHeaders, signal: s,
-      body: JSON.stringify({ model: input.model, max_tokens: 1, messages: [{ role: 'user', content: 'ping' }] }),
-    }))
-    if (res.ok) return { ok: true, status: res.status, detail: 'reachable (chat/completions)' }
-    if (res.status === 401 || res.status === 403) return { ok: false, status: res.status, detail: 'authentication failed — check the API key' }
-    if (res.status === 404) return { ok: false, status: res.status, detail: 'model or endpoint not found — check the base URL + model id' }
-    return { ok: false, status: res.status, detail: `endpoint returned ${res.status}` }
-  } catch (e: any) {
-    if (e?.name === 'AbortError') return { ok: false, status: null, detail: `timed out after ${timeoutMs}ms` }
-    return { ok: false, status: null, detail: `unreachable — ${e?.message ?? 'network error'}` }
-  }
-}
 
 export async function arturitaCustomModelRoutes(app: FastifyInstance) {
   // Add / update a custom model → persists base URL (+ encrypted key) and upserts

--- a/backend/src/routes/custom-models.ts
+++ b/backend/src/routes/custom-models.ts
@@ -1,0 +1,175 @@
+// Epic AG — custom adapters/models for AGENTS: an operator-defined, OpenAI-
+// compatible endpoint (NVIDIA NIM, Together, vLLM, a local server, or any
+// OpenAI-standard provider) that an agent can be pointed at from its
+// Configuration tab and that its runs actually use.
+//
+// This is the SAME machinery as Arturita's custom model (#207) — the validation,
+// slugging, AES-256-GCM key storage, credential resolution and reachability probe
+// all come from services/custom-model.ts. The only thing that differs is WHERE
+// the entry is registered: `custom_models`, not `arturita_llm_chain`. That chain
+// is Arturita's ordered FAILOVER list, and defining a model for some other agent
+// must not silently change what Arturita falls back to. Both lists are surfaced
+// by GET /available-models, so a model added at either door is selectable at both.
+//
+// Secrets: the API key is stored ENCRYPTED and is never returned or logged —
+// responses carry a masked tail and a `hasKey` flag, nothing more.
+
+import { FastifyInstance } from 'fastify'
+import { db, schema } from '../db/client'
+import { eq } from 'drizzle-orm'
+import { z } from 'zod'
+import { randomUUID } from 'node:crypto'
+import { requireOrgRole } from '../middleware/rbac'
+import { documentEndpoint } from '../services/openapi'
+import {
+  CATALOG_KEY, applyCustomModel, encKeyKey, hasStoredKey, parseCustomModels, probeEndpoint,
+  removeCustomModel, resolveLlmCreds, validateCustomModel,
+} from '../services/custom-model'
+
+const CustomModelBody = z.object({
+  label: z.string().optional(),
+  provider: z.string().optional(),
+  model: z.string(),
+  baseUrl: z.string(),
+  apiKey: z.string().optional(),
+  mode: z.enum(['local', 'provider']).optional(),
+})
+
+const TestBody = z.object({
+  model: z.string(),
+  baseUrl: z.string(),
+  apiKey: z.string().optional(),
+  /** existing slug — probe with the STORED key when apiKey is omitted. */
+  provider: z.string().optional(),
+})
+
+const cfgOf = async (orgId: string) =>
+  db.query.organisations.findFirst({ where: eq(schema.organisations.id, orgId), columns: { deployConfig: true } })
+
+/** The catalog as the UI sees it: never the key, only whether one is stored. */
+const view = (cfg: Record<string, unknown>) =>
+  parseCustomModels(cfg).map(e => ({ ...e, hasKey: hasStoredKey(cfg, e.provider) }))
+
+export async function customModelRoutes(app: FastifyInstance) {
+  // List. Member-visible: it is a catalogue of endpoints, and carries no secrets.
+  app.get('/api/orgs/:orgId/custom-models', async (req, reply) => {
+    const { orgId } = req.params as { orgId: string }
+    const org = await cfgOf(orgId)
+    if (!org) return reply.code(404).send({ error: 'Organisation not found' })
+    return { models: view((org.deployConfig ?? {}) as Record<string, unknown>) }
+  })
+
+  // Add or update. Owner-gated — this stores a credential and changes what the
+  // agents pointed at it will call.
+  app.post('/api/orgs/:orgId/custom-models', { preHandler: requireOrgRole('owner') }, async (req, reply) => {
+    const { orgId } = req.params as { orgId: string }
+    let b: z.infer<typeof CustomModelBody>
+    try { b = CustomModelBody.parse(req.body ?? {}) } catch (e: any) { return reply.code(400).send({ error: e?.message ?? 'invalid body' }) }
+
+    const v = validateCustomModel(b)
+    if (!v.ok || !v.entry || !v.slug) return reply.code(400).send({ error: v.errors.join('; '), errors: v.errors })
+
+    const org = await cfgOf(orgId)
+    if (!org) return reply.code(404).send({ error: 'Organisation not found' })
+
+    const before = (org.deployConfig ?? {}) as Record<string, unknown>
+
+    // Key semantics, because "blank" is ambiguous and getting it wrong either
+    // wipes a working credential or makes one impossible to clear:
+    //   apiKey omitted   → KEEP whatever is stored (the edit dialog leaves the
+    //                      field blank because the key can never be shown again)
+    //   apiKey: ''       → explicitly CLEAR the stored key (a keyless endpoint)
+    //   apiKey: '…'      → replace it
+    const clearing = b.apiKey === ''
+    const keeping = b.apiKey === undefined && hasStoredKey(before, v.slug)
+
+    const { deployConfig, maskedKey } = applyCustomModel({
+      deployConfig: before, slug: v.slug, entry: v.entry,
+      apiKey: clearing ? '' : b.apiKey, catalogKey: CATALOG_KEY,
+    })
+    // applyCustomModel drops the key when none is supplied — carry the stored
+    // (still-encrypted) blob forward when the operator simply didn't retype it.
+    if (keeping) deployConfig[encKeyKey(v.slug)] = before[encKeyKey(v.slug)]
+
+    await db.update(schema.organisations).set({ deployConfig: deployConfig as any }).where(eq(schema.organisations.id, orgId))
+    await snapshot(orgId, v.slug, before, deployConfig, req)
+
+    reply.code(201)
+    return {
+      ok: true, slug: v.slug, entry: v.entry,
+      maskedKey, hasKey: hasStoredKey(deployConfig, v.slug),
+      models: view(deployConfig),
+    }
+  })
+
+  // Reachability + auth probe for a (possibly unsaved) endpoint — the form's
+  // "Test connection". Uses the typed key if given, else the stored one.
+  app.post('/api/orgs/:orgId/custom-models/test', { preHandler: requireOrgRole('owner') }, async (req, reply) => {
+    const { orgId } = req.params as { orgId: string }
+    let b: z.infer<typeof TestBody>
+    try { b = TestBody.parse(req.body ?? {}) } catch (e: any) { return reply.code(400).send({ error: e?.message ?? 'invalid body' }) }
+
+    let apiKey = b.apiKey
+    if (!apiKey && b.provider) {
+      const org = await cfgOf(orgId)
+      apiKey = resolveLlmCreds((org?.deployConfig ?? {}) as Record<string, unknown>, b.provider).orgApiKey
+    }
+    return probeEndpoint({ baseUrl: b.baseUrl, apiKey, model: b.model })  // no key echoed
+  })
+
+  // Remove: catalogue entry + base URL + stored key. Agents still pointed at the
+  // slug are reported, so the operator learns before they discover it at runtime.
+  app.delete('/api/orgs/:orgId/custom-models/:provider', { preHandler: requireOrgRole('owner') }, async (req, reply) => {
+    const { orgId, provider } = req.params as { orgId: string; provider: string }
+    const org = await cfgOf(orgId)
+    if (!org) return reply.code(404).send({ error: 'Organisation not found' })
+
+    const before = (org.deployConfig ?? {}) as Record<string, unknown>
+    const had = parseCustomModels(before).some(e => e.provider === provider) || hasStoredKey(before, provider)
+    const { deployConfig } = removeCustomModel({ deployConfig: before, slug: provider, catalogKey: CATALOG_KEY })
+    await db.update(schema.organisations).set({ deployConfig: deployConfig as any }).where(eq(schema.organisations.id, orgId))
+    await snapshot(orgId, provider, before, deployConfig, req)
+
+    const stranded = (await db.select({ id: schema.agents.id, name: schema.agents.name, llmProvider: schema.agents.llmProvider })
+      .from(schema.agents).where(eq(schema.agents.orgId, orgId)))
+      .filter(a => a.llmProvider === provider)
+      .map(({ id, name }) => ({ id, name }))
+
+    return { ok: true, removed: had, models: view(deployConfig), stranded }
+  })
+
+  documentEndpoint('GET', '/api/orgs/:orgId/custom-models', {
+    summary: 'List operator-defined custom adapters/models (no key material)', tag: 'agents',
+  })
+  documentEndpoint('POST', '/api/orgs/:orgId/custom-models', {
+    summary: 'Add/update a custom OpenAI-compatible adapter for agents (key stored AES-256-GCM encrypted, never returned)',
+    tag: 'agents', body: CustomModelBody,
+  })
+  documentEndpoint('POST', '/api/orgs/:orgId/custom-models/test', {
+    summary: 'Reachability/auth probe for a custom endpoint (no key echoed)', tag: 'agents', body: TestBody,
+  })
+  documentEndpoint('DELETE', '/api/orgs/:orgId/custom-models/:provider', {
+    summary: 'Remove a custom adapter (entry + base URL + stored key)', tag: 'agents',
+  })
+}
+
+/** Config-revision snapshot, with key material scrubbed — a revision is an audit
+ *  record, not a second place the credential lives. */
+async function snapshot(orgId: string, slug: string, before: unknown, after: unknown, req: unknown) {
+  return db.insert(schema.configRevisions).values({
+    id: randomUUID(), orgId, entity: 'custom-model', entityId: slug,
+    before: JSON.stringify(scrub(before)), after: JSON.stringify(scrub(after)),
+    actor: (req as { userId?: string }).userId ?? 'human', createdAt: new Date(),
+  }).catch(() => {})
+}
+
+/** Drop every stored credential from a deployConfig before it is written to an
+ *  audit row. Encrypted or not, a key does not belong in a revision snapshot. */
+export function scrub(cfg: unknown): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries((cfg ?? {}) as Record<string, unknown>)) {
+    if (k.endsWith('_api_key') || k.endsWith('_api_key_enc')) continue
+    out[k] = v
+  }
+  return out
+}

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -16,6 +16,12 @@ import { canAgentRun } from './governance'
 import { enforceAgentBudget } from './budget'
 import { preflightWake, parseCapUsd, estimateInputTokens } from './preflight'
 import { parseFallbackChain } from './llm-fallback'
+// One credential resolver for every provider, built-in or operator-defined. It
+// reads BOTH the legacy plaintext `<slug>_api_key` and the AES-256-GCM
+// `<slug>_api_key_enc` — reading only the plaintext key (as this file used to)
+// meant a custom model saved with a key could never authenticate on a run, since
+// the save path only ever writes the encrypted form.
+import { resolveLlmCreds } from './custom-model'
 import { streamLLMWithFallback } from './llm-fallback-runtime'
 import { resolveVaultForOrg, fetchSharedMemory } from './agent-memory'
 import { isAskMode, buildAskSystemPrompt, ASK_ANSWER_KIND } from './askmode'
@@ -238,8 +244,7 @@ export async function executeAgentTask(opts: {
     const model    = wakePlan.model
     const provider = wakePlan.provider
     const reasoningEffort = wakePlan.reasoningEffort ?? undefined
-    const orgApiKey = org?.deployConfig?.[`${provider}_api_key`] as string | undefined
-    const baseURL   = org?.deployConfig?.[`${provider}_base_url`] as string | undefined
+    const { orgApiKey, baseURL } = resolveLlmCreds(org?.deployConfig as any, provider)
     const messages = [...conversationHistory, { role: 'user' as const, content: input }]
     const start = Date.now()
     let rawOutput = ''
@@ -256,10 +261,7 @@ export async function executeAgentTask(opts: {
     const fb = await streamLLMWithFallback({
       base: { system: systemPrompt, messages, reasoningEffort, onToken: (chunk) => { rawOutput += chunk; onToken?.(chunk) } },
       chain: effectiveChain,
-      resolveCreds: (prov) => ({
-        orgApiKey: org?.deployConfig?.[`${prov}_api_key`] as string | undefined,
-        baseURL: org?.deployConfig?.[`${prov}_base_url`] as string | undefined,
-      }),
+      resolveCreds: (prov) => resolveLlmCreds(org?.deployConfig as any, prov),
       inputTokens: wakeInputTokens,
       capUsd: wakeCapUsd,
     })
@@ -403,8 +405,7 @@ export async function answerAskTask(opts: {
     })
     const model    = wakePlan.model
     const provider = wakePlan.provider
-    const orgApiKey = org?.deployConfig?.[`${provider}_api_key`] as string | undefined
-    const baseURL   = org?.deployConfig?.[`${provider}_base_url`] as string | undefined
+    const { orgApiKey, baseURL } = resolveLlmCreds(org?.deployConfig as any, provider)
     const messages  = [...conversationHistory, { role: 'user' as const, content: input }]
     const start = Date.now()
 

--- a/backend/src/services/custom-model.ts
+++ b/backend/src/services/custom-model.ts
@@ -107,6 +107,42 @@ export const baseUrlKey = (slug: string) => `${slug}_base_url`
 export const encKeyKey = (slug: string) => `${slug}_api_key_enc`
 export const plainKeyKey = (slug: string) => `${slug}_api_key`
 
+/**
+ * Where an AGENT's custom models live.
+ *
+ * Deliberately NOT `arturita_llm_chain`. That chain is Arturita's ordered
+ * FAILOVER list — appending to it would mean defining a custom model for one
+ * agent silently changes what Arturita falls back to. The two are different
+ * things that happen to share a credential format, so they get different keys
+ * and the same plumbing: `<slug>_base_url` + `<slug>_api_key_enc`, resolved by
+ * `resolveLlmCreds` either way. `available-models` reads both, so a model added
+ * from either door is selectable from either.
+ */
+export const CATALOG_KEY = 'custom_models'
+
+/** Read a catalog of custom entries from deployConfig. Tolerates junk rows. */
+export function parseCustomModels(
+  deployConfig: Record<string, unknown> | null | undefined,
+  key: string = CATALOG_KEY,
+): LlmEntry[] {
+  const raw = (deployConfig ?? {})[key]
+  if (!Array.isArray(raw)) return []
+  return raw
+    .map((e: any): LlmEntry | null => {
+      const provider = String(e?.provider ?? '').trim()
+      const model = String(e?.model ?? '').trim()
+      if (!provider || !model) return null
+      return {
+        provider, model,
+        mode: e?.mode === 'local' ? 'local' : 'provider',
+        label: String(e?.label ?? `${provider} · ${model}`),
+        baseUrl: typeof e?.baseUrl === 'string' ? e.baseUrl : undefined,
+        custom: true,
+      }
+    })
+    .filter((e): e is LlmEntry => e !== null)
+}
+
 export interface CustomModelPersist {
   /** the new deployConfig (base URL + encrypted key merged, chain appended). */
   deployConfig: Record<string, unknown>
@@ -129,6 +165,9 @@ export function applyCustomModel(input: {
   entry: LlmEntry
   apiKey?: string | null
   encryptFn?: (plain: string) => string
+  /** Which list to upsert into. Defaults to Arturita's LLM chain (the #207 door);
+   *  the agent Configuration tab passes CATALOG_KEY so it cannot disturb it. */
+  catalogKey?: string
 }): CustomModelPersist {
   const enc = input.encryptFn ?? encrypt
   const cfg: Record<string, unknown> = { ...((input.deployConfig ?? {}) as Record<string, unknown>) }
@@ -144,25 +183,80 @@ export function applyCustomModel(input: {
     delete cfg[plainKeyKey(input.slug)]
   }
 
-  const existing = parseLlmChain(cfg).filter(e => !(e.provider === input.slug && e.model === input.entry.model))
+  const catalogKey = input.catalogKey ?? PIPELINE_KEYS.llm
+  const read = catalogKey === PIPELINE_KEYS.llm ? parseLlmChain(cfg) : parseCustomModels(cfg, catalogKey)
+  const existing = read.filter(e => !(e.provider === input.slug && e.model === input.entry.model))
   const chain = [...existing, input.entry]
-  cfg[PIPELINE_KEYS.llm] = chain
+  cfg[catalogKey] = chain
 
   return { deployConfig: cfg, chain, maskedKey: key ? maskValue(key) : null }
 }
 
-/** Remove a custom model (chain entry + its base URL + stored key). Pure. */
+/** Remove a custom model (catalog entry + its base URL + stored key). Pure. */
 export function removeCustomModel(input: {
   deployConfig: Record<string, unknown> | null | undefined
   slug: string
+  catalogKey?: string
 }): { deployConfig: Record<string, unknown>; chain: LlmEntry[] } {
   const cfg: Record<string, unknown> = { ...((input.deployConfig ?? {}) as Record<string, unknown>) }
   delete cfg[baseUrlKey(input.slug)]
   delete cfg[encKeyKey(input.slug)]
   delete cfg[plainKeyKey(input.slug)]
-  const chain = parseLlmChain(cfg).filter(e => e.provider !== input.slug)
-  cfg[PIPELINE_KEYS.llm] = chain
+  const catalogKey = input.catalogKey ?? PIPELINE_KEYS.llm
+  const read = catalogKey === PIPELINE_KEYS.llm ? parseLlmChain(cfg) : parseCustomModels(cfg, catalogKey)
+  const chain = read.filter(e => e.provider !== input.slug)
+  cfg[catalogKey] = chain
   return { deployConfig: cfg, chain }
+}
+
+// ─── Endpoint reachability probe (network) ───────────────────────────────────
+
+export interface ProbeResult { ok: boolean; status: number | null; detail: string }
+
+/**
+ * Reachability + auth probe for an OpenAI-compatible endpoint. Tries GET /models
+ * (cheapest liveness + auth check), then falls back to a 1-token POST
+ * /chat/completions for servers that don't expose /models. Never logs the key.
+ *
+ * Shared by the Arturita custom-model route (#207) and the agent Configuration
+ * tab's "Test connection" — one probe, one set of error strings.
+ */
+export async function probeEndpoint(
+  input: { baseUrl: string; apiKey?: string; model: string },
+  timeoutMs = 6000,
+): Promise<ProbeResult> {
+  const base = input.baseUrl.replace(/\/$/, '')
+  const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (input.apiKey) authHeaders.Authorization = `Bearer ${input.apiKey}`
+
+  const withTimeout = async (fn: (signal: AbortSignal) => Promise<Response>): Promise<Response> => {
+    const ctrl = new AbortController()
+    const t = setTimeout(() => ctrl.abort(), timeoutMs)
+    try { return await fn(ctrl.signal) } finally { clearTimeout(t) }
+  }
+
+  try {
+    const res = await withTimeout(s => fetch(`${base}/models`, { headers: authHeaders, signal: s }))
+    if (res.ok) return { ok: true, status: res.status, detail: 'reachable (GET /models)' }
+    if (res.status === 401 || res.status === 403) return { ok: false, status: res.status, detail: 'authentication failed — check the API key' }
+    // 404/405 → server may not expose /models; fall through to a chat probe.
+  } catch (e: any) {
+    if (e?.name !== 'AbortError') return { ok: false, status: null, detail: `unreachable — ${e?.message ?? 'network error'}` }
+  }
+
+  try {
+    const res = await withTimeout(s => fetch(`${base}/chat/completions`, {
+      method: 'POST', headers: authHeaders, signal: s,
+      body: JSON.stringify({ model: input.model, max_tokens: 1, messages: [{ role: 'user', content: 'ping' }] }),
+    }))
+    if (res.ok) return { ok: true, status: res.status, detail: 'reachable (chat/completions)' }
+    if (res.status === 401 || res.status === 403) return { ok: false, status: res.status, detail: 'authentication failed — check the API key' }
+    if (res.status === 404) return { ok: false, status: res.status, detail: 'model or endpoint not found — check the base URL + model id' }
+    return { ok: false, status: res.status, detail: `endpoint returned ${res.status}` }
+  } catch (e: any) {
+    if (e?.name === 'AbortError') return { ok: false, status: null, detail: `timed out after ${timeoutMs}ms` }
+    return { ok: false, status: null, detail: `unreachable — ${e?.message ?? 'network error'}` }
+  }
 }
 
 // ─── Credential resolution (decrypts) ─────────────────────────────────────────

--- a/backend/src/tests/boot.test.ts
+++ b/backend/src/tests/boot.test.ts
@@ -28,6 +28,7 @@ import { webhookRoutes } from '../routes/webhooks'
 import { telegramWebhookRoutes } from '../routes/telegram-webhook'
 import { arturitaRoutes, arturitaPublicRoutes } from '../routes/arturita'
 import { arturitaWalletRoutes } from '../routes/arturita-wallet'
+import { customModelRoutes } from '../routes/custom-models'
 import { arturitaVoiceRoutes } from '../routes/arturita-voice'
 import { agentApiRoutes } from '../routes/agent-api'
 
@@ -58,6 +59,7 @@ test('app boots: all route groups register without collision', async () => {
     await secured.register(skillRoutes)
     await secured.register(arturitaRoutes)
     await secured.register(arturitaWalletRoutes)
+    await secured.register(customModelRoutes)
     await secured.register(arturitaVoiceRoutes)
   })
 

--- a/backend/src/tests/custom-model-agent.test.ts
+++ b/backend/src/tests/custom-model-agent.test.ts
@@ -1,0 +1,227 @@
+// Epic AG — custom adapters/models for agents, driven through the real routes
+// against a real SQLite file. The things that must be true:
+//
+//   1. The API key is stored ENCRYPTED and never comes back out.
+//   2. A saved model is selectable as an agent's model (available-models).
+//   3. The agent's RUN path can resolve the key — the executor used to read only
+//      the plaintext `<slug>_api_key`, which the save path never writes, so a
+//      custom model with a key could not have authenticated on a single run.
+//   4. Registering an agent model does NOT disturb Arturita's failover chain.
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+const tmp = mkdtempSync(join(tmpdir(), 'ag-custom-'))
+process.env.DATABASE_URL = `file:${join(tmp, 'test.db')}`
+delete process.env.DATABASE_AUTH_TOKEN
+process.env.ENCRYPTION_KEY ??= 'a'.repeat(64)
+
+const { db, schema } = await import('../db/client')
+const { setupDatabase } = await import('../db/setup')
+const { customModelRoutes, scrub } = await import('../routes/custom-models')
+const { agentRoutes } = await import('../routes/all')
+const { resolveLlmCreds, parseCustomModels, CATALOG_KEY } = await import('../services/custom-model')
+const { PIPELINE_KEYS } = await import('../services/arturita-pipeline')
+const { eq } = await import('drizzle-orm')
+
+const ORG = 'org-cm', OWNER = 'user-owner', MEMBER = 'user-member', AGENT = 'agent-cm'
+const KEY = 'nvapi-super-secret-key-value'
+
+let app: FastifyInstance
+
+function appAs(userId: string) {
+  const a = Fastify({ logger: false })
+  a.addHook('onRequest', async (req) => { (req as any).auth = { userId }; (req as any).userId = userId })
+  a.register(customModelRoutes)
+  a.register(agentRoutes)
+  return a
+}
+
+const cfg = async () => {
+  const o = await db.query.organisations.findFirst({ where: eq(schema.organisations.id, ORG), columns: { deployConfig: true } })
+  return (o?.deployConfig ?? {}) as Record<string, unknown>
+}
+
+const add = (payload: Record<string, unknown>) =>
+  app.inject({ method: 'POST', url: `/api/orgs/${ORG}/custom-models`, payload })
+
+before(async () => {
+  await setupDatabase()
+  const now = new Date()
+  await db.insert(schema.organisations).values({ id: ORG, name: 'Sevenei', ownerId: OWNER, createdAt: now } as any)
+  await db.insert(schema.orgMembers).values([
+    { id: randomUUID(), orgId: ORG, userId: OWNER, role: 'owner', createdAt: now },
+    { id: randomUUID(), orgId: ORG, userId: MEMBER, role: 'member', createdAt: now },
+  ] as any)
+  await db.insert(schema.agents).values({
+    id: AGENT, orgId: ORG, name: 'Vera', role: 'Analyst', runtime: 'internal', createdAt: now,
+  } as any)
+  app = appAs(OWNER)
+  await app.ready()
+})
+
+after(async () => {
+  await app?.close()
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+test('[AG-CM] adding a custom model stores it and never echoes the key', async () => {
+  const res = await add({
+    label: 'NVIDIA Llama 3.3', baseUrl: 'https://integrate.api.nvidia.com/v1',
+    model: 'meta/llama-3.3-70b-instruct', apiKey: KEY,
+  })
+  assert.equal(res.statusCode, 201, res.body)
+
+  assert.ok(!res.body.includes(KEY), 'the response must not contain the key')
+  const masked = res.json().maskedKey as string
+  assert.ok(!masked.includes(KEY) && masked.length < KEY.length, 'only a masked tail comes back')
+  assert.ok(masked.endsWith(KEY.slice(-4)), 'the tail is what lets the operator recognise which key it is')
+  assert.equal(res.json().entry.baseUrl, 'https://integrate.api.nvidia.com/v1')
+})
+
+test('[AG-CM] the key is stored encrypted, not in plaintext', async () => {
+  const c = await cfg()
+  const slug = 'nvidia_llama_3_3'
+  assert.equal(c[`${slug}_api_key`], undefined, 'no plaintext key may be stored')
+  const enc = c[`${slug}_api_key_enc`] as string
+  assert.ok(enc, 'an encrypted key must be stored')
+  assert.ok(!enc.includes(KEY), 'the stored blob must not contain the key')
+  assert.ok(!JSON.stringify(c).includes(KEY), 'the key must appear nowhere in deployConfig')
+})
+
+test('[AG-CM] the RUN path resolves the encrypted key + base URL', async () => {
+  // This is the interop the feature turns on. resolveLlmCreds is exactly what
+  // agent-executor now calls for every provider, built-in or custom.
+  const creds = resolveLlmCreds(await cfg(), 'nvidia_llama_3_3')
+  assert.equal(creds.orgApiKey, KEY, 'the executor must be able to decrypt the key, or every run 401s')
+  assert.equal(creds.baseURL, 'https://integrate.api.nvidia.com/v1')
+})
+
+test('[AG-CM] the model is selectable as an agent’s model', async () => {
+  const res = await app.inject({ method: 'GET', url: `/api/orgs/${ORG}/available-models` })
+  assert.equal(res.statusCode, 200)
+  const opt = res.json().models.find((m: any) => m.id === 'meta/llama-3.3-70b-instruct')
+  assert.ok(opt, 'the custom model must appear in the Model picker')
+  assert.equal(opt.provider, 'nvidia_llama_3_3')
+  assert.equal(opt.custom, true)
+  assert.equal(opt.tier, 'custom')
+})
+
+test('[AG-CM] the list never carries key material, only whether one is stored', async () => {
+  const res = await app.inject({ method: 'GET', url: `/api/orgs/${ORG}/custom-models` })
+  assert.equal(res.statusCode, 200)
+  assert.ok(!res.body.includes(KEY))
+  const m = res.json().models[0]
+  assert.equal(m.hasKey, true)
+  assert.equal(m.provider, 'nvidia_llama_3_3')
+})
+
+test('[AG-CM] registering an agent model does not touch Arturita’s failover chain', async () => {
+  const c = await cfg()
+  assert.equal((c[PIPELINE_KEYS.llm] as unknown[] | undefined) ?? undefined, undefined,
+    'the agent catalogue must not be written into arturita_llm_chain')
+  assert.equal(parseCustomModels(c).length, 1)
+  assert.ok(Array.isArray(c[CATALOG_KEY]))
+})
+
+test('[AG-CM] a keyless local endpoint is allowed (and drops any stale key)', async () => {
+  const res = await add({ label: 'Local vLLM', baseUrl: 'http://localhost:8000/v1', model: 'qwen2.5-7b', mode: 'local' })
+  assert.equal(res.statusCode, 201, res.body)
+  assert.equal(res.json().maskedKey, null)
+  const creds = resolveLlmCreds(await cfg(), 'local_vllm')
+  assert.equal(creds.orgApiKey, undefined)
+  assert.equal(creds.baseURL, 'http://localhost:8000/v1')
+})
+
+test('[AG-CM] re-saving without a key keeps the stored one', async () => {
+  // The dialog leaves the key field blank when editing — that must not wipe it.
+  const res = await add({
+    provider: 'nvidia_llama_3_3', label: 'NVIDIA Llama 3.3',
+    baseUrl: 'https://integrate.api.nvidia.com/v1', model: 'meta/llama-3.3-70b-instruct',
+  })
+  assert.equal(res.statusCode, 201)
+  assert.equal(res.json().hasKey, true)
+  const creds = resolveLlmCreds(await cfg(), 'nvidia_llama_3_3')
+  assert.equal(creds.orgApiKey, KEY, 're-saving an existing model without retyping the key must keep it')
+})
+
+test('[AG-CM] an explicit empty key clears the stored one', async () => {
+  // Blank-because-not-retyped and blank-because-I-want-it-gone are different
+  // intents; `apiKey: ''` is the second, and must actually clear.
+  const res = await add({
+    provider: 'nvidia_llama_3_3', label: 'NVIDIA Llama 3.3',
+    baseUrl: 'https://integrate.api.nvidia.com/v1', model: 'meta/llama-3.3-70b-instruct', apiKey: '',
+  })
+  assert.equal(res.statusCode, 201)
+  assert.equal(res.json().hasKey, false)
+  assert.equal(resolveLlmCreds(await cfg(), 'nvidia_llama_3_3').orgApiKey, undefined)
+
+  // Put it back for the removal test below.
+  await add({
+    provider: 'nvidia_llama_3_3', label: 'NVIDIA Llama 3.3',
+    baseUrl: 'https://integrate.api.nvidia.com/v1', model: 'meta/llama-3.3-70b-instruct', apiKey: KEY,
+  })
+  assert.equal(resolveLlmCreds(await cfg(), 'nvidia_llama_3_3').orgApiKey, KEY)
+})
+
+test('[AG-CM] a bad base URL is refused', async () => {
+  for (const baseUrl of ['javascript:alert(1)', 'not-a-url', '']) {
+    const res = await add({ label: 'Bad', baseUrl, model: 'm' })
+    assert.equal(res.statusCode, 400, `${baseUrl} should be refused`)
+  }
+})
+
+test('[AG-CM] a missing model id is refused', async () => {
+  const res = await add({ label: 'No model', baseUrl: 'https://x.example/v1', model: '' })
+  assert.equal(res.statusCode, 400)
+})
+
+test('[AG-CM] a custom slug can never clobber a built-in provider key', async () => {
+  const res = await add({ provider: 'openai', baseUrl: 'https://evil.example/v1', model: 'gpt-4o', apiKey: 'sk-evil' })
+  assert.equal(res.statusCode, 201)
+  assert.equal(res.json().slug, 'custom_openai', 'a reserved provider name must be namespaced')
+  const c = await cfg()
+  assert.equal(c['openai_api_key_enc'], undefined, 'the real openai key slot must be untouched')
+})
+
+test('[AG-CM] audit snapshots carry no key material', async () => {
+  const revs = await db.select().from(schema.configRevisions).where(eq(schema.configRevisions.orgId, ORG))
+  assert.ok(revs.length > 0, 'custom-model changes must be auditable')
+  for (const r of revs) {
+    assert.ok(!(r.before ?? '').includes(KEY) && !(r.after ?? '').includes(KEY), 'a revision must never hold a key')
+    assert.ok(!(r.after ?? '').includes('_api_key_enc'), 'not even the encrypted blob belongs in an audit row')
+  }
+  assert.deepEqual(scrub({ a: 1, x_api_key: 'p', x_api_key_enc: 'e' }), { a: 1 })
+})
+
+test('[AG-CM] a member cannot add or remove a custom model', async () => {
+  const member = appAs(MEMBER)
+  await member.ready()
+  const post = await member.inject({
+    method: 'POST', url: `/api/orgs/${ORG}/custom-models`,
+    payload: { label: 'Sneaky', baseUrl: 'https://x.example/v1', model: 'm' },
+  })
+  assert.equal(post.statusCode, 403)
+  const del = await member.inject({ method: 'DELETE', url: `/api/orgs/${ORG}/custom-models/nvidia_llama_3_3` })
+  assert.equal(del.statusCode, 403)
+  await member.close()
+})
+
+test('[AG-CM] removing a model takes its key with it and names the stranded agents', async () => {
+  await db.update(schema.agents).set({ llmProvider: 'nvidia_llama_3_3' }).where(eq(schema.agents.id, AGENT))
+
+  const res = await app.inject({ method: 'DELETE', url: `/api/orgs/${ORG}/custom-models/nvidia_llama_3_3` })
+  assert.equal(res.statusCode, 200, res.body)
+  assert.equal(res.json().removed, true)
+  assert.deepEqual(res.json().stranded.map((a: any) => a.name), ['Vera'],
+    'an agent still pointed at the deleted model must be reported, not left to fail at run time')
+
+  const c = await cfg()
+  assert.equal(c['nvidia_llama_3_3_api_key_enc'], undefined, 'the stored key must be gone')
+  assert.equal(resolveLlmCreds(c, 'nvidia_llama_3_3').orgApiKey, undefined)
+  assert.ok(!parseCustomModels(c).some(e => e.provider === 'nvidia_llama_3_3'))
+})

--- a/web/app/dashboard/agent/ConfigurationTab.tsx
+++ b/web/app/dashboard/agent/ConfigurationTab.tsx
@@ -6,9 +6,10 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { api, API } from '@/lib/api'
 import { ACCEPTED_UPLOAD_TYPES, downscaleAvatar, isAcceptedUpload } from '@/lib/avatarImage'
 import { Button, Card, Select, Skeleton, TextArea, TextInput } from '../ui'
-import { FormLabel } from '../cockpit/shared'
+import { FormLabel, sx } from '../cockpit/shared'
 import { tk, text, space } from '../tokens'
 import { AgentAvatar, ax, type DAgent, type Getter } from './shared'
+import CustomModelDialog, { type CustomModel } from './CustomModelDialog'
 
 type Roster = { id: string; name: string; role: string; avatarEmoji?: string | null; reportsTo?: string | null }
 type ModelOption = { id: string; label: string; provider: string; tier: string; custom?: boolean }
@@ -30,6 +31,8 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
   const [agent, setAgent] = useState<DAgent | null>(null)
   const [roster, setRoster] = useState<Roster[]>([])
   const [models, setModels] = useState<ModelOption[]>([])
+  const [custom, setCustom] = useState<CustomModel[]>([])
+  const [dialog, setDialog] = useState<{ open: boolean; editing: CustomModel | null }>({ open: false, editing: null })
   const [form, setForm] = useState({ name: '', title: '', role: '', jobDescription: '', avatarEmoji: '', reportsTo: '', runtime: 'internal', model: '', contactChannel: '' })
   const [busy, setBusy] = useState(false)
   const [uploading, setUploading] = useState(false)
@@ -55,8 +58,12 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
         contactChannel: a.contactChannel ?? '',
       })
       try {
-        const { models: m } = await api<{ models: ModelOption[] }>(`/api/orgs/${orgId}/available-models`, { token })
+        const [{ models: m }, { models: c }] = await Promise.all([
+          api<{ models: ModelOption[] }>(`/api/orgs/${orgId}/available-models`, { token }),
+          api<{ models: CustomModel[] }>(`/api/orgs/${orgId}/custom-models`, { token }),
+        ])
         setModels(m)
+        setCustom(c)
       } catch { /* the model picker degrades to the current value */ }
     } catch (e: any) { setErr(e?.message ?? 'Could not load this agent’s configuration.') }
   }, [orgId, agentId, getToken])
@@ -101,6 +108,32 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
       onSaved?.()
     } catch (e: any) { setErr(e?.message ?? 'Could not upload that picture.') }
     setUploading(false)
+  }
+
+  // A model saved from the dialog is immediately selected as this agent's model:
+  // adding one and then having to find it in the dropdown is a step with no
+  // purpose. It is not persisted on the agent until Save changes — same as every
+  // other field on this page.
+  const onCustomSaved = async (m: CustomModel) => {
+    setDialog({ open: false, editing: null })
+    await load()
+    setForm(f => ({ ...f, model: m.model }))
+    setSaved(false)
+  }
+
+  const removeCustom = async (provider: string) => {
+    setBusy(true); setErr(null)
+    try {
+      const r = await api<{ stranded: { id: string; name: string }[] }>(`/api/orgs/${orgId}/custom-models/${encodeURIComponent(provider)}`,
+        { token: await getToken(), method: 'DELETE' })
+      await load()
+      // Deleting the endpoint does not un-point the agents at it — say so rather
+      // than let them fail at run time.
+      if (r.stranded?.length) {
+        setErr(`Removed. ${r.stranded.map(a => a.name).join(', ')} ${r.stranded.length === 1 ? 'is' : 'are'} still set to this model and will fail to run until you pick another.`)
+      }
+    } catch (e: any) { setErr(e?.message ?? 'Could not remove that model.') }
+    setBusy(false)
   }
 
   const removeAvatar = async () => {
@@ -201,6 +234,40 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
           A local/BYO adapter (OpenClaw, Claude Code, Cursor) runs on the operator’s machine and claims tasks over the
           agent API; the internal adapter runs on the 7Ei backend.
         </p>
+
+        {/* ── Custom models ──────────────────────────────────────────────
+            An operator-defined OpenAI-compatible endpoint. It is a MODEL, not a
+            runtime: the internal executor calls it. Kept next to the picker it
+            feeds, rather than buried in org settings. */}
+        <Card style={{ display: 'flex', flexDirection: 'column', gap: space.md, marginTop: space.lg, padding: 0, overflow: 'hidden' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: space.md, padding: `${space.md}px ${space.lg}px`, borderBottom: `1px solid ${tk.line}` }}>
+            <span style={{ fontSize: text.sm.fontSize, fontWeight: 700 }}>Custom models</span>
+            <Button onClick={() => setDialog({ open: true, editing: null })}>＋ Add a custom model</Button>
+          </div>
+
+          {custom.length === 0 ? (
+            <p style={{ ...ax.empty, fontSize: text.xs.fontSize, padding: `0 ${space.lg}px ${space.lg}px` }}>
+              None yet. Add any OpenAI-compatible endpoint — NVIDIA NIM, Together, vLLM, a local server, or an
+              OpenAI-standard provider — and it becomes selectable in the Model list above.
+            </p>
+          ) : custom.map(m => (
+            <div key={m.provider} style={{ display: 'flex', alignItems: 'center', gap: space.md, padding: `${space.md}px ${space.lg}px`, borderTop: `1px solid ${tk.line}` }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: space.sm, flexWrap: 'wrap' }}>
+                  <span style={{ fontSize: text.md.fontSize, fontWeight: 600 }}>{m.label || m.model}</span>
+                  {form.model === m.model && <span style={{ ...sx.badge, color: tk.accent, borderColor: 'var(--accent-line)' }}>IN USE</span>}
+                  {/* Whether a key is stored is a fact the operator needs; the key itself never comes back. */}
+                  <span style={sx.badge}>{m.hasKey ? '🔒 key stored' : 'no key'}</span>
+                </div>
+                <div style={{ fontSize: text.xs.fontSize, color: tk.muted, fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {m.model} · {m.baseUrl}
+                </div>
+              </div>
+              <Button onClick={() => setDialog({ open: true, editing: m })} disabled={busy}>Edit</Button>
+              <Button variant="danger" onClick={() => removeCustom(m.provider)} disabled={busy}>Remove</Button>
+            </div>
+          ))}
+        </Card>
       </section>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: space.lg }}>
@@ -209,6 +276,11 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
         </Button>
         {saved && <span style={{ color: tk.green, fontSize: text.sm.fontSize }}>✓ Saved</span>}
       </div>
+
+      {dialog.open && (
+        <CustomModelDialog orgId={orgId} getToken={getToken} existing={dialog.editing}
+          onClose={() => setDialog({ open: false, editing: null })} onSaved={onCustomSaved} />
+      )}
     </div>
   )
 }

--- a/web/app/dashboard/agent/CustomModelDialog.tsx
+++ b/web/app/dashboard/agent/CustomModelDialog.tsx
@@ -1,0 +1,136 @@
+'use client'
+// Epic AG — define a custom adapter/model for an agent: any OpenAI-compatible
+// endpoint (NVIDIA NIM, Together, vLLM, a local server, or a plain OpenAI-standard
+// provider). Same shape as Arturita's custom-model insertion (#207) and the same
+// backend service behind it — display name, base URL, model id, optional API key.
+//
+// The key is sent once, stored AES-256-GCM encrypted, and never comes back: the
+// server returns a masked tail only. Leaving the field blank on an existing model
+// keeps the stored key; that is why the placeholder says so rather than showing
+// a fake value the operator might think is real.
+import { useState } from 'react'
+import { api } from '@/lib/api'
+import { Button, TextInput } from '../ui'
+import { Modal, ModalTitle, FormLabel, sx } from '../cockpit/shared'
+import { tk, text, space } from '../tokens'
+import { ax, type Getter } from './shared'
+
+export type CustomModel = {
+  provider: string
+  model: string
+  label?: string
+  baseUrl?: string
+  mode?: 'local' | 'provider'
+  hasKey?: boolean
+}
+
+type Probe = { ok: boolean; status: number | null; detail: string }
+
+export default function CustomModelDialog({ orgId, getToken, existing, onClose, onSaved }: {
+  orgId: string
+  getToken: Getter
+  /** editing an existing entry (key left blank keeps the stored one) */
+  existing?: CustomModel | null
+  onClose: () => void
+  /** the saved entry — the caller selects it as the agent's model */
+  onSaved: (m: CustomModel) => void
+}) {
+  const [label, setLabel] = useState(existing?.label ?? '')
+  const [baseUrl, setBaseUrl] = useState(existing?.baseUrl ?? '')
+  const [model, setModel] = useState(existing?.model ?? '')
+  const [apiKey, setApiKey] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [probe, setProbe] = useState<Probe | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const base = `/api/orgs/${orgId}/custom-models`
+  const ready = !!model.trim() && !!baseUrl.trim()
+
+  const test = async () => {
+    setTesting(true); setErr(null); setProbe(null)
+    try {
+      setProbe(await api<Probe>(`${base}/test`, {
+        token: await getToken(), method: 'POST',
+        body: JSON.stringify({
+          model: model.trim(), baseUrl: baseUrl.trim(),
+          // No key typed + editing → probe with the stored one.
+          ...(apiKey.trim() ? { apiKey: apiKey.trim() } : existing ? { provider: existing.provider } : {}),
+        }),
+      }))
+    } catch (e: any) { setErr(e?.message ?? 'Could not reach the endpoint.') }
+    setTesting(false)
+  }
+
+  const save = async () => {
+    setBusy(true); setErr(null)
+    try {
+      const r = await api<{ entry: CustomModel }>(base, {
+        token: await getToken(), method: 'POST',
+        body: JSON.stringify({
+          label: label.trim() || undefined,
+          model: model.trim(),
+          baseUrl: baseUrl.trim(),
+          ...(existing ? { provider: existing.provider } : {}),
+          ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+        }),
+      })
+      onSaved(r.entry)
+    } catch (e: any) { setErr(e?.message ?? 'Could not save this model.'); setBusy(false) }
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <ModalTitle onClose={onClose}>{existing ? 'Edit custom model' : 'Add a custom model'}</ModalTitle>
+
+      <p style={{ ...ax.empty, fontSize: text.xs.fontSize, maxWidth: 460 }}>
+        Any OpenAI-compatible endpoint — NVIDIA NIM, Together, vLLM, a local server, or an OpenAI-standard provider.
+        The 7Ei executor calls it directly on this agent’s runs.
+      </p>
+
+      {err && <div style={ax.err}>{err}</div>}
+
+      <FormLabel>Display name <span style={{ fontWeight: 400, color: tk.muted }}>· optional</span>
+        <TextInput value={label} placeholder="NVIDIA Llama 3.3 70B" onChange={e => setLabel(e.target.value)} />
+      </FormLabel>
+
+      <FormLabel>Base URL <span style={{ fontWeight: 400, color: tk.muted }}>· the OpenAI-compatible root, ending in /v1</span>
+        <TextInput value={baseUrl} placeholder="https://integrate.api.nvidia.com/v1" inputMode="url"
+          onChange={e => { setBaseUrl(e.target.value); setProbe(null) }} />
+      </FormLabel>
+
+      <FormLabel>Model id <span style={{ fontWeight: 400, color: tk.muted }}>· exactly as the provider names it</span>
+        <TextInput value={model} placeholder="meta/llama-3.3-70b-instruct"
+          onChange={e => { setModel(e.target.value); setProbe(null) }} />
+      </FormLabel>
+
+      <FormLabel>API key <span style={{ fontWeight: 400, color: tk.muted }}>· optional — a local endpoint may need none</span>
+        <TextInput type="password" value={apiKey} autoComplete="off"
+          placeholder={existing?.hasKey ? 'A key is stored — leave blank to keep it' : 'nvapi-…'}
+          onChange={e => { setApiKey(e.target.value); setProbe(null) }} />
+      </FormLabel>
+      <p style={{ ...ax.empty, fontSize: text.xs.fontSize }}>
+        The key is encrypted (AES-256-GCM) before it is stored, and is never shown or logged again.
+      </p>
+
+      {/* Result is stated in words and marked with a glyph — never colour alone. */}
+      {probe && (
+        <div style={{
+          ...sx.badge, display: 'flex', gap: space.sm, alignItems: 'center', padding: `${space.sm}px ${space.md}px`,
+          color: probe.ok ? tk.green : tk.red, borderColor: probe.ok ? tk.green : tk.red, whiteSpace: 'normal',
+        }}>
+          <span aria-hidden="true">{probe.ok ? '✓' : '✕'}</span>
+          <span>{probe.ok ? 'Reachable' : 'Failed'} — {probe.detail}{probe.status ? ` (HTTP ${probe.status})` : ''}</span>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: space.sm, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+        <Button onClick={onClose} disabled={busy}>Cancel</Button>
+        <Button onClick={test} disabled={!ready || testing || busy}>{testing ? 'Testing…' : 'Test connection'}</Button>
+        <Button variant="primary" onClick={save} disabled={!ready || busy}>
+          {busy ? 'Saving…' : existing ? 'Save model' : 'Add model'}
+        </Button>
+      </div>
+    </Modal>
+  )
+}


### PR DESCRIPTION
Feature 4. Reuses the #207 custom-model service rather than forking it.

## What the operator gets

Agent → **Configuration → Adapter → Custom models → ＋ Add a custom model**. A form for **display name**, **base URL** (the OpenAI-compatible root, e.g. `https://integrate.api.nvidia.com/v1`), **model id** (`meta/llama-3.3-70b-instruct`), and an **optional API key**. **Test connection** probes the endpoint (GET `/models`, falling back to a 1-token chat call) and reports reachable / auth-failed / not-found in words and with a glyph — never colour alone. Save, and it is immediately selected as this agent's model and appears in the Model dropdown; **Save changes** persists it on the agent.

OpenAI-compatible is the general case, so this covers NVIDIA NIM, Together, vLLM, a local server, and any OpenAI-standard provider. The endpoint is a **model**, not a runtime — the internal 7Ei executor calls it, which the UI copy says plainly.

The key is sent once, stored **AES-256-GCM encrypted**, and never comes back: responses carry a masked tail and a `hasKey` flag. Owner-gated; every change snapshots a config revision (scrubbed of key material). Removing a model takes its key with it and **names the agents still pointed at it**, rather than letting them fail at run time.

## Reuse, not a fork

`services/custom-model.ts` gains a `catalogKey` parameter and `parseCustomModels`; `probeEndpoint` moved out of the Arturita route into the service, so there is now **one** probe implementation instead of two. The Arturita door is unchanged by default.

Agent models register into `custom_models`, **not** `arturita_llm_chain` — that chain is Arturita's ordered *failover* list, and defining a model for another agent must not silently change what Arturita falls back to. `available-models` merges both (deduped), so a model added at either door is selectable at both.

## The interop bug this closes

`agent-executor` read only the **plaintext** `${provider}_api_key`, while the save path only ever writes the **encrypted** `${provider}_api_key_enc`. A custom model with a key could not have authenticated on a single run. The executor now resolves credentials through `resolveLlmCreds` for every provider — built-in or custom, on the primary call and on every fallback hop. It rides the existing fallback chain, preflight and budget machinery unchanged.

## Bugs the tests caught in this change before it shipped

- **Re-saving an existing model without retyping the key wiped the stored key** — and the edit dialog leaves that field blank *by design*, because a key can never be shown again. `apiKey` omitted → keep; `apiKey: ''` → explicitly clear.
- The stranded-agents check filtered on a column the query never selected, so it always found none.
- A reserved slug (`openai`) is namespaced to `custom_openai`, so a custom entry can never clobber a real provider's key slot.

## Verify

- backend `npm test` -> **1065 pass, 0 fail** (15 new) · `evals` -> **11/11** · typecheck clean
- web `npm test` -> **146 pass** · `npm run build` -> passes
- Tests assert the key is never echoed, never stored in plaintext, absent from audit rows, and *decryptable by the run path* — the last one is the whole feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)