### PR TITLE
fix(AG): Command Center — 🎙️ mic icon, moved directly under Dashboard

### DIFF
--- a/web/lib/navModel.test.ts
+++ b/web/lib/navModel.test.ts
@@ -37,6 +37,20 @@ test('[AGFIX4] the assistant nav item reads "Command Center", keeping its id', (
   assert.equal(allNavItems().filter(i => i.label === 'Arturita').length, 0, 'no nav item is labelled with the persona')
 })
 
+// Command Center is the operator's primary way in, so it sits directly under
+// Dashboard in Overview and wears the microphone (it is voice-first).
+test('[AGFIX5] Command Center is second in Overview, right after Dashboard', () => {
+  const overview = NAV_GROUPS.find(g => g.id === 'overview')
+  assert.deepEqual(
+    overview?.items.slice(0, 2).map(i => i.id),
+    ['overview', 'assistant'],
+  )
+})
+
+test('[AGFIX5] Command Center carries the microphone icon', () => {
+  assert.equal(findNavItem('assistant')?.icon, '🎙️')
+})
+
 test('[P0-web] nav item ids are globally unique', () => {
   const ids = allNavItems().map(i => i.id)
   assert.equal(new Set(ids).size, ids.length)

--- a/web/lib/navModel.ts
+++ b/web/lib/navModel.ts
@@ -47,13 +47,14 @@ export const NAV_GROUPS: NavGroup[] = [
     label: 'Overview',
     items: [
       { id: 'overview', label: 'Dashboard', icon: '🏠', kind: 'tab', paperclip: 'Dashboard' },
-      { id: 'cockpit', label: 'Operations', icon: '🛰️', kind: 'tab', paperclip: 'Dashboard / live' },
-      { id: 'inbox', label: 'Inbox', icon: '📥', kind: 'section', section: 'inbox', paperclip: 'Inbox' },
-      { id: 'activity', label: 'Activity', icon: '📈', kind: 'section', section: 'activity', paperclip: 'Activity' },
       // The nav label is the surface, not the persona: the tab is the operator's
       // Command Center. The assistant answering inside it is still Arturita, and
       // the id stays `assistant` — it is the dashboard Tab value and is deep-linked.
-      { id: 'assistant', label: 'Command Center', icon: '🌸', kind: 'tab', paperclip: 'Board Chat', beyond: true },
+      // It sits directly under Dashboard: it is the operator's primary way in.
+      { id: 'assistant', label: 'Command Center', icon: '🎙️', kind: 'tab', paperclip: 'Board Chat', beyond: true },
+      { id: 'cockpit', label: 'Operations', icon: '🛰️', kind: 'tab', paperclip: 'Dashboard / live' },
+      { id: 'inbox', label: 'Inbox', icon: '📥', kind: 'section', section: 'inbox', paperclip: 'Inbox' },
+      { id: 'activity', label: 'Activity', icon: '📈', kind: 'section', section: 'activity', paperclip: 'Activity' },
       { id: 'search', label: 'Search', icon: '🔍', kind: 'placeholder', paperclip: 'Search', note: 'Global search page. Today: press ⌘K for the command palette. A dedicated search surface is an Epic-P gap.' },
     ],
   },


### PR DESCRIPTION
Two small nav changes to `web/lib/navModel.ts` (the single source of the sidebar IA — `Sidebar.tsx` and `page.tsx` render from it).

## What changed
1. **Icon** — the Command Center item now uses 🎙️ instead of 🌸, so it renders as "🎙️ Command Center". The surface is voice-first; the 🌸 persona mark stays where it belongs, inside `AssistantPanel` (Arturita is still Arturita).
2. **Position** — moved from fifth to **second in the Overview group, directly under Dashboard**. Order is now Dashboard · Command Center · Operations · Inbox · Activity · Search. Nothing else moved, no item was dropped, and the id stays `assistant` (it is the dashboard Tab value and is deep-linked).

## Tests
+2 tests in `web/lib/navModel.test.ts` pinning the new position and the icon, on top of the existing "every tab is re-homed exactly once (nothing lost)" invariant.

- `npm test` (web) → **154/154 pass**
- `npm run build` (web) → **green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)