### PR TITLE
feat(P1): sidebar restructure — six removals + five surfaces folded into parent tabs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,20 @@
 # 7Ei Mission Control — Status
 
-_Last updated: 2026-07-14 (Epic AG follow-up 2 — avatar-Remove 400 root cause + three UI fixes; prior: CORS PUT/DELETE fix + Skills editable + custom adapter; prior: Epic AG COMPLETE — Agents experience: Staff grid + six-tab agent detail page) · auto-maintained by the build agent (bumped at each story/phase)._
+_Last updated: 2026-07-14 (Epic P / P1 — sidebar restructure: six removals + five surfaces folded into tabs; prior: Epic AG follow-up 2 — avatar-Remove 400 root cause + three UI fixes; prior: Epic AG COMPLETE — Agents experience: Staff grid + six-tab agent detail page) · auto-maintained by the build agent (bumped at each story/phase)._
 
-**Latest (2026-07-14) — Epic AG follow-up 2: the avatar-Remove 400 + three UI fixes (#239):**
+**Latest (2026-07-14) — Epic P / P1: sidebar restructure — a shorter rail, nothing lost (#241):**
+
+P0b promoted every Cockpit section to a first-class nav area, which worked but left the rail **long**. P1 shortens it. The rule throughout: **remove from the rail, never from the app** — every surface stays routable (⌘K palette + any deep link to its id still renders it), and `web/lib/navModel.ts` remains the single IA source that `Sidebar.tsx` and the dashboard render from.
+
+**Six surfaces off the rail** (`HIDDEN_ITEMS`): **Search · Issues · Goals · Pipelines · Workspaces · Artifacts**. Search/Pipelines/Artifacts were "coming soon" placeholders; Issues/Goals/Workspaces are real surfaces whose components, routes and data are **untouched** — they simply aren't in the sidebar. All six still resolve through `findNavItem`, still appear in the command palette, and still render.
+
+**Five surfaces folded into a parent's tab bar** — new `PageTabs.tsx`, driven by `navPageTabs()`: **Costs → `Costs | Budgets`**, **Connectors → `Connectors | Plugins`**, **Inbox (renamed **Inbox / Comms**) → `Inbox | Comms`**, **Settings → `Settings | Adapters | Secrets`**. Opening a hosted tab keeps its **parent** lit in the rail (`navSelectedId`), so the rail can't lose the user inside a tabbed page. No panel was rebuilt: each tab renders the exact component it always did (a promoted Cockpit section, a dashboard tab, or the honest Adapters placeholder).
+
+The model now partitions every surface into exactly one of **rail · hosted tab · off-rail**, and the tests assert that partition — plus each removal, each fold target, the full rail order, and the carried-over **"every prior surface still reachable (nothing lost)"** invariant, which now spans all three homes. **17 nav tests** (was 10); the removals and folds can't silently regress.
+
+**Invariant green: web build · 161 web tests (+9) · backend untouched (1073 tests).**
+
+**Prior (2026-07-14) — Epic AG follow-up 2: the avatar-Remove 400 + three UI fixes (#239):**
 
 **BUG — avatar Remove returned `HTTP 400: Bad Request` (the layer under the CORS fix).** Once CORS stopped blocking the DELETE preflight, the request finally reached the backend — and was refused **before any handler ran**. `web/lib/api.ts` set **`Content-Type: application/json` on every request**, body or not. A DELETE has no body, and Fastify's stock JSON parser rejects exactly that pair: **`FST_ERR_CTP_EMPTY_JSON_BODY`** — *"Body cannot be empty when content-type is set to 'application/json'"* → 400, which the client surfaced as a bare `HTTP 400`. The route, the Zod validators and the owner gate were all innocent; `avatar_url` was never nullable-constrained and the DELETE handler was correct all along. **Why the existing route test passed:** it injected the DELETE **without a Content-Type**, so it never reproduced the browser's request. Fixed at both layers — the client no longer claims a JSON body it isn't sending (`apiHeaders`), and the API now installs a **tolerant JSON parser** (`middleware/body-parser.ts`, mirroring the `cors.ts` precedent: a transport default that breaks a healthy route belongs in a tested module) that parses an **empty body to `{}`** while still refusing genuinely broken JSON with a message that names the problem. This fixes **every** bodiless write across the dashboard, not just the avatar. Regression-guarded by a test that drives the real handler with the **browser's exact headers**, plus one that asserts the raw Fastify default still 400s — so the bug can't come back unnoticed.
 

--- a/docs/IA-paperclip-mapping.md
+++ b/docs/IA-paperclip-mapping.md
@@ -15,7 +15,32 @@
 collapsed/expanded state persists per browser (`localStorage["mc.nav.collapsed"]`). The whole rail
 also **folds to icons** (`localStorage["mc.nav.railFolded"]`).
 
+## The rail after P1 (current)
+
+P1 shortened the rail. **No surface was deleted** — every one of them is still routable (⌘K palette
++ any deep link to its id still renders it). A surface now lives in exactly one of three places, and
+`navModel` enforces that partition (`allSurfaces() = rail ∪ hosted tabs ∪ off-rail`):
+
+| Group | Rail item | Tabs it hosts |
+|---|---|---|
+| **Overview** | Dashboard · 🎙️ Command Center · Operations · **Inbox / Comms** · Activity | Inbox / Comms → `Inbox` \| `Comms` |
+| **Workspace** | Agents · Projects · Org · Routines _(soon)_ | — |
+| **Operate** | Governance · Review Queue _(soon)_ | — |
+| **Delivery** | **Costs** · Skills · Memory | Costs → `Costs` \| `Budgets` |
+| **Company** | **Connectors** · Members & Access _(soon)_ | Connectors → `Connectors` \| `Plugins` |
+| **General** | Usage · **Settings** | Settings → `Settings` \| `Adapters` \| `Secrets` |
+
+**Off the rail, still routable** (`HIDDEN_ITEMS` — reachable via ⌘K, code untouched):
+`Search`, `Issues`, `Goals`, `Pipelines`, `Workspaces`, `Artifacts`.
+
+Selecting a hosted tab keeps its **parent** lit in the rail (`navSelectedId`), so the rail never
+"loses" the user inside a tabbed page.
+
 ## Mapping — Paperclip area → our surface
+
+> The `Our surface` column below records the **original** re-home (P0a/P0b). Where P1 moved a surface
+> into a tab bar or off the rail, the P1 table above is the authority on **where it appears**; the
+> surface itself is unchanged.
 
 | Group | Paperclip area | Our surface | How it's fulfilled |
 |---|---|---|---|
@@ -65,6 +90,13 @@ analog; they're mounted in the nearest-fit group and clearly ours.
   section filter — the same composition root renders either the full **Operations** stack or a single
   focused area, reusing every existing section component (no rebuild). Approvals stay in Inbox +
   Governance (see note above).
+- **P1 — shorten the rail (shipped):** P0b made every surface first-class, which made the rail long.
+  P1 folds five surfaces into their parent's **tab bar** (`Budgets`→Costs, `Plugins`→Connectors,
+  `Comms`→Inbox _(now "Inbox / Comms")_, `Adapters` + `Secrets`→Settings) via a new `PageTabs.tsx`
+  driven by `navPageTabs()`, and takes six off the rail entirely (`Search`, `Issues`, `Goals`,
+  `Pipelines`, `Workspaces`, `Artifacts` → `HIDDEN_ITEMS`). **Nothing was deleted and nothing became
+  unreachable** — the palette walks `allSurfaces()`, and the nav tests assert the removals, each fold
+  target, and the "every prior surface still reachable" invariant.
 
 ## Non-negotiables carried through
 Colorblind-safe (icon + label + tone, never color alone), **design tokens only** (no raw hex in new

--- a/web/app/dashboard/PageTabs.tsx
+++ b/web/app/dashboard/PageTabs.tsx
@@ -1,0 +1,40 @@
+'use client'
+// P1 — the tab bar for a page that hosts other surfaces as tabs (Costs | Budgets,
+// Connectors | Plugins, Inbox | Comms, Settings | Adapters | Secrets). The tabs
+// come from lib/navModel (`navPageTabs`); this file is only presentation.
+// Colorblind-safe: the active tab carries accent + bold + a filled background,
+// and aria-selected states it outright.
+import type { PageTab } from '@/lib/navModel'
+
+export default function PageTabs({ tabs, active, onSelect }: {
+  tabs: PageTab[]
+  active: string
+  onSelect: (id: string) => void
+}) {
+  if (tabs.length < 2) return null
+  return (
+    <div style={s.bar}>
+      <div role="tablist" aria-label="Page sections" style={s.list}>
+        {tabs.map(t => {
+          const on = t.id === active
+          return (
+            <button key={t.id} role="tab" aria-selected={on} onClick={() => onSelect(t.id)}
+              style={{
+                ...s.tab,
+                background: on ? 'var(--accent-dim)' : 'transparent',
+                border: `1px solid ${on ? 'var(--accent-line)' : 'var(--line-strong)'}`,
+                color: on ? 'var(--accent)' : 'var(--muted)',
+                fontWeight: on ? 700 : 600,
+              }}>{t.label}</button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+const s: Record<string, React.CSSProperties> = {
+  bar: { padding: '20px 28px 0', maxWidth: 1200, margin: '0 auto' },
+  list: { display: 'flex', gap: 6, borderBottom: '1px solid var(--line)', paddingBottom: 12 },
+  tab: { borderRadius: 8, padding: '6px 14px', cursor: 'pointer', fontSize: 12.5 },
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -10,9 +10,10 @@ import TaskDrawer from './TaskDrawer'
 import GovernancePanel from './GovernancePanel'
 import Sidebar from './Sidebar'
 import PlaceholderView from './PlaceholderView'
+import PageTabs from './PageTabs'
 import AgentDetail from './agent/AgentDetail'
 import StaffGrid from './agent/StaffGrid'
-import { allNavItems, isPlaceholder, isSection, navSectionKey, findNavItem } from '@/lib/navModel'
+import { allSurfaces, isPlaceholder, isSection, navSectionKey, navPageTabs, navSelectedId, navSurfaceTitle } from '@/lib/navModel'
 import { DEFAULT_AGENT_TAB, agentRouteHash, parseAgentRoute, type AgentRoute, type AgentTab } from '@/lib/agentRoute'
 import { AgentAvatar } from './agent/shared'
 import { useTheme } from '../theme'
@@ -329,8 +330,11 @@ export default function DashboardPage() {
   // T2 command-palette shell — navigation + theme. Nav entries come from the
   // Paperclip-style nav model (P0a); selecting a "coming soon" area lands on its
   // placeholder view. Epic V extends this list (jump to task/agent/approval).
+  // P1 — this walks *every* surface, not just the rail: the surfaces we folded
+  // into tabs (Budgets, Plugins, Comms, Adapters, Secrets) and the ones we took
+  // off the rail entirely (Issues, Goals, Workspaces, …) stay one ⌘K away.
   const commands: Command[] = [
-    ...allNavItems().map(n => ({ id: `nav-${n.id}`, label: n.kind === 'placeholder' ? `${n.label} (soon)` : n.label, icon: n.icon, group: 'Navigate', keywords: `go to open view tab ${n.paperclip}`, run: () => selectTab(n.id) })),
+    ...allSurfaces().map(n => ({ id: `nav-${n.id}`, label: n.kind === 'placeholder' ? `${n.label} (soon)` : n.label, icon: n.icon, group: 'Navigate', keywords: `go to open view tab ${n.paperclip}`, run: () => selectTab(n.id) })),
     // AG1 — jump straight to an agent's detail page.
     ...agents.map(a => ({ id: `agent-${a.id}`, label: a.name, icon: a.avatarEmoji || '🤖', group: 'Agents', keywords: `agent open ${a.role}`, run: () => openAgent(a.id) })),
     { id: 'theme-light', label: 'Light theme', icon: '☀', group: 'Theme', keywords: 'appearance mode', run: () => setMode('light') },
@@ -341,10 +345,15 @@ export default function DashboardPage() {
   return (
     <div className="mc-layout" style={s.layout}>
       <CommandPalette commands={commands} open={paletteOpen} onOpenChange={setPaletteOpen} />
-      {/* P0a — Paperclip-style folded, grouped, collapsible nav rail. */}
-      <Sidebar orgName={org.name} selected={tab} onSelect={selectTab} onOpenPalette={() => setPaletteOpen(true)} unread={unread} />
+      {/* P0a — Paperclip-style folded, grouped, collapsible nav rail. P1: when a
+          hosted tab is open (e.g. Budgets), the rail keeps its parent (Costs) lit. */}
+      <Sidebar orgName={org.name} selected={navSelectedId(tab)} onSelect={selectTab} onOpenPalette={() => setPaletteOpen(true)} unread={unread} />
 
       <main className="mc-main" style={s.main}>
+
+        {/* P1 — a page that hosts other surfaces as tabs shows them above its body.
+            Selecting one swaps the body; the rail selection doesn't move. */}
+        <PageTabs tabs={navPageTabs(navSelectedId(tab))} active={tab} onSelect={selectTab} />
 
         {/* P0a — Paperclip areas not yet built land on an honest "coming soon" view. */}
         {isPlaceholder(tab) && <PlaceholderView id={tab} />}
@@ -353,7 +362,7 @@ export default function DashboardPage() {
             reusing the CockpitPanel composition root (no rebuild). */}
         {isSection(tab) && (
           <CockpitPanel orgId={org.id} getToken={getToken} onOpenTask={setOpenTaskId} onOpenAgent={openAgent}
-            only={[navSectionKey(tab) as CockpitSectionKey]} title={findNavItem(tab)?.label} />
+            only={[navSectionKey(tab) as CockpitSectionKey]} title={navSurfaceTitle(tab)} />
         )}
 
         {tab === 'cockpit' && <CockpitPanel orgId={org.id} getToken={getToken} onOpenTask={setOpenTaskId} onOpenAgent={openAgent} />}

--- a/web/lib/navModel.test.ts
+++ b/web/lib/navModel.test.ts
@@ -1,8 +1,9 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  NAV_GROUPS, allNavItems, navTabIds, findNavItem, isPlaceholder,
-  isSection, navSectionKey,
+  NAV_GROUPS, HIDDEN_ITEMS, allNavItems, allSurfaces, hostedTabItems, navTabIds,
+  findNavItem, isPlaceholder, isSection, isHidden, navSectionKey,
+  navPageTabs, navParentId, navSelectedId, navSurfaceTitle,
   parseCollapsed, serializeCollapsed, toggleCollapsed, type NavGroupId,
 } from './navModel.ts'
 
@@ -12,6 +13,18 @@ const EXISTING_TABS = [
   'projects', 'skills', 'costs', 'comms', 'connectors', 'governance', 'usage', 'settings',
 ]
 
+// P1 — surfaces taken off the rail entirely. Still routable, never rendered in the sidebar.
+const REMOVED_FROM_RAIL = ['search', 'tasks', 'goals', 'pipelines', 'workspaces', 'artifacts']
+
+// P1 — surfaces folded into a parent page's tab bar: child → parent.
+const FOLDED: Record<string, string> = {
+  budgets: 'costs',
+  plugins: 'connectors',
+  comms: 'inbox',
+  adapters: 'settings',
+  secrets: 'settings',
+}
+
 test('[P0-web] groups are in Paperclip order', () => {
   assert.deepEqual(
     NAV_GROUPS.map(g => g.id),
@@ -20,6 +33,8 @@ test('[P0-web] groups are in Paperclip order', () => {
 })
 
 test('[P0-web] every existing tab is re-homed exactly once (nothing lost)', () => {
+  // The invariant survives P1: a tab may now live in the rail, in a parent's tab
+  // bar, or off-rail-but-routable — but it must still exist, exactly once.
   const tabIds = navTabIds()
   for (const t of EXISTING_TABS) {
     assert.equal(tabIds.filter(id => id === t).length, 1, `tab ${t} must appear exactly once`)
@@ -28,13 +43,118 @@ test('[P0-web] every existing tab is re-homed exactly once (nothing lost)', () =
   assert.deepEqual([...tabIds].sort(), [...EXISTING_TABS].sort())
 })
 
+// ─── P1 — the restructure: removals + folds ─────────────────────────────────
+
+test('[P1-nav] removed surfaces are gone from the sidebar', () => {
+  const railIds = allNavItems().map(i => i.id)
+  for (const id of REMOVED_FROM_RAIL) {
+    assert.equal(railIds.includes(id), false, `${id} must not be a rail item`)
+    assert.equal(isHidden(id), true, `${id} must be a hidden (off-rail) surface`)
+  }
+})
+
+test('[P1-nav] removed surfaces stay routable — the code is kept, not deleted', () => {
+  for (const id of REMOVED_FROM_RAIL) {
+    const item = findNavItem(id)
+    assert.ok(item, `${id} must still resolve (deep links + palette)`)
+    assert.equal(item!.id, id)
+    assert.ok(item!.label && item!.icon, `${id} still needs a label + icon for the palette`)
+    // and it is reachable through the surface set the palette and router walk.
+    assert.equal(allSurfaces().some(sfc => sfc.id === id), true)
+  }
+  // The real surfaces we kept still render the way they always did.
+  assert.equal(findNavItem('tasks')!.kind, 'tab')
+  assert.equal(navSectionKey('goals'), 'goals')
+  assert.equal(navSectionKey('workspaces'), 'workspaces')
+})
+
+test('[P1-nav] folded surfaces are tabs on their parent page, not rail items', () => {
+  const railIds = allNavItems().map(i => i.id)
+  for (const [child, parent] of Object.entries(FOLDED)) {
+    assert.equal(railIds.includes(child), false, `${child} must not be a rail item any more`)
+    assert.equal(railIds.includes(parent), true, `${parent} must still be a rail item`)
+    assert.equal(navParentId(child), parent, `${child} must be hosted by ${parent}`)
+    // Selecting the child keeps the PARENT lit in the sidebar.
+    assert.equal(navSelectedId(child), parent)
+    // …and the child is still a fully-resolvable surface.
+    assert.ok(findNavItem(child), `${child} must still resolve`)
+  }
+  // A rail item that hosts nothing has no parent and selects itself.
+  assert.equal(navParentId('memory'), undefined)
+  assert.equal(navSelectedId('memory'), 'memory')
+})
+
+test('[P1-nav] each parent page exposes exactly the expected tab bar, itself first', () => {
+  assert.deepEqual(navPageTabs('costs'), [
+    { id: 'costs', label: 'Costs' },
+    { id: 'budgets', label: 'Budgets' },
+  ])
+  assert.deepEqual(navPageTabs('connectors'), [
+    { id: 'connectors', label: 'Connectors' },
+    { id: 'plugins', label: 'Plugins' },
+  ])
+  assert.deepEqual(navPageTabs('inbox'), [
+    { id: 'inbox', label: 'Inbox' },
+    { id: 'comms', label: 'Comms' },
+  ])
+  assert.deepEqual(navPageTabs('settings'), [
+    { id: 'settings', label: 'Settings' },
+    { id: 'adapters', label: 'Adapters' },
+    { id: 'secrets', label: 'Secrets' },
+  ])
+  // Pages that host nothing get no tab bar (PageTabs renders null under 2 tabs).
+  for (const id of ['overview', 'assistant', 'agents', 'memory', 'usage', 'governance']) {
+    assert.deepEqual(navPageTabs(id), [], `${id} must not sprout a tab bar`)
+  }
+  // Only the four parents host tabs — nothing else silently grows one.
+  assert.deepEqual(
+    allNavItems().filter(i => i.tabs?.length).map(i => i.id).sort(),
+    ['connectors', 'costs', 'inbox', 'settings'],
+  )
+})
+
+test('[P1-nav] the Inbox rail entry reads "Inbox / Comms" but its own tab reads "Inbox"', () => {
+  const inbox = allNavItems().find(i => i.id === 'inbox')
+  assert.equal(inbox?.label, 'Inbox / Comms')
+  assert.equal(navSurfaceTitle('inbox'), 'Inbox')
+  assert.equal(navSurfaceTitle('comms'), 'Comms')
+})
+
+test('[P1-nav] the sidebar is exactly the intended items, in order', () => {
+  assert.deepEqual(
+    NAV_GROUPS.map(g => [g.id, g.items.map(i => i.id)]),
+    [
+      ['overview', ['overview', 'assistant', 'cockpit', 'inbox', 'activity']],
+      ['workspace', ['agents', 'projects', 'org', 'routines']],
+      ['operate', ['governance', 'review-queue']],
+      ['delivery', ['costs', 'skills', 'memory']],
+      ['company', ['connectors', 'members']],
+      ['general', ['usage', 'settings']],
+    ],
+  )
+})
+
+test('[P1-nav] every surface lives in exactly one place: rail, a tab bar, or hidden', () => {
+  const ids = allSurfaces().map(i => i.id)
+  assert.equal(new Set(ids).size, ids.length, 'no surface is registered twice')
+  // Partition check: rail ∪ hosted ∪ hidden == allSurfaces, with no overlap.
+  const rail = new Set(allNavItems().map(i => i.id))
+  const hosted = new Set(hostedTabItems().map(i => i.id))
+  const hidden = new Set(HIDDEN_ITEMS.map(i => i.id))
+  assert.equal(rail.size + hosted.size + hidden.size, new Set(ids).size)
+  for (const h of hosted) assert.equal(rail.has(h), false)
+  for (const h of hidden) { assert.equal(rail.has(h), false); assert.equal(hosted.has(h), false) }
+})
+
+// ─── Invariants carried over from P0 ────────────────────────────────────────
+
 // FIX 4 — the nav item is labelled for the surface, not the persona. The id is
 // the dashboard Tab value and is deep-linked, so it stays `assistant`.
 test('[AGFIX4] the assistant nav item reads "Command Center", keeping its id', () => {
   const item = findNavItem('assistant')
   assert.equal(item?.label, 'Command Center')
   assert.equal(item?.kind, 'tab')
-  assert.equal(allNavItems().filter(i => i.label === 'Arturita').length, 0, 'no nav item is labelled with the persona')
+  assert.equal(allSurfaces().filter(i => i.label === 'Arturita').length, 0, 'no nav item is labelled with the persona')
 })
 
 // Command Center is the operator's primary way in, so it sits directly under
@@ -52,12 +172,12 @@ test('[AGFIX5] Command Center carries the microphone icon', () => {
 })
 
 test('[P0-web] nav item ids are globally unique', () => {
-  const ids = allNavItems().map(i => i.id)
+  const ids = allSurfaces().map(i => i.id)
   assert.equal(new Set(ids).size, ids.length)
 })
 
 test('[P0-web] every item carries an icon, label, and Paperclip mapping', () => {
-  for (const i of allNavItems()) {
+  for (const i of allSurfaces()) {
     assert.ok(i.icon, `${i.id} needs an icon`)
     assert.ok(i.label, `${i.id} needs a label`)
     assert.ok(i.paperclip, `${i.id} needs a paperclip mapping`)
@@ -65,8 +185,9 @@ test('[P0-web] every item carries an icon, label, and Paperclip mapping', () => 
 })
 
 test('[P0-web] placeholders are flagged and explain themselves (no faked features)', () => {
-  const placeholders = allNavItems().filter(i => i.kind === 'placeholder')
-  // The genuinely-missing Paperclip areas, per the mapping doc.
+  const placeholders = allSurfaces().filter(i => i.kind === 'placeholder')
+  // The genuinely-missing Paperclip areas, per the mapping doc. (Adapters is now
+  // a Settings tab, and Search/Pipelines/Artifacts are off-rail — still honest.)
   assert.deepEqual(
     placeholders.map(i => i.id).sort(),
     ['adapters', 'artifacts', 'members', 'pipelines', 'review-queue', 'routines', 'search'].sort(),
@@ -83,17 +204,18 @@ test('[P0-web] placeholders are flagged and explain themselves (no faked feature
 test('[P0b-web] promoted Cockpit sections are first-class areas with valid keys', () => {
   // Keys CockpitPanel knows how to render focused (CockpitSectionKey union).
   const COCKPIT_KEYS = new Set(['inbox', 'voice', 'agents', 'activity', 'org', 'goals', 'budgets', 'secrets', 'workspaces', 'plugins', 'tasks'])
-  const sections = allNavItems().filter(i => i.kind === 'section')
-  // The 8 Cockpit sections we promote out of the Operations stack.
+  const sections = allSurfaces().filter(i => i.kind === 'section')
+  // The 8 Cockpit sections we promoted out of the Operations stack — same eight
+  // after P1; some are rail items, some tabs, some off-rail.
   assert.deepEqual(
     sections.map(i => i.id).sort(),
     ['activity', 'budgets', 'goals', 'inbox', 'org', 'plugins', 'secrets', 'workspaces'].sort(),
   )
-  for (const sroot of sections) {
-    assert.equal(isSection(sroot.id), true)
-    assert.ok(sroot.section, `${sroot.id} needs a section key`)
-    assert.equal(navSectionKey(sroot.id), sroot.section)
-    assert.ok(COCKPIT_KEYS.has(sroot.section!), `${sroot.id} → ${sroot.section} must be a CockpitPanel key`)
+  for (const sec of sections) {
+    assert.equal(isSection(sec.id), true)
+    assert.ok(sec.section, `${sec.id} needs a section key`)
+    assert.equal(navSectionKey(sec.id), sec.section)
+    assert.ok(COCKPIT_KEYS.has(sec.section!), `${sec.id} → ${sec.section} must be a CockpitPanel key`)
   }
   // A tab is never a section, and navSectionKey is undefined for non-sections.
   assert.equal(isSection('governance'), false)

--- a/web/lib/navModel.ts
+++ b/web/lib/navModel.ts
@@ -5,6 +5,18 @@
 //   Overview · Workspace · Operate · Delivery · Company · General
 // with our existing surfaces re-homed under it. See docs/IA-paperclip-mapping.md.
 //
+// P1 — the rail is deliberately short. Two mechanisms keep it that way without
+// losing a surface:
+//   * hosted tabs (`tabs`)  — a child surface renders as a tab on its parent's
+//     page (Budgets under Costs, Plugins under Connectors, Comms under Inbox,
+//     Adapters + Secrets under Settings). One rail entry, two-plus surfaces.
+//   * HIDDEN_ITEMS        — surfaces dropped from the rail but still routable:
+//     the command palette lists them and the dashboard still renders them, so
+//     nothing is deleted and no deep link dies.
+// Every surface in the app is therefore in exactly one of NAV_GROUPS (rail),
+// a parent's `tabs`, or HIDDEN_ITEMS — `allSurfaces()` is the union, and the
+// tests assert that union still covers every dashboard tab.
+//
 // Kept pure so the structure + collapse/fold logic is unit-testable under
 // `node --test` (web has no jest/vitest). The dashboard page renders from this.
 
@@ -29,12 +41,28 @@ export interface NavItem {
   note?: string
   /** Beyond-Paperclip surface kept + re-homed (Arturita/Memory/Comms). */
   beyond?: boolean
+  /**
+   * P1 — surfaces this page hosts as tabs, after its own. The parent stays the
+   * single rail entry; `navPageTabs(parent.id)` builds the page's tab bar.
+   */
+  tabs?: NavItem[]
+  /**
+   * P1 — the parent's own tab label when it differs from the rail label
+   * (Inbox / Comms in the rail; the first tab just reads "Inbox").
+   */
+  tabLabel?: string
 }
 
 export interface NavGroup {
   id: NavGroupId
   label: string
   items: NavItem[]
+}
+
+/** One entry in a tabbed page's tab bar. */
+export interface PageTab {
+  id: string
+  label: string
 }
 
 // Epic-P gap plan the placeholders point at.
@@ -53,22 +81,24 @@ export const NAV_GROUPS: NavGroup[] = [
       // It sits directly under Dashboard: it is the operator's primary way in.
       { id: 'assistant', label: 'Command Center', icon: '🎙️', kind: 'tab', paperclip: 'Board Chat', beyond: true },
       { id: 'cockpit', label: 'Operations', icon: '🛰️', kind: 'tab', paperclip: 'Dashboard / live' },
-      { id: 'inbox', label: 'Inbox', icon: '📥', kind: 'section', section: 'inbox', paperclip: 'Inbox' },
+      // P1 — Comms folds in here: one "Inbox / Comms" rail entry, tabs Inbox | Comms.
+      {
+        id: 'inbox', label: 'Inbox / Comms', tabLabel: 'Inbox', icon: '📥', kind: 'section', section: 'inbox', paperclip: 'Inbox',
+        tabs: [
+          { id: 'comms', label: 'Comms', icon: '📬', kind: 'tab', paperclip: 'Communications', beyond: true },
+        ],
+      },
       { id: 'activity', label: 'Activity', icon: '📈', kind: 'section', section: 'activity', paperclip: 'Activity' },
-      { id: 'search', label: 'Search', icon: '🔍', kind: 'placeholder', paperclip: 'Search', note: 'Global search page. Today: press ⌘K for the command palette. A dedicated search surface is an Epic-P gap.' },
     ],
   },
   {
     id: 'workspace',
     label: 'Workspace',
     items: [
-      { id: 'tasks', label: 'Issues', icon: '📋', kind: 'tab', paperclip: 'Issues / Tasks' },
       { id: 'agents', label: 'Agents', icon: '🤖', kind: 'tab', paperclip: 'Agents' },
       { id: 'projects', label: 'Projects', icon: '📁', kind: 'tab', paperclip: 'Projects' },
-      { id: 'goals', label: 'Goals', icon: '🎯', kind: 'section', section: 'goals', paperclip: 'Goals' },
       { id: 'org', label: 'Org', icon: '🗂️', kind: 'section', section: 'org', paperclip: 'Org' },
       { id: 'routines', label: 'Routines', icon: '🔁', kind: 'placeholder', paperclip: 'Routines', note: 'Recurring scheduled tasks. Backend exists (routines.ts / scheduled_tasks); a dedicated web surface is an Epic-P gap.' },
-      { id: 'pipelines', label: 'Pipelines', icon: '🧩', kind: 'placeholder', paperclip: 'Pipelines', note: 'Multi-stage case pipelines. Not yet built (no pipeline/case entity) — Epic-P gap.' },
     ],
   },
   {
@@ -76,7 +106,6 @@ export const NAV_GROUPS: NavGroup[] = [
     label: 'Operate',
     items: [
       { id: 'governance', label: 'Governance', icon: '🛡️', kind: 'tab', paperclip: 'Approvals · Review Queue · RBAC' },
-      { id: 'workspaces', label: 'Workspaces', icon: '🧱', kind: 'section', section: 'workspaces', paperclip: 'Workspaces' },
       { id: 'review-queue', label: 'Review Queue', icon: '🧪', kind: 'placeholder', paperclip: 'Review Queue', note: 'Low-trust quarantine review lives inside Governance today; a dedicated queue page is an Epic-P gap.' },
     ],
   },
@@ -84,22 +113,28 @@ export const NAV_GROUPS: NavGroup[] = [
     id: 'delivery',
     label: 'Delivery',
     items: [
-      { id: 'costs', label: 'Costs', icon: '💰', kind: 'tab', paperclip: 'Costs · Budgets · Preflight' },
-      { id: 'budgets', label: 'Budgets', icon: '💵', kind: 'section', section: 'budgets', paperclip: 'Budgets / Preflight' },
+      // P1 — Budgets folds in here: tabs Costs | Budgets.
+      {
+        id: 'costs', label: 'Costs', icon: '💰', kind: 'tab', paperclip: 'Costs · Budgets · Preflight',
+        tabs: [
+          { id: 'budgets', label: 'Budgets', icon: '💵', kind: 'section', section: 'budgets', paperclip: 'Budgets / Preflight' },
+        ],
+      },
       { id: 'skills', label: 'Skills', icon: '⚡', kind: 'tab', paperclip: 'Skills' },
       { id: 'memory', label: 'Memory', icon: '🧠', kind: 'tab', paperclip: 'Learnings', beyond: true },
-      { id: 'artifacts', label: 'Artifacts', icon: '📦', kind: 'placeholder', paperclip: 'Artifacts', note: 'Work-product / artifact stacks. Not yet built — Epic-P gap.' },
     ],
   },
   {
     id: 'company',
     label: 'Company',
     items: [
-      { id: 'connectors', label: 'Connectors', icon: '🔌', kind: 'tab', paperclip: 'Plugins / Connectors' },
-      { id: 'plugins', label: 'Plugins', icon: '🧰', kind: 'section', section: 'plugins', paperclip: 'Plugins' },
-      { id: 'secrets', label: 'Secrets', icon: '🔐', kind: 'section', section: 'secrets', paperclip: 'Secrets' },
-      { id: 'comms', label: 'Comms', icon: '📬', kind: 'tab', paperclip: 'Communications', beyond: true },
-      { id: 'adapters', label: 'Adapters', icon: '🧷', kind: 'placeholder', paperclip: 'Adapter registry', note: 'BYO-runtime adapter registry + model catalogs + probes. Not yet built — Epic-P gap.' },
+      // P1 — Plugins folds in here: tabs Connectors | Plugins.
+      {
+        id: 'connectors', label: 'Connectors', icon: '🔌', kind: 'tab', paperclip: 'Plugins / Connectors',
+        tabs: [
+          { id: 'plugins', label: 'Plugins', icon: '🧰', kind: 'section', section: 'plugins', paperclip: 'Plugins' },
+        ],
+      },
       { id: 'members', label: 'Members & Access', icon: '👥', kind: 'placeholder', paperclip: 'Members / Access', note: 'Per-resource RBAC grants ledger. We have org-level roles (org_members); the fine-grained ledger is an Epic-P gap.' },
     ],
   },
@@ -108,24 +143,93 @@ export const NAV_GROUPS: NavGroup[] = [
     label: 'General',
     items: [
       { id: 'usage', label: 'Usage', icon: '📊', kind: 'tab', paperclip: 'Usage' },
-      { id: 'settings', label: 'Settings', icon: '⚙️', kind: 'tab', paperclip: 'Settings (Company / Instance)' },
+      // P1 — Adapters + Secrets fold in here: tabs Settings | Adapters | Secrets.
+      {
+        id: 'settings', label: 'Settings', icon: '⚙️', kind: 'tab', paperclip: 'Settings (Company / Instance)',
+        tabs: [
+          { id: 'adapters', label: 'Adapters', icon: '🧷', kind: 'placeholder', paperclip: 'Adapter registry', note: 'BYO-runtime adapter registry + model catalogs + probes. Not yet built — Epic-P gap.' },
+          { id: 'secrets', label: 'Secrets', icon: '🔐', kind: 'section', section: 'secrets', paperclip: 'Secrets' },
+        ],
+      },
     ],
   },
 ]
 
-/** Flat list of every nav item, in render order. */
+/**
+ * P1 — surfaces removed from the rail but NOT from the app. They stay routable:
+ * the command palette lists them, the dashboard still renders them, and any
+ * deep link to their id keeps working. Nothing here is deleted; the rail is
+ * simply not where they live any more.
+ */
+export const HIDDEN_ITEMS: NavItem[] = [
+  { id: 'search', label: 'Search', icon: '🔍', kind: 'placeholder', paperclip: 'Search', note: 'Global search page. Today: press ⌘K for the command palette. A dedicated search surface is an Epic-P gap.' },
+  { id: 'tasks', label: 'Issues', icon: '📋', kind: 'tab', paperclip: 'Issues / Tasks' },
+  { id: 'goals', label: 'Goals', icon: '🎯', kind: 'section', section: 'goals', paperclip: 'Goals' },
+  { id: 'pipelines', label: 'Pipelines', icon: '🧩', kind: 'placeholder', paperclip: 'Pipelines', note: 'Multi-stage case pipelines. Not yet built (no pipeline/case entity) — Epic-P gap.' },
+  { id: 'workspaces', label: 'Workspaces', icon: '🧱', kind: 'section', section: 'workspaces', paperclip: 'Workspaces' },
+  { id: 'artifacts', label: 'Artifacts', icon: '📦', kind: 'placeholder', paperclip: 'Artifacts', note: 'Work-product / artifact stacks. Not yet built — Epic-P gap.' },
+]
+
+/** The rail's own items, in render order (top-level only — hosted tabs excluded). */
 export function allNavItems(): NavItem[] {
   return NAV_GROUPS.flatMap(g => g.items)
 }
 
-/** The tab ids the nav can route to (every `kind:'tab'` item). */
-export function navTabIds(): string[] {
-  return allNavItems().filter(i => i.kind === 'tab').map(i => i.id)
+/** Surfaces hosted as tabs on some parent page (Budgets, Plugins, Comms, …). */
+export function hostedTabItems(): NavItem[] {
+  return allNavItems().flatMap(i => i.tabs ?? [])
 }
 
-/** Look up an item by id (undefined if unknown). */
+/**
+ * Every routable surface: rail items + the tabs they host + the hidden ones.
+ * This is the "nothing is lost" set — the palette and the router use it.
+ */
+export function allSurfaces(): NavItem[] {
+  return [...allNavItems(), ...hostedTabItems(), ...HIDDEN_ITEMS]
+}
+
+/** The tab ids anything can route to (every `kind:'tab'` surface). */
+export function navTabIds(): string[] {
+  return allSurfaces().filter(i => i.kind === 'tab').map(i => i.id)
+}
+
+/** Look up any routable surface by id (undefined if unknown). */
 export function findNavItem(id: string): NavItem | undefined {
-  return allNavItems().find(i => i.id === id)
+  return allSurfaces().find(i => i.id === id)
+}
+
+/** True when this surface is reachable but no longer in the rail (P1 removals). */
+export function isHidden(id: string): boolean {
+  return HIDDEN_ITEMS.some(i => i.id === id)
+}
+
+/**
+ * The tab bar for a page that hosts tabs: the page itself first, then its
+ * children. Empty for a page with no hosted tabs (most of them).
+ */
+export function navPageTabs(id: string): PageTab[] {
+  const parent = allNavItems().find(i => i.id === id)
+  if (!parent?.tabs?.length) return []
+  return [
+    { id: parent.id, label: parent.tabLabel ?? parent.label },
+    ...parent.tabs.map(t => ({ id: t.id, label: t.label })),
+  ]
+}
+
+/** The rail item hosting this surface as a tab (undefined if it isn't hosted). */
+export function navParentId(id: string): string | undefined {
+  return allNavItems().find(i => i.tabs?.some(t => t.id === id))?.id
+}
+
+/** Which rail item should read as active while `id` is open. */
+export function navSelectedId(id: string): string {
+  return navParentId(id) ?? id
+}
+
+/** The heading a surface shows on its own page (tab label wins over rail label). */
+export function navSurfaceTitle(id: string): string | undefined {
+  const item = findNavItem(id)
+  return item ? (item.tabLabel ?? item.label) : undefined
 }
 
 /** True when selecting this id should show the "coming soon" placeholder view. */


### PR DESCRIPTION
## What

P0b promoted every Cockpit section to a first-class nav area — correct, but it left the sidebar **long**. P1 shortens it. The rule throughout: **remove from the rail, never from the app.** Everything stays driven by `web/lib/navModel.ts` (the single IA source) + `Sidebar.tsx`.

### Removed from the sidebar (6) — still routable
`Search` · `Issues` · `Goals` · `Pipelines` · `Workspaces` · `Artifacts` → a new `HIDDEN_ITEMS` list.
Search/Pipelines/Artifacts were "coming soon" placeholders. **Issues/Goals/Workspaces are real surfaces and their components, routes and data are untouched** — they just aren't in the rail. All six still resolve via `findNavItem`, still render, and still show up in the ⌘K palette (which now walks `allSurfaces()` instead of the rail).

### Folded into a parent page's tabs (5)
New `PageTabs.tsx`, driven by `navPageTabs()`:

| Rail item | Tabs |
|---|---|
| Costs | `Costs` \| `Budgets` |
| Connectors | `Connectors` \| `Plugins` |
| **Inbox / Comms** (renamed) | `Inbox` \| `Comms` |
| Settings | `Settings` \| `Adapters` \| `Secrets` |

Opening a hosted tab keeps its **parent** lit in the rail (`navSelectedId`), so the rail never loses the user inside a tabbed page. No panel was rebuilt — each tab renders exactly the component it always did (a promoted Cockpit section, a dashboard tab, or the honest Adapters placeholder).

## Final sidebar

- **Overview** — Dashboard · 🎙️ Command Center · Operations · Inbox / Comms · Activity
- **Workspace** — Agents · Projects · Org · Routines *(soon)*
- **Operate** — Governance · Review Queue *(soon)*
- **Delivery** — Costs · Skills · Memory
- **Company** — Connectors · Members & Access *(soon)*
- **General** — Usage · Settings

## Tests

`navModel` now partitions every surface into exactly one of **rail · hosted tab · off-rail**. The tests assert that partition, plus each removal, each fold target, the full rail order, the Inbox label/tab split, and the carried-over **"every prior surface still reachable (nothing lost)"** invariant — which now spans all three homes. Nav tests 10 → **17**.

## Verify

- `web`: build ✅ · **161 tests, 0 fail** (+9)
- `backend`: **1073 tests, 0 fail** (untouched — web-only change)
- Adapters not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)