### PR TITLE
fix(ONB): exclude recurring agent-runtime writes from the audit trail (audit M-A)

### DIFF
--- a/GO-LIVE.md
+++ b/GO-LIVE.md
@@ -241,14 +241,33 @@ guard so `NODE_ENV=production` refuses to start on the default key.
 >   cap on row count — the age window is the bound.
 > - **Scope:** edit `shouldAudit(method, path)` in `middleware/audit-log.ts`
 >   (`SENSITIVE_METHODS` + `AUDITED_PATH_SEGMENTS`). It is a pure, tested helper.
+> - **Recurring-agent-write exclusions (audit M-A):** `isHighFrequencyAgentWrite()`
+>   in `middleware/audit-log.ts` is a denylist of high-frequency recurring
+>   agent-runtime writes that `shouldAudit` skips even though they are mutating
+>   methods — **`POST /api/agent/heartbeat`**, **`POST /api/agent/runs/:id/log`**,
+>   **`POST /api/agent/messages`**. These are liveness/telemetry chatter posted on
+>   the adapter poll loop or streamed continuously during a run; each was otherwise
+>   one Turso INSERT at `active agents × poll cadence`, so heartbeat/run-log traffic
+>   could dominate the onboarding events the trail was framed around. Excluding them
+>   bounds the **daily insert rate away from the heartbeat cadence** — the write
+>   volume is now driven by real actions, not liveness pings. To tune: add a path to
+>   that denylist (skip more) or remove one (audit it again); it is a pure, tested
+>   helper (`[AUDIT-MA]` tests in `audit-onb-enable.test.ts`). **Kept audited on
+>   purpose** (meaningful and not per-poll): task result-posting + claim, approvals,
+>   `run-token` minting, memory writes, plugin-job claim/result, workspace runtime,
+>   and all org-scoped writes (agent create/config, credentials/secrets, wallet, RBAC).
+>   When unsure whether an endpoint is security-relevant, KEEP it — be conservative.
 > - **Turn it off again:** revert the hoist in `src/index.ts` (the `auditLogPlugin(app)`
 >   call at the top of `start()`) back to an encapsulated `app.register(auditLogPlugin)`
 >   — the `[ONB2-H1]` tripwire in `audit-onb2-fix.test.ts` guards the wiring either way.
 >
 > **Cost, stated honestly:** one fire-and-forget Turso `INSERT` per SENSITIVE request
-> (writes + the low-volume onboarding surfaces). The insert is `.catch()`-swallowed, so
-> it can never add latency to or fail the request it records. The `GET` dashboard-poll
-> flood — the expensive, low-value half — is skipped by construction.
+> (writes + the low-volume onboarding surfaces), **minus the recurring agent-runtime
+> writes** (heartbeat / run-log / messages, audit M-A) which are excluded so the daily
+> insert rate is bounded away from the heartbeat cadence. The insert is
+> `.catch()`-swallowed, so it can never add latency to or fail the request it records.
+> The `GET` dashboard-poll flood — the expensive, low-value half — is skipped by
+> construction.
 
 **The original problem (now fixed): `audit_logs` recorded nothing.**
 `auditLogPlugin` and `telemetryPlugin` added their `onResponse` hooks inside an

--- a/backend/src/middleware/audit-log.ts
+++ b/backend/src/middleware/audit-log.ts
@@ -104,19 +104,50 @@ const SENSITIVE_METHODS = ['POST', 'DELETE', 'PATCH', 'PUT']
 const AUDITED_PATH_SEGMENTS = ['/agent-invites', '/agent-join-requests', '/approvals']
 
 /**
+ * High-frequency recurring agent-runtime writes EXCLUDED from the trail (audit
+ * finding M-A). Without this, "sensitive writes" swept in the entire agent-API
+ * write chatter: each is one fire-and-forget Turso INSERT, and the *rate* is set by
+ * `active agents × poll cadence`, not by any security event — the heartbeat alone
+ * fires once per adapter poll loop, per agent, even when nothing is happening. These
+ * three carry no onboarding / RBAC / wallet / secret / config action to record, so
+ * dropping them bounds the daily insert rate away from the heartbeat cadence without
+ * losing a single meaningful audit event.
+ *
+ *   POST /api/agent/heartbeat        — liveness ping, once per poll loop per agent
+ *   POST /api/agent/runs/:id/log     — run-progress stream (log line + running cost/tokens)
+ *   POST /api/agent/messages         — free-form runtime progress/chatter
+ *
+ * Deliberately NOT excluded — meaningful and NOT per-poll, so kept audited:
+ *   task result-posting, task claim, approvals, run-token minting, memory writes,
+ *   plugin-job claim/result, workspace runtime. When unsure, KEEP auditing (be
+ *   conservative — the goal is to cut the flood, not to stop recording actions).
+ *
+ * Matched against the REDACTED path (query already dropped). `redactPath` only
+ * rewrites minted token segments (`mci_inv_`/`mca_`/…), NOT the run `:id` UUID, so
+ * the run-log arm matches by prefix+suffix rather than an exact string. See GO-LIVE §7.
+ */
+export function isHighFrequencyAgentWrite(path: string): boolean {
+  if (path === '/api/agent/heartbeat' || path === '/api/agent/messages') return true
+  if (path.startsWith('/api/agent/runs/') && path.endsWith('/log')) return true
+  return false
+}
+
+/**
  * The should-this-request-be-audited filter (audit H-1, enablement scope).
  *
  * The operator enabled the trail for the SENSITIVE half only — every mutating
  * method anywhere, plus any method on the onboarding/invite/join/approval surfaces —
  * and deliberately SKIPS the read-only `GET` flood (org/agent/task dashboard polls),
- * which is the expensive, low-value half of "one Turso INSERT per request".
+ * which is the expensive, low-value half of "one Turso INSERT per request". The
+ * recurring agent-runtime write chatter is skipped too (audit M-A, see above).
  *
  * Pure: (method, redacted-path) → boolean. Tested in `audit-onb-enable.test.ts`.
- * Health/readiness probes are never audited.
+ * Health/readiness probes and the recurring agent-runtime writes are never audited.
  */
 export function shouldAudit(method: string, path: string): boolean {
   const p = String(path).split('?')[0]
   if (p === '/health' || p === '/ready' || p === '/api/health') return false
+  if (isHighFrequencyAgentWrite(p)) return false
   if (SENSITIVE_METHODS.includes(String(method).toUpperCase())) return true
   return AUDITED_PATH_SEGMENTS.some(seg => p.includes(seg))
 }

--- a/backend/src/tests/audit-onb-enable.test.ts
+++ b/backend/src/tests/audit-onb-enable.test.ts
@@ -18,7 +18,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import Fastify from 'fastify'
 
-import { auditLogPlugin, auditLogQueryRoutes, shouldAudit, type AuditRow } from '../middleware/audit-log'
+import { auditLogPlugin, auditLogQueryRoutes, shouldAudit, isHighFrequencyAgentWrite, type AuditRow } from '../middleware/audit-log'
 import { telemetryQueryRoutes } from '../services/telemetry'
 import { createClerkAuth } from '../middleware/clerk-auth'
 import {
@@ -126,6 +126,52 @@ test('[ONB-H1] shouldAudit is a pure method/route filter', () => {
   assert.equal(shouldAudit('GET', '/health'), false)
   assert.equal(shouldAudit('GET', '/ready'), false)
   assert.equal(shouldAudit('GET', '/api/health'), false)
+})
+
+// ─── audit M-A — the recurring agent-runtime write flood is NOT audited ─────────
+
+test('[AUDIT-MA] recurring agent-runtime writes (heartbeat / run-log / messages) are NOT audited', () => {
+  // These are the per-poll / per-run-stream chatter that would otherwise be one Turso
+  // INSERT each at `active agents × poll cadence` — liveness/telemetry, no security event.
+  assert.equal(shouldAudit('POST', '/api/agent/heartbeat'), false, 'heartbeat is a per-poll liveness ping, not an audit event')
+  assert.equal(shouldAudit('POST', '/api/agent/messages'), false, 'free-form runtime chatter is not an audit event')
+  // redactPath leaves the run :id UUID verbatim, so run-log arrives with a real UUID.
+  assert.equal(shouldAudit('POST', '/api/agent/runs/550e8400-e29b-41d4-a716-446655440000/log'), false,
+    'the run-progress stream is not an audit event')
+  // The predicate is method-agnostic and tightly scoped by prefix+suffix.
+  assert.equal(isHighFrequencyAgentWrite('/api/agent/heartbeat'), true)
+  assert.equal(isHighFrequencyAgentWrite('/api/agent/messages'), true)
+  assert.equal(isHighFrequencyAgentWrite('/api/agent/runs/any-uuid-here/log'), true)
+  assert.equal(isHighFrequencyAgentWrite('/api/agent/runs/'), false, 'the runs collection is not a run-log')
+})
+
+test('[AUDIT-MA] the security-relevant agent + org writes are STILL audited', () => {
+  // Everything the trail was framed around stays in. Result-posting is per-task
+  // (terminal, not per-poll) and meaningful, so it is KEPT despite the "result" name.
+  const stillAudited: Array<[string, string]> = [
+    ['POST', '/api/agent/tasks/t1/result'],          // task result-posting — meaningful, low-frequency
+    ['POST', '/api/agent/tasks/t1/claim'],           // claiming work
+    ['POST', '/api/agent/approvals'],                // human sign-off request (machine_exec / wallet_tx / …)
+    ['POST', '/api/agent/run-token'],                // mints an HMAC credential
+    ['PUT',  '/api/agent/memory/file'],              // vault write
+    ['POST', '/api/agent/plugin-jobs/j1/claim'],     // plugin-job state transition
+    ['POST', '/api/agent/plugin-jobs/j1/result'],
+    ['POST', '/api/agent/workspaces/w1/runtime'],
+    ['POST', '/api/orgs/o1/credentials'],            // secrets
+    ['POST', '/api/orgs/o1/agents'],                 // agent create
+    ['DELETE', '/api/orgs/o1/agents/a1'],            // agent delete
+    ['POST', '/api/agent-invites'],                  // onboarding / invite
+    ['POST', '/api/agent-invites/:token/join'],      // join (redacted token)
+    ['POST', '/api/orgs/o1/wallet/tx'],              // wallet
+    ['PATCH', '/api/orgs/o1'],                       // org config / RBAC changes
+  ]
+  for (const [m, p] of stillAudited) {
+    assert.equal(shouldAudit(m, p), true, `${m} ${p} must still be audited (security-relevant write)`)
+  }
+  // A generic mutating write on an unmodelled path is still audited (default-on for writes).
+  assert.equal(shouldAudit('POST', '/api/orgs/o1/something-new'), true, 'a generic mutating write stays audited')
+  // The onboarding GET surfaces still audited; the run-log arm did not over-match audit-log reads.
+  assert.equal(shouldAudit('GET', '/api/orgs/o1/audit-log'), false, 'a plain org read is still not audited (and not a /log match)')
 })
 
 // ─── 4 — enabling WRITES did not open the READ routes ─────────────────────────


### PR DESCRIPTION
## What

Small cost fix on the now-live audit trail, per `docs/AUDIT-audit-trail.md` finding **M-A**. The `shouldAudit` filter recorded **every** mutating method API-wide, sweeping in the high-frequency recurring agent-runtime chatter — one Turso `INSERT` per `POST /api/agent/heartbeat` (fired once per adapter poll loop, per active agent), plus per run-log stream append and per free-form runtime message. The daily insert *rate* was set by `active agents × poll cadence`, not by any security event.

## Change

Adds `isHighFrequencyAgentWrite()` — a pure, tested denylist that `shouldAudit` skips **even for mutating methods**:

| Excluded (recurring, low-security) | Why safe to exclude |
|---|---|
| `POST /api/agent/heartbeat` | Liveness ping, once per poll loop per agent. Pure telemetry. |
| `POST /api/agent/runs/:id/log` | Run-progress stream (log line + running cost/tokens). Matched by prefix+suffix because `redactPath` leaves the `:id` UUID verbatim. |
| `POST /api/agent/messages` | Free-form runtime progress/chatter. |

**Conservatively KEPT audited** (meaningful, not per-poll): task result-posting + claim, `approvals`, `run-token` minting, memory writes, plugin-job claim/result, workspace runtime, and every org-scoped write (agent create/config, credentials/secrets, wallet, RBAC). When unsure whether an endpoint is security-relevant, it stays audited — the goal is to cut the flood, not to stop recording actions.

## Tests

`[AUDIT-MA]` cases in `audit-onb-enable.test.ts`:
- heartbeat / run-log / messages → **NOT** audited
- result-posting, claim, approvals, run-token, memory, plugin-jobs, workspace, credentials, agent create/delete, invite/join, wallet, org PATCH → **still** audited
- a generic unmodelled mutating write → **still** audited

`GO-LIVE.md` §7 documents the exclusion, how to tune it, and that the daily insert rate is now bounded away from the heartbeat cadence.

## Verify

- `npm test` → **1235 pass / 0 fail** (2 new cases)
- `npm run evals` → **11/11**
- `npm run typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)