### PR TITLE
fix(web): 7Ei honeycomb reads as solid black on the light reactor

### DIFF
--- a/web/app/dashboard/tokens.ts
+++ b/web/app/dashboard/tokens.ts
@@ -60,6 +60,11 @@ export const themes: Record<ThemeName, Record<string, string>> = {
     '--reactor-core-2': 'rgba(120,168,255,.55)',  // core mid
     '--reactor-core-3': 'rgba(76,120,224,.20)',    // core falloff
     '--reactor-glow': 'rgba(120,168,255,.28)',      // outer bloom behind the assembly
+    // The honeycomb mark sits ON the core, so it cannot share --reactor-core-1
+    // like it did: mark and backdrop were the same icy white-blue and the logo
+    // washed out. Solid black reads against the light core; dark keeps the
+    // luminous treatment (see the dark twin below).
+    '--reactor-logo-fill': '#000000',
   },
   dark: {
     '--s0': '#070707',
@@ -107,6 +112,9 @@ export const themes: Record<ThemeName, Record<string, string>> = {
     '--reactor-core-2': 'rgba(130,178,255,.62)',  // core mid
     '--reactor-core-3': 'rgba(86,132,240,.24)',    // core falloff
     '--reactor-glow': 'rgba(130,178,255,.34)',      // outer bloom
+    // Matches --reactor-core-1 — on the dark field the luminous mark is correct,
+    // so this is the pre-token look held as-is. Only light diverges.
+    '--reactor-logo-fill': 'rgba(232,242,255,.97)',
   },
 }
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -435,7 +435,7 @@ p  { margin: 0; color: var(--text); }
   position: relative;
   width: 64%;
   z-index: 2;
-  color: var(--reactor-core-1);
+  color: var(--reactor-logo-fill);
   filter: drop-shadow(0 0 7px var(--reactor-core-1)) drop-shadow(0 1px 2px rgba(0,0,0,.35));
 }
 .mc-reactor-hex svg { display: block; width: 100%; height: auto; }


### PR DESCRIPTION
## What

In the **light** theme the 7Ei honeycomb at the centre of the Command Center reactor rendered in a near-invisible pale blue. Operator confirmed with a screenshot.

## Root cause

The mark is inline SVG whose paths are `fill="currentColor"` (`Reactor.tsx:118`). That `currentColor` came from:

```css
.mc-reactor-hex { color: var(--reactor-core-1); }   /* globals.css:438 */
```

`--reactor-core-1` is *also* what paints the core's radial gradient (`globals.css:417`). On light it's `rgba(226,238,255,.95)` — "icy white-blue". So the logo and the disc directly behind it were the **same colour**, and the mark washed out. On dark the luminous look is correct, so only light is wrong.

## Change (9 lines, 2 files)

- `tokens.ts:64` / `tokens.ts:115` — new `--reactor-logo-fill` in **both** theme maps: `#000000` on light, and on dark the *existing* `rgba(232,242,255,.97)` verbatim.
- `globals.css:438` — `color: var(--reactor-core-1)` → `var(--reactor-logo-fill)`.

A separate token rather than retuning `--reactor-core-1`, which the core gradient, the swirl and the hex drop-shadow all still depend on. Raw hex stays confined to `tokens.ts`, per the file's own invariant, and it rides the existing `themeCss()` → `[data-theme]` mechanism — no new theming path.

The `drop-shadow(0 0 7px var(--reactor-core-1))` at `:439` is deliberately left alone: on light it becomes an icy halo *around* the black mark, which aids separation.

## Scope

Light-theme logo fill only. Dark is byte-identical; glassmorphism, silver ramp and all motion untouched. Nothing outside `web/`.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — **202/202** pass (incl. `reactor.logic.test.ts` 11/11)
- `npm run build` — passes
- Asserted on the emitted CSS: light `--reactor-logo-fill: #000000`, dark `rgba(232,242,255,.97)`; light logo no longer equals light `--reactor-core-1`, dark still equals dark `--reactor-core-1`.
- Rendered both themes side-by-side in a static harness using the real CSS + real hex paths: light is solid black and clearly legible, dark is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)