### PR TITLE
fix(MOB-6b): route the heartbeat through its own table — green was rendering as "never checked in"

### DIFF
--- a/apps/mobile/src/screens/AgentDetailScreen.tsx
+++ b/apps/mobile/src/screens/AgentDetailScreen.tsx
@@ -36,7 +36,7 @@ import {
   type AgentRecentTask,
 } from '../api'
 import { useAuth } from '../auth'
-import { statusIcon, statusTone } from '../status'
+import { heartbeatIcon, heartbeatTone, statusIcon, statusTone } from '../status'
 import { formatCost, formatTokens, NONE } from '../taskLog'
 import { font, radius, space, theme } from '../theme'
 import { Banner, Card, Chip, Empty, Loading } from '../ui'
@@ -130,10 +130,14 @@ export default function AgentDetailScreen({ agentId }: { agentId: string }) {
               tone={statusTone(agent.status)}
               glyph={statusIcon(agent.status)}
             />
+            {/* A heartbeat is its own vocabulary (green/amber/stale) — it has to
+                go through the heartbeat mapping, not the task-status table, or
+                `green` and `amber` collapse onto 'idle' and a healthy agent
+                looks exactly like one that never checked in. */}
             <Chip
               label={`heartbeat: ${agent.heartbeatStatus || 'unknown'}`}
-              tone={statusTone(agent.heartbeatStatus)}
-              glyph={statusIcon(agent.heartbeatStatus)}
+              tone={heartbeatTone(agent.heartbeatStatus)}
+              glyph={heartbeatIcon(agent.heartbeatStatus)}
             />
           </View>
         </Card>

--- a/apps/mobile/src/status.test.ts
+++ b/apps/mobile/src/status.test.ts
@@ -18,6 +18,7 @@
 // is pure (no React), which is what makes it loadable outside Metro at all.
 
 import assert from 'node:assert/strict'
+import { readFile, readdir } from 'node:fs/promises'
 import { test } from 'node:test'
 import {
   HEARTBEAT_STATUS as WEB_HEARTBEAT,
@@ -27,7 +28,9 @@ import {
 import {
   HEARTBEAT_STATUS,
   canonicalStatus,
+  heartbeatIcon,
   heartbeatStatus,
+  heartbeatTone,
   statusIcon,
   statusTone,
 } from './status.ts'
@@ -78,6 +81,66 @@ test('active is never green, and done never shares failed’s tone', () => {
   assert.equal(statusTone('active'), 'delegate')
   assert.equal(statusTone('running'), 'delegate')
   assert.notEqual(statusTone('done'), statusTone('failed'))
+})
+
+// ─── The heartbeat is a SEPARATE vocabulary ─────────────────────────────────
+//
+// AUDIT (MOB-6b): heartbeatStatus() existed and was tested, but AgentDetailScreen
+// passed the RAW heartbeat into statusIcon/statusTone instead of calling it.
+// `green` and `amber` are in neither ICON nor ALIAS, so both fell through to
+// 'idle' — a healthy agent got the same ○/neutral chip as one that had never
+// checked in, and amber lost its warning entirely. The unit under test was
+// correct; the call site simply didn't use it. These tests pin the wrappers the
+// screen now calls, so the glyph a heartbeat renders with is covered, not just
+// the row it maps to.
+
+test('a healthy heartbeat never renders as an absent one', () => {
+  // The defect verbatim: green must not look like unknown.
+  assert.notEqual(heartbeatIcon('green'), heartbeatIcon('unknown'))
+  assert.notEqual(heartbeatTone('green'), heartbeatTone('unknown'))
+  // ...and it must not look like a dead one either.
+  assert.notEqual(heartbeatIcon('green'), heartbeatIcon('stale'))
+})
+
+test('each heartbeat carries its own row’s glyph and tone', () => {
+  for (const h of ['green', 'amber', 'stale', 'unknown']) {
+    assert.equal(heartbeatIcon(h), statusIcon(heartbeatStatus(h)), `heartbeat glyph drift on "${h}"`)
+    assert.equal(heartbeatTone(h), statusTone(heartbeatStatus(h)), `heartbeat tone drift on "${h}"`)
+  }
+  // amber is a warning and must read as one — this is what collapsing to 'idle' ate.
+  assert.equal(heartbeatTone('amber'), 'warn')
+  assert.equal(heartbeatIcon('amber'), '⏸')
+})
+
+test('an absent or unrecognised heartbeat is idle, never a crash', () => {
+  for (const h of [null, undefined, '', 'bogus']) {
+    assert.equal(heartbeatIcon(h), '○')
+    assert.equal(heartbeatTone(h), 'neutral')
+  }
+})
+
+// The tests above pin the WRAPPERS — but the bug they describe was never in a
+// wrapper. heartbeatStatus() was already correct and already tested; the screen
+// just didn't call it. Testing the helper harder would not have caught it. The
+// screens import react-native and can't load under `node --test` (the same
+// constraint navModel.test.ts works around with a hand-kept list), so the call
+// site gets a source-level guard instead: the raw heartbeat field must never be
+// handed to the task-status table. This is the assertion that actually fails if
+// someone writes the original defect back.
+test('no screen glyphs a raw heartbeat with the task-status table', async () => {
+  const dir = new URL('./screens/', import.meta.url)
+  for (const file of await readdir(dir)) {
+    if (!file.endsWith('.tsx')) continue
+    const src = await readFile(new URL(file, dir), 'utf8')
+    const offenders = src.match(/status(?:Icon|Tone)\s*\(\s*[A-Za-z_$][\w.$]*\.heartbeatStatus\b/g)
+    assert.equal(
+      offenders,
+      null,
+      `${file}: passes a raw heartbeat to ${offenders?.[0]}(…). ` +
+        'green/amber are not in the status table and collapse onto idle — ' +
+        'use heartbeatIcon()/heartbeatTone(), which route through HEARTBEAT_STATUS.',
+    )
+  }
 })
 
 test('every canonical row has a tone and a glyph', () => {

--- a/apps/mobile/src/status.ts
+++ b/apps/mobile/src/status.ts
@@ -83,3 +83,22 @@ export const HEARTBEAT_STATUS: Record<string, CanonicalStatus> = {
 export function heartbeatStatus(h: string | undefined | null): CanonicalStatus {
   return HEARTBEAT_STATUS[(h ?? '').toLowerCase()] ?? 'idle'
 }
+
+// A heartbeat is a SEPARATE vocabulary (green/amber/stale) from a task or run
+// status, and only HEARTBEAT_STATUS bridges the two. Passing a raw heartbeat to
+// statusIcon/statusTone silently collapses `green` and `amber` onto 'idle' —
+// neither word is in ICON or ALIAS — so a healthy agent renders with the same
+// ○/neutral chip as one that has never checked in, and amber loses its warning.
+// (`stale` only survives that path by coincidence: it happens to be an ALIAS
+// key.) These two wrappers are the only correct way to glyph a heartbeat; call
+// them instead of reaching for statusIcon/statusTone directly.
+
+/** The glyph for a heartbeat — always via the heartbeat mapping. */
+export function heartbeatIcon(h: string | undefined | null): string {
+  return ICON[heartbeatStatus(h)]
+}
+
+/** The chip tone for a heartbeat — always via the heartbeat mapping. */
+export function heartbeatTone(h: string | undefined | null): StatusTone {
+  return TONE[heartbeatStatus(h)]
+}


### PR DESCRIPTION
Audit finding on #289, fixed on top of that branch. **Do not merge before #289** — the base is `mob-6b-agent-detail-tasks`, not `main`.

## The defect

`AgentDetailScreen.tsx` rendered the heartbeat chip with:

```tsx
tone={statusTone(agent.heartbeatStatus)}
glyph={statusIcon(agent.heartbeatStatus)}
```

Those two resolve the **task/run** vocabulary. A heartbeat is a *different* vocabulary (`green`/`amber`/`stale`), and only `HEARTBEAT_STATUS` bridges them. `green` and `amber` are in neither `ICON` nor `ALIAS`, so `canonicalStatus()` fell through to its `'idle'` default:

| heartbeat | as rendered | correct |
|---|---|---|
| `green` | ○ / neutral | ⬡ / delegate |
| `amber` | ○ / neutral | ⏸ / warn |
| `stale` | ✕ / danger | ✕ / danger |
| `unknown` | ○ / neutral | ○ / neutral |

So a **healthy agent rendered identically to one that had never checked in**, and amber's warning disappeared. `stale` only looked right by coincidence — it happens to also be an ALIAS key for `failed`, which is exactly why this read as working.

This lands on the colorblind rule the module was written to serve: the glyph *is* the signal, so a heartbeat that glyphs wrong is the failure the vocabulary exists to prevent.

## Why the tests missed it

`status.ts` already exported `heartbeatStatus()` for precisely this, and `status.test.ts` already covered it. **The helper was correct and tested; the call site simply never called it.** Testing the helper harder would not have caught this — the gap was between the two.

## The fix

- `heartbeatIcon()` / `heartbeatTone()` — the only correct way to glyph a heartbeat, so the right call is the obvious one rather than a rule to remember.
- `AgentDetailScreen` points at them.
- Behaviour pinned: green ≠ unknown ≠ stale, amber is ⏸/warn, absent/junk is idle-not-a-crash.
- **A source-level guard** asserting no screen hands a raw heartbeat to the status table. The screens import react-native and can't load under `node --test` (the same constraint `navModel.test.ts` works around with a hand-kept list), so this is the assertion that actually fails if the defect is written back. Verified the honest way: reintroduced the original line, watched it go red, restored.

## Not fixed here (reported, not touched)

`AgentsScreen`'s roster still uses its own local `status === 'active' ? '●' : '○'` logic instead of `status.ts`, so a `running`/`failed` agent glyphs differently on the roster than on the detail screen now sitting one tap away. That code is **pre-existing (MOB-4)**, not introduced by #289, and the web's own roster does use the canonical table — so it's a real parity gap, but it's a separate story's call, not an audit fix.

## Verification

`apps/mobile`: **37/37** (was 33; +4), `typecheck` clean, `export` 3.54 MB Hermes. Additive — `apps/mobile/**` only, no dep change, SDK 54 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)