### PR TITLE
fix(MOB): make the phone's white screen readable — top-level ErrorBoundary + no boot hang

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -15,6 +15,7 @@ import React from 'react'
 import { StatusBar } from 'react-native'
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
 import { AuthProvider, useAuth } from './src/auth'
+import ErrorBoundary from './src/ErrorBoundary'
 import { PushProvider } from './src/notifications'
 import RootNavigator from './src/navigation'
 import { theme } from './src/theme'
@@ -56,12 +57,18 @@ function Gate({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  // ErrorBoundary is the OUTERMOST component on purpose: a throw inside
+  // SafeAreaProvider or AuthProvider (which mounts ClerkProvider) takes the whole
+  // tree down to a blank screen, and those providers are precisely the ones worth
+  // reporting on. Anything above the boundary is unreportable, so nothing is.
   return (
-    <SafeAreaProvider>
-      <AuthProvider>
-        <StatusBar barStyle="light-content" backgroundColor={theme.bg} />
-        <Shell />
-      </AuthProvider>
-    </SafeAreaProvider>
+    <ErrorBoundary>
+      <SafeAreaProvider>
+        <AuthProvider>
+          <StatusBar barStyle="light-content" backgroundColor={theme.bg} />
+          <Shell />
+        </AuthProvider>
+      </SafeAreaProvider>
+    </ErrorBoundary>
   )
 }

--- a/apps/mobile/src/ErrorBoundary.tsx
+++ b/apps/mobile/src/ErrorBoundary.tsx
@@ -1,0 +1,107 @@
+// Top-level error boundary — the difference between a diagnosis and a white screen.
+//
+// WHY THIS EXISTS: a React render error anywhere in the tree unmounts the WHOLE
+// tree. With no boundary, what the operator sees is a blank white screen — white
+// specifically because none of our own surfaces (all of which paint theme.bg,
+// #0B1220) ever mounted. The error itself is real and it IS printed to the Metro
+// terminal, but on the phone it is invisible, so a crash-on-mount is indis-
+// tinguishable from a hang, a bad bundle, or a dead backend. That ambiguity cost
+// a whole debugging session once; this class buys it back permanently.
+//
+// The fallback deliberately depends on NOTHING but react-native core + theme
+// constants:
+//   • not SafeAreaProvider — it sits ABOVE it in App.tsx, because a provider that
+//     throws is exactly the case we must still render for. Hence the hand-rolled
+//     top padding instead of insets.
+//   • not ui.tsx — fewer modules in the fallback path, fewer ways for the screen
+//     that reports the crash to itself crash.
+//
+// It catches RENDER-phase errors only. That is the failure mode that produces the
+// silent white screen; an async rejection already surfaces in the Metro terminal
+// and does not blank the UI.
+
+import React from 'react'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { font, radius, space, theme } from './theme'
+
+type Props = { children: React.ReactNode }
+type State = { error: Error | null; componentStack: string | null }
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null, componentStack: null }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: { componentStack?: string | null }) {
+    // The component stack names the component that threw, which a bare message
+    // ("undefined is not an object") almost never does. Keep both.
+    this.setState({ componentStack: info?.componentStack ?? null })
+    // Mirror to the Metro terminal so the operator can copy it from a real
+    // console rather than retyping it off a phone screen.
+    console.error('[7Ei] Fatal render error:', error, info?.componentStack ?? '')
+  }
+
+  render() {
+    const { error, componentStack } = this.state
+    if (!error) return this.props.children
+
+    return (
+      <View style={s.root}>
+        <ScrollView contentContainerStyle={s.wrap}>
+          <Text style={s.title}>Something crashed on mount</Text>
+          <Text style={s.sub}>
+            The app caught a render error instead of showing a blank screen. Send this to the
+            dev — it is the whole diagnosis.
+          </Text>
+
+          <Text style={s.h}>Error</Text>
+          <Text style={s.mono} selectable>
+            {String(error?.message || error)}
+          </Text>
+
+          {error?.stack ? (
+            <>
+              <Text style={s.h}>Stack</Text>
+              <Text style={s.mono} selectable>
+                {error.stack}
+              </Text>
+            </>
+          ) : null}
+
+          {componentStack ? (
+            <>
+              <Text style={s.h}>Component stack</Text>
+              <Text style={s.mono} selectable>
+                {componentStack}
+              </Text>
+            </>
+          ) : null}
+        </ScrollView>
+      </View>
+    )
+  }
+}
+
+const s = StyleSheet.create({
+  // paddingTop clears the notch by hand: SafeAreaProvider may be the thing that threw.
+  root: { flex: 1, backgroundColor: theme.bg, paddingTop: 64 },
+  wrap: { padding: space.lg, paddingBottom: space.xxl },
+  title: { color: theme.vermillion, fontSize: font.xl, fontWeight: '800' },
+  sub: { color: theme.textDim, fontSize: font.sm, marginTop: space.xs, lineHeight: 18 },
+  h: { color: theme.text, fontSize: font.base, fontWeight: '700', marginTop: space.xl },
+  mono: {
+    marginTop: space.sm,
+    color: theme.text,
+    fontSize: font.sm - 1,
+    // Platform-agnostic: 'monospace' resolves to Menlo on iOS, Roboto Mono on Android.
+    fontFamily: 'monospace',
+    backgroundColor: theme.s1,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: theme.s3,
+    padding: space.md,
+    lineHeight: 17,
+  },
+})

--- a/apps/mobile/src/auth.tsx
+++ b/apps/mobile/src/auth.tsx
@@ -90,10 +90,20 @@ function useSessionStore() {
   const [session, setSession] = useState<Session | null>(null)
 
   useEffect(() => {
-    loadSession().then((s) => {
-      setSession(s)
-      setReady(true)
-    })
+    // A Keychain read can reject (device locked, entitlement missing). Without the
+    // catch, `ready` stays false forever and the app hangs on "Loading…" — a hang
+    // is a worse failure than a signed-out app, because it offers no way forward.
+    // Treat an unreadable session as no session: the operator lands on Connect and
+    // can sign in again.
+    loadSession()
+      .catch((e) => {
+        console.warn('[7Ei] could not read the stored session; starting signed out:', e)
+        return null
+      })
+      .then((s) => {
+        setSession(s)
+        setReady(true)
+      })
   }, [])
 
   const persist = useCallback(async (next: Session | null) => {


### PR DESCRIPTION
## The symptom, and what it already tells us

Expo Go renders a **complete white screen**. White is itself the clue: every surface this app draws paints `theme.bg` (`#0B1220`), and the splash is `#0B1220` too. **White is not a state we render** — React mounted nothing. So the tree throws before first paint, and with no error boundary that throw is invisible on-device.

**This PR does not claim to have found that throw.** I could not reproduce it off-device (see below). It makes it impossible for the next one to hide, and closes the two real defects found while looking.

## Eliminated, with evidence (all reproducible off-device)

| Hypothesis | Verdict |
|---|---|
| Build / bundle broken | **No** — typecheck clean, 147/147 tests, `expo export --platform ios` bundles (3.63 MB), and Metro's **dev** bundle (the exact payload Expo Go fetches) serves **HTTP 200 / 8.1 MB**, no error |
| Malformed `pk_test_` key wedging clerk-js | **No** — decodes to `neutral-escargot-37.clerk.accounts.dev$`; valid Clerk format, trailing `$` present |
| Missing Clerk polyfill (crypto/URL/streams) | **No** — `react-native-url-polyfill` + base64 ship *inside* `@clerk/clerk-expo` |
| Missing Clerk peer deps | **No** — `@clerk/expo-passkeys`, `expo-apple-authentication` are `optional` in `peerDependenciesMeta` |
| clerk-js browser build on Hermes | **No** — `@clerk/clerk-js/headless` requires cleanly with **no `window`/`document`** |
| Duplicate React → invalid hook call | **No** — exactly one `react` (19.1.8) |
| Bad/`undefined` component in `SCREENS` | **No** — every entry type-checks as a real `React.ComponentType`; a bad import would fail `tsc` |
| Require cycle → `undefined` at runtime | **No** — nothing imports `navigation.tsx` except `App.tsx` |
| Module-scope throw in MOB-6* screens | **No** — no `Intl`/`Date`/locale at module scope |

`config.ts`'s own comment predicted that a malformed key would *"wedge the whole app on a blank screen."* That is **not** what is happening here — the key is good.

## The changes

**1. `src/ErrorBoundary.tsx` (new)** — renders the error message, stack, and component stack on screen (selectable, scrollable) instead of white, and mirrors them to the Metro terminal.

It is the **outermost** component in `App.tsx`, above `SafeAreaProvider` and `AuthProvider` — a provider that throws is precisely the case that must still render. Its fallback depends on nothing but react-native core + theme constants, so the screen reporting a crash cannot itself crash. It catches render-phase errors, which is the failure mode that produces the silent white screen.

**2. `src/auth.tsx`** — `loadSession()` had **no `.catch`**. A rejected Keychain read (device locked, entitlement missing) left `ready` false *forever*, hanging on "Loading…" behind an unhandled rejection. An unreadable session is now treated as no session: the operator lands on Connect and can sign in.

## Verify

- `npm run typecheck` — clean
- `npm test` — **147/147**
- `npx expo export --platform ios` — bundles, 3.63 MB

Additive, `apps/mobile` only. SDK 54 and the `react`/`react-dom` exact pins untouched; **no new dependency**; still boots in stock Expo Go.

**Web/mobile parity: N/A** — phone-only defensive fix, no web peer.

## What the operator does next

Rescan the QR. The white screen should become either the real app or a **red error card with the actual message** — which is the diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)