### PR TITLE
fix(MOB): no native module may throw at import in the boot path — kill the white-screen class

### DIFF
--- a/apps/mobile/src/nativeModule.test.ts
+++ b/apps/mobile/src/nativeModule.test.ts
@@ -1,0 +1,87 @@
+// The contract that keeps a missing native module from blanking the app.
+//
+// This module is deliberately dependency-free (no react-native import), which is
+// what lets it run under the workspace's node --test harness at all — see
+// CLAUDE.md on Mobile CI and cross-workspace test imports.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { lazyNativeModule } from './nativeModule.ts'
+
+// The loader logs a warning on failure by design; keep the test output readable.
+function silencingWarnings<T>(fn: () => T): T {
+  const real = console.warn
+  console.warn = () => {}
+  try {
+    return fn()
+  } finally {
+    console.warn = real
+  }
+}
+
+test('returns the module when the require succeeds', () => {
+  const mod = { getDocumentAsync: () => 'ok' }
+  const get = lazyNativeModule('expo-fake', () => mod)
+  assert.equal(get(), mod)
+})
+
+test('does not load at registration — only on first call', () => {
+  let calls = 0
+  const get = lazyNativeModule('expo-fake', () => {
+    calls++
+    return {}
+  })
+  // THE point of the module: registering it must not touch the native module,
+  // because registration happens at module scope, i.e. in the boot path.
+  assert.equal(calls, 0, 'lazyNativeModule must not invoke the loader at module scope')
+  get()
+  assert.equal(calls, 1)
+})
+
+test('a throwing require yields null instead of propagating — the white-screen guard', () => {
+  const get = lazyNativeModule('expo-missing', () => {
+    // Exactly what requireNativeModule does on a host without the module.
+    throw new Error("Cannot find native module 'ExpoMissing'")
+  })
+  const got = silencingWarnings(() => get())
+  assert.equal(got, null)
+})
+
+test('failure is cached — the loader is not retried on every call', () => {
+  let calls = 0
+  const get = lazyNativeModule('expo-missing', () => {
+    calls++
+    throw new Error("Cannot find native module 'ExpoMissing'")
+  })
+  silencingWarnings(() => {
+    assert.equal(get(), null)
+    assert.equal(get(), null)
+    assert.equal(get(), null)
+  })
+  assert.equal(calls, 1, 'a missing module must be logged and retried at most once')
+})
+
+test('success is cached — the module is required exactly once', () => {
+  let calls = 0
+  const mod = { ok: true }
+  const get = lazyNativeModule('expo-fake', () => {
+    calls++
+    return mod
+  })
+  assert.equal(get(), mod)
+  assert.equal(get(), mod)
+  assert.equal(calls, 1)
+})
+
+test('a module that legitimately loads as a falsy value is not treated as a failure', () => {
+  let calls = 0
+  const get = lazyNativeModule('expo-falsy', () => {
+    calls++
+    return 0 as unknown as object
+  })
+  assert.equal(get(), 0 as unknown as object)
+  get()
+  // `undefined` means "not tried"; a real falsy result must still be cached, or the
+  // loader would re-require on every call forever.
+  assert.equal(calls, 1)
+})

--- a/apps/mobile/src/nativeModule.ts
+++ b/apps/mobile/src/nativeModule.ts
@@ -1,0 +1,63 @@
+// Lazy, fail-soft loading for native modules — the boot path's safety rail.
+//
+// THE PROBLEM THIS SOLVES. An Expo native package resolves its native counterpart
+// in its own MODULE BODY:
+//
+//     export default requireNativeModule('ExpoDocumentPicker')   // throws AT IMPORT
+//
+// so `import * as DocumentPicker from 'expo-document-picker'` throws at IMPORT if
+// the host doesn't carry that native module — not on first use, where a try/catch
+// would be waiting. And because navigation.tsx imports every screen and App.tsx
+// imports navigation.tsx, ANY such import anywhere under a screen sits in the BOOT
+// path. One absent module there takes down the entire app before React mounts.
+//
+// That failure is uniquely nasty: it happens during module evaluation, so the
+// top-level ErrorBoundary cannot catch it (there is no render to catch), and the
+// operator sees a plain WHITE screen with the real error only in the Metro
+// terminal. That is exactly the class of bug this module exists to make impossible.
+//
+// THE RULE: no native package may be imported for its VALUE at module scope in the
+// boot path. Import it for its TYPES (`import type`, erased at compile time), and
+// pull the value through here at the point of use.
+//
+// Failure is cached, so a missing module logs once rather than on every tap, and
+// callers get a null they must handle — which turns "the app is white" into "the
+// attach button says it can't open".
+
+/**
+ * Wrap a `require` of a native package so it can never throw at module scope.
+ *
+ * @param name  the package name, for the log line only.
+ * @param load  `() => require('the-package')` — called at most once.
+ * @returns a getter: the module, or null if it isn't available on this host.
+ *
+ * Usage:
+ *   import type * as FooNS from 'expo-foo'
+ *   const getFoo = lazyNativeModule('expo-foo', () => require('expo-foo') as typeof FooNS)
+ *   ...
+ *   const Foo = getFoo()
+ *   if (!Foo) return  // degrade; never crash
+ */
+export function lazyNativeModule<T>(name: string, load: () => T): () => T | null {
+  // `undefined` = not tried yet; `null` = tried and unavailable. Distinct on purpose:
+  // a module that legitimately loads as null would otherwise be retried forever.
+  let cached: T | null | undefined
+
+  return () => {
+    if (cached !== undefined) return cached
+    try {
+      cached = load()
+    } catch (e) {
+      cached = null
+      // The one line that names the missing module. If a white screen ever returns,
+      // this is what to grep for in the Metro terminal.
+      console.warn(
+        `[7Ei] native module "${name}" is unavailable on this host — the features that need it are disabled. ` +
+          `This is usually a client (e.g. Expo Go) that doesn't bundle it. Cause: ${
+            (e as Error)?.message ?? String(e)
+          }`,
+      )
+    }
+    return cached
+  }
+}

--- a/apps/mobile/src/notifications.tsx
+++ b/apps/mobile/src/notifications.tsx
@@ -21,7 +21,14 @@
 //
 // See docs/DESIGN-mobile-expo.md §4 and §14 (MOB-3 as-built).
 
-import * as Notifications from 'expo-notifications'
+// TYPE-only: erased at compile time. A VALUE import of expo-notifications is
+// itself a native side effect — its module body resolves
+// requireNativeModule('ExpoNotificationsHandlerModule') AND constructs a
+// LegacyEventEmitter over it at module scope. Since App.tsx imports this file,
+// that ran at BOOT: a host that doesn't carry the module would throw during module
+// evaluation and blank the app before React mounts (where the ErrorBoundary can't
+// reach). Pulled in lazily at each point of use instead.
+import type * as NotificationsNS from 'expo-notifications'
 import React, {
   createContext,
   useCallback,
@@ -33,21 +40,42 @@ import React, {
 import { Api } from './api'
 import { useAuth } from './auth'
 import { EAS_PROJECT_ID, pushRemoteConfigured } from './config'
+import { lazyNativeModule } from './nativeModule'
+
+const getNotifications = lazyNativeModule(
+  'expo-notifications',
+  () => require('expo-notifications') as typeof NotificationsNS,
+)
 
 // Where a notification tap should land. Kept in sync with App.tsx's TabKey.
 export type PushRouteTarget = 'command' | 'inbox' | 'agents' | 'status'
 
 // Foreground behaviour — show a banner + play a sound even when the app is open,
-// so an approval-needed push is visible while you're already in the app. Set once
-// at module load (before any React render), per Expo's guidance.
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldShowBanner: true,
-    shouldShowList: true,
-    shouldPlaySound: true,
-    shouldSetBadge: false,
-  }),
-})
+// so an approval-needed push is visible while you're already in the app.
+//
+// This USED to run at module load, per Expo's guidance. It no longer does: a
+// top-level call into a native module is a boot-path throw waiting to happen, and
+// module load is exactly where such a throw is invisible (no render → no
+// ErrorBoundary → white screen). PushProvider now installs it from an effect, which
+// still lands well before any notification can arrive — the handler only matters
+// once a push is delivered, and the provider mounts at sign-in. Idempotent, and
+// fail-soft: no notifications module simply means no foreground handler.
+function installForegroundHandler(): void {
+  const N = getNotifications()
+  if (!N) return
+  try {
+    N.setNotificationHandler({
+      handleNotification: async () => ({
+        shouldShowBanner: true,
+        shouldShowList: true,
+        shouldPlaySound: true,
+        shouldSetBadge: false,
+      }),
+    })
+  } catch (e) {
+    console.warn('[7Ei] could not install the foreground notification handler:', e)
+  }
+}
 
 type PermState = 'granted' | 'denied' | 'undetermined' | 'unknown'
 
@@ -91,6 +119,8 @@ export type PushApi = {
 const Ctx = createContext<PushApi | null>(null)
 
 async function readPermission(): Promise<PermState> {
+  const Notifications = getNotifications()
+  if (!Notifications) return 'unknown'
   try {
     const p = await Notifications.getPermissionsAsync()
     if (p.granted) return 'granted'
@@ -105,6 +135,8 @@ async function readPermission(): Promise<PermState> {
 // whole "graceful in Expo Go" contract.
 async function obtainExpoToken(): Promise<string | null> {
   if (!pushRemoteConfigured()) return null
+  const Notifications = getNotifications()
+  if (!Notifications) return null
   try {
     const t = await Notifications.getExpoPushTokenAsync({ projectId: EAS_PROJECT_ID })
     return t?.data ?? null
@@ -123,6 +155,12 @@ export function PushProvider({ children }: { children: React.ReactNode }) {
     ...INITIAL,
     userKnown: !!userId,
   }))
+
+  // Install the foreground handler here rather than at module load — see
+  // installForegroundHandler. Once per mount; the call is idempotent.
+  useEffect(() => {
+    installForegroundHandler()
+  }, [])
 
   // What we last registered, so we can de-register exactly on sign-out / change.
   const registeredRef = useRef<{ apiUrl: string; userId: string; token: string } | null>(null)
@@ -160,8 +198,15 @@ export function PushProvider({ children }: { children: React.ReactNode }) {
         let perm = await readPermission()
         if (perm !== 'granted' && request) {
           try {
-            const r = await Notifications.requestPermissionsAsync()
-            perm = r.granted ? 'granted' : r.status === 'denied' ? 'denied' : 'undetermined'
+            const N = getNotifications()
+            const r = await N?.requestPermissionsAsync()
+            perm = !r
+              ? 'unknown'
+              : r.granted
+                ? 'granted'
+                : r.status === 'denied'
+                  ? 'denied'
+                  : 'undetermined'
           } catch {
             perm = 'unknown'
           }
@@ -235,6 +280,11 @@ export function PushProvider({ children }: { children: React.ReactNode }) {
 
   const sendTest = useCallback(async () => {
     patch({ error: null })
+    const Notifications = getNotifications()
+    if (!Notifications) {
+      patch({ error: "This app build can't send notifications." })
+      return
+    }
     try {
       let perm = await readPermission()
       if (perm !== 'granted') {
@@ -297,6 +347,10 @@ export function useNotificationRouting(onRoute: (t: PushRouteTarget) => void): v
   onRouteRef.current = onRoute
 
   useEffect(() => {
+    const Notifications = getNotifications()
+    // No notifications module → no taps to route. Nothing to wire, nothing to throw.
+    if (!Notifications) return
+
     let cancelled = false
     // Cold start: launched from a notification tap.
     Notifications.getLastNotificationResponseAsync()

--- a/apps/mobile/src/screens/CommandCenterScreen.tsx
+++ b/apps/mobile/src/screens/CommandCenterScreen.tsx
@@ -20,12 +20,23 @@ import {
   TextInput,
   View,
 } from 'react-native'
-import * as DocumentPicker from 'expo-document-picker'
+// TYPE-only: erased at compile time, so it keeps expo-document-picker's
+// requireNativeModule('ExpoDocumentPicker') OUT of the boot path. The value is
+// pulled in lazily at the tap — see getDocumentPicker below.
+import type * as DocumentPickerNS from 'expo-document-picker'
 import { Api } from '../api'
 import { useAuth } from '../auth'
 import { attachmentChipLabel, canSendTurn, rejectAttachment, toConverseAttachment, type AttachedDoc } from '../attach'
+import { lazyNativeModule } from '../nativeModule'
 import { font, radius, space, theme } from '../theme'
 import { Banner, Chip } from '../ui'
+
+// Resolved on the first attach tap, never at import. A host without the picker
+// costs the operator the attach button, not the app.
+const getDocumentPicker = lazyNativeModule(
+  'expo-document-picker',
+  () => require('expo-document-picker') as typeof DocumentPickerNS,
+)
 
 type Msg = {
   role: 'user' | 'assistant'
@@ -60,7 +71,13 @@ export default function CommandCenterScreen() {
   const pickAttachment = useCallback(async () => {
     setError(null)
     setNotice(null)
-    let picked: DocumentPicker.DocumentPickerResult
+    const DocumentPicker = getDocumentPicker()
+    if (!DocumentPicker) {
+      // Readable, not white: the loader already logged which module is missing.
+      setError("This app build can't open the file picker. You can still send a message.")
+      return
+    }
+    let picked: DocumentPickerNS.DocumentPickerResult
     try {
       picked = await DocumentPicker.getDocumentAsync({
         type: '*/*',

--- a/apps/mobile/src/stepup.ts
+++ b/apps/mobile/src/stepup.ts
@@ -20,7 +20,18 @@
 // rather than crashing the Inbox. NEVER log the step-up token (it never reaches
 // this module) or any biometric material.
 
-import * as LocalAuthentication from 'expo-local-authentication'
+// TYPE-only: erased at compile time. expo-local-authentication runs
+// requireNativeModule('ExpoLocalAuthentication') in its module body, so a VALUE
+// import here would throw at IMPORT on a host without it — and this module is in
+// the boot path (InboxScreen → StepUpModal → stepup.ts), so that throw would blank
+// the app before React mounts. Pulled in lazily at the gate instead.
+import type * as LocalAuthenticationNS from 'expo-local-authentication'
+import { lazyNativeModule } from './nativeModule'
+
+const getLocalAuth = lazyNativeModule(
+  'expo-local-authentication',
+  () => require('expo-local-authentication') as typeof LocalAuthenticationNS,
+)
 import type { Approval } from './api'
 
 // The word the operator must type in the fallback modal to confirm a dangerous
@@ -72,6 +83,9 @@ export interface BiometricProbe {
  *  error (module missing, native unavailable) → `usable:false`, so the caller
  *  falls back to typed confirmation rather than skipping the gate. */
 export async function probeBiometric(): Promise<BiometricProbe> {
+  const LocalAuthentication = getLocalAuth()
+  // Absent module → same fail-closed answer as absent hardware: typed confirmation.
+  if (!LocalAuthentication) return { usable: false, label: '' }
   try {
     const hasHardware = await LocalAuthentication.hasHardwareAsync()
     const enrolled = await LocalAuthentication.isEnrolledAsync()
@@ -99,6 +113,8 @@ export type BiometricResult =
  *  without a biometric enrolled can still confirm with its passcode. Fail-closed:
  *  any thrown error → `unavailable` (caller re-routes to typed confirmation). */
 export async function runBiometricGate(prompt: string): Promise<BiometricResult> {
+  const LocalAuthentication = getLocalAuth()
+  if (!LocalAuthentication) return { ok: false, reason: 'unavailable' }
   try {
     const res = await LocalAuthentication.authenticateAsync({
       promptMessage: prompt,


### PR DESCRIPTION
## The class of bug, not the instance

`App.tsx` imports `navigation.tsx`, which imports **every screen**. So any module-scope native side effect anywhere under a screen runs at **boot**. And Expo packages resolve their native counterpart in their own module body:

```js
export default requireNativeModule('ExpoDocumentPicker')   // throws AT IMPORT
```

That throws **at import** — not at first use, where our `try/catch` was waiting. It happens during module evaluation, **before React mounts**, so the ErrorBoundary from #296 **cannot catch it**: white screen, trace only in the Metro terminal.

Rather than patch the one suspect, this closes the class.

## The three module-scope native side effects found in the boot path

| # | Module | What ran at import | Reached via | Added | Now |
|---|---|---|---|---|---|
| 1 | **expo-document-picker** | `requireNativeModule('ExpoDocumentPicker')` | `CommandCenterScreen` (a `SCREENS` entry) | **MOB-PAR-1 #287 — inside the broken window** | lazy-required at the attach tap |
| 2 | **expo-local-authentication** | `requireNativeModule('ExpoLocalAuthentication')` | `InboxScreen` → `StepUpModal` → `stepup.ts` | MOB-4 #280 | lazy-required at the gate |
| 3 | **expo-notifications** | `requireNativeModule('ExpoNotificationsHandlerModule')` **+** `new LegacyEventEmitter(...)` in its module body — *the import itself is the side effect* — plus our own top-level `setNotificationHandler()` call | `notifications.tsx`, imported by `App.tsx` | MOB-3 #278 | lazy-required at each use; handler installs from `PushProvider`'s effect |

**#1 is the prime suspect**: it is the *only* native module added after last-known-working MOB-6a (#282).

For #2, `probeBiometric` / `runBiometricGate` already fail closed to typed confirmation, so an absent module degrades exactly as absent hardware does. For #3, the handler still installs well before any push can arrive (the provider mounts at sign-in).

## How each is deferred

All three go through `src/nativeModule.ts` — `lazyNativeModule(name, load)`:

- requires **at most once**, caching **success and failure**
- **never throws** — returns `null`
- logs one line naming the missing module
- callers degrade with a readable message (*"This app build can't open the file picker."*) instead of a blank app

Type imports are `import type`, erased at compile time, so they stay out of the boot path.

## Deliberately left alone

**`expo-secure-store`** (`store.ts`, `clerkCache.ts`) is the one remaining module-scope native import. It's been in the boot path since MOB-1 (#276) and demonstrably works, and it's the riskiest file to touch while the app is down. Flagged, not changed — per instruction.

## Also swept, clean

No Hermes-sensitive construct (`Intl`, `structuredClone`, `BigInt`, `.at`/`findLast`, named capture groups, lookbehind, `import.meta`, top-level await) anywhere in the boot path. `@react-navigation/*` are pure JS.

## Verify

- `npm run typecheck` — clean
- `npm test` — **153/153** (+6: `nativeModule.test.ts` locks no-load-at-registration, throwing-require→null, failure cached, success cached, falsy-module-isn't-failure)
- `npx expo export --platform ios` — bundles, 3.64 MB

Additive, `apps/mobile` only. SDK 54 + react/react-dom pins untouched, no dep change, Expo Go bootable.

**Web/mobile parity: N/A** — phone-only boot hardening, no web peer.

## After merge

If #1 was the cause, the rescan boots. If a native module is genuinely missing, you'll now get a working app with one warning in Metro naming it:

```bash
grep -n "native module .* is unavailable" metro.log
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)