### PR TITLE
fix(MOB): pin react to EXACTLY 19.1.0 — the renderer's version check is what blanked the phone

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -21,8 +21,8 @@
         "expo-secure-store": "~15.0.8",
         "expo-status-bar": "~3.0.9",
         "expo-web-browser": "~15.0.11",
-        "react": "19.1.8",
-        "react-dom": "19.1.8",
+        "react": "19.1.0",
+        "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0"
@@ -12180,9 +12180,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-XzY1Xytszq73B9T+4Q8VYfUX9qTz54+AoeZ+cSYNSVAzgz4gxFMZ8Ngk4RlmE9yVWpiZ3JAtQeHBLOK6ZfvOnw==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12199,15 +12199,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.8.tgz",
-      "integrity": "sha512-CGK3BOzbtfWrDVjKM+Ffmvf8J3I8+jbdd75+tKZjfwPTiaeFewsYTPrb2Ct4vlqyPHZpFWanfahdqjaQCv4tHg==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.1.8"
+        "react": "^19.1.0"
       }
     },
     "node_modules/react-freeze": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -27,8 +27,8 @@
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",
     "expo-web-browser": "~15.0.11",
-    "react": "19.1.8",
-    "react-dom": "19.1.8",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0"
@@ -37,13 +37,9 @@
     "@types/react": "~19.1.0",
     "typescript": "~5.9.2"
   },
-  "expo": {
-    "install": {
-      "//": "SDK 54 pins react/react-dom to 19.1.0, but @clerk/clerk-js floors them at ~19.1.4. react-native@0.81.5 peers react at ^19.1.0, so 19.1.8 (newest 19.1.x) satisfies BOTH and dedupes Clerk onto one React copy. Excluded so `expo install --check` stops trying to pull them back to 19.1.0 and re-break Clerk. Re-evaluate on the next SDK bump.",
-      "exclude": [
-        "react",
-        "react-dom"
-      ]
-    }
+  "//overrides": "react MUST be EXACTLY 19.1.0 — react-native@0.81.5 ships a PREBUILT renderer that hardcodes its React version and compares with strict !==: `if (\"19.1.0\" !== React.version) throw Error('Incompatible React versions...')` (Libraries/Renderer/implementations/ReactNativeRenderer-{dev,prod,profiling}.js). RN's PEER range is the looser `^19.1.0`, which is why npm, tsc and `expo export` all stayed green on 19.1.8 while the app threw on the device at first render. @clerk/clerk-js peers react at `~19.1.4 || …`, which 19.1.0 does NOT satisfy — but that is install-time metadata, whereas RN's check is a runtime hard throw, so RN wins and we force the tree with `overrides`. Clerk declares react only as a PEER (never a dependency), so it cannot nest a second copy; the override just settles the peer. Do NOT raise react without re-reading the renderer's hardcoded constant for the new RN version.",
+  "overrides": {
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
   }
 }

--- a/apps/mobile/src/reactVersion.test.ts
+++ b/apps/mobile/src/reactVersion.test.ts
@@ -1,0 +1,91 @@
+// The tripwire for the bug that cost us a live outage.
+//
+// react-native ships a PREBUILT React renderer. It hardcodes the React version it
+// was compiled against and checks it with a strict !== at first render:
+//
+//   var isomorphicReactPackageVersion = React.version;
+//   if ("19.1.0" !== isomorphicReactPackageVersion)
+//     throw Error('Incompatible React versions: The "react" and
+//                  "react-native-renderer" packages must have the exact same version…')
+//
+// WHY THIS TEST EXISTS. react-native's *peer* range is the looser `^19.1.0`, so npm
+// installs 19.1.8 happily, tsc type-checks it, and `expo export` bundles it — every
+// gate green. The renderer's equality check only runs ON THE DEVICE, at first
+// render, where it threw and took the whole tree down to a white screen. Every
+// automated signal we had said the app was fine. This test is the signal we didn't
+// have: it reads the constant out of the installed renderer and compares it to the
+// installed react, so a drift fails in CI instead of on the operator's phone.
+//
+// If this fails after an SDK/RN bump, do NOT "fix" it by loosening the assert. Set
+// `react` (and react-dom) in package.json to EXACTLY the version the renderer names,
+// and keep the `overrides` block pinning the tree to it.
+//
+// Dependency-free on purpose (node:fs only) so it runs under Mobile CI, which
+// installs apps/mobile alone.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+const require_ = createRequire(import.meta.url)
+
+/** The React version a given prebuilt renderer bundle demands, or null. */
+function rendererExpectedReact(file: string): string | null {
+  const src = readFileSync(require_.resolve(file), 'utf8')
+  // Matches the emitted check regardless of minification/formatting:
+  //   "19.1.0" !== isomorphicReactPackageVersion
+  const m = src.match(/"(\d+\.\d+\.\d+)"\s*!==\s*isomorphicReactPackageVersion/)
+  return m ? m[1] : null
+}
+
+const RENDERERS = [
+  // The one Expo Go runs.
+  'react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js',
+  // The one a release build runs — must agree, or we'd ship a white screen.
+  'react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js',
+]
+
+test('react-native still performs an exact-version check (the premise of this test)', () => {
+  const v = rendererExpectedReact(RENDERERS[0])
+  assert.ok(
+    v,
+    'Could not find the renderer version check. react-native may have changed how it ' +
+      'validates the React version — re-read the renderer source before trusting this suite.',
+  )
+})
+
+test('the installed react EXACTLY matches what every react-native renderer demands', () => {
+  const installed = require_('react/package.json').version as string
+
+  for (const r of RENDERERS) {
+    const expected = rendererExpectedReact(r)
+    if (!expected) continue
+    assert.equal(
+      installed,
+      expected,
+      `react@${installed} !== the ${r.split('/').pop()} renderer's required ${expected}. ` +
+        `This throws "Incompatible React versions" on device at first render — a WHITE SCREEN — ` +
+        `while npm, tsc and expo export all stay green. Pin react AND react-dom to exactly ` +
+        `${expected} in apps/mobile/package.json, and keep the "overrides" block.`,
+    )
+  }
+})
+
+test('react-dom matches react, so Clerk and react never straddle two versions', () => {
+  const react = require_('react/package.json').version as string
+  const reactDom = require_('react-dom/package.json').version as string
+  assert.equal(reactDom, react, 'react-dom must track react exactly')
+})
+
+test('react matches the version Expo SDK 54 pins for this react-native', () => {
+  // The SDK's own version map is the second, independent opinion — if it and the
+  // renderer ever disagree, the pin is not a judgement call and this will say so.
+  const bundled = require_('expo/bundledNativeModules.json') as Record<string, string>
+  const installed = require_('react/package.json').version as string
+  assert.equal(
+    installed,
+    bundled['react'],
+    `Expo SDK pins react to ${bundled['react']} but ${installed} is installed.`,
+  )
+})


### PR DESCRIPTION
## Root cause — confirmed from the operator's ErrorBoundary card

react-native ships a **prebuilt** React renderer. It hardcodes the React version it was compiled against and checks it with a **strict `!==`** at first render:

```js
// react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js:16871
var isomorphicReactPackageVersion = React.version;
if ("19.1.0" !== isomorphicReactPackageVersion)
  throw Error('Incompatible React versions: The "react" and "react-native-renderer" ' +
              'packages must have the exact same version…')
```

We had **react 19.1.8**. `"19.1.0" !== "19.1.8"` → **throw at first render** → whole tree unmounts → **white screen**.

The reported `TypeError: Cannot read property 'default' of undefined` in `findNodeHandle → _connectAnimatedView2` is the **aftermath**, not the cause: Animated dereferencing a renderer that never initialised. The LogBox toast — *"Incompatible React versions"* — was the actual error all along.

## Why every gate stayed green

RN's **peer** range is the looser `^19.1.0`, which 19.1.8 satisfies. So npm resolved it, `tsc` type-checked it, and `expo export` bundled it. The equality check runs **only on the device, at first render**. We had no signal — which is exactly why this PR ships a tripwire.

## Q1 — the constraint, and is it a duplicate react?

| | |
|---|---|
| RN 0.81.5 **peer** on react | `^19.1.0` (a range — accepts 19.1.8) |
| RN 0.81.5 **renderer** check | **exact `!==` against `"19.1.0"`** — dev, prod *and* profiling all agree |
| Expo SDK 54 `bundledNativeModules` | react **19.1.0**, react-dom **19.1.0** |
| `npm ls react` (before) | **a single 19.1.8, fully deduped** |

**Not a duplicate.** There was exactly one react on disk. Option (a) is ruled out by evidence → **option (b)**.

## Q2 — which option, and why

**Option (b): pin react + react-dom to exactly `19.1.0` + `overrides`.**

The two constraints genuinely conflict, and the tie-break isn't a judgement call:

- **RN** requires exactly `19.1.0` — a **runtime hard throw**. The app cannot boot otherwise.
- **`@clerk/clerk-js`** peers react at `^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0`. `19.1.0` satisfies **none** of those branches (`~19.0.3` is `<19.1.0`; `~19.1.4` is `>=19.1.4`). But that is **install-time metadata**, not a runtime requirement.

**RN wins.** Decisively: Clerk declares react only as a **peerDependency — never a dependency** (verified across `clerk-js`, `clerk-react`, `shared`, `clerk-expo`), so it **cannot nest a second copy**. `overrides` simply settles the peer. Result: `npm install` **and** `npm ci` resolve clean, no `ERESOLVE`, **zero invalid peers**, one `react@19.1.0 overridden`, and Clerk still bundles.

## The pin that caused it — and the real timeline

MOB-5 (#281) moved SDK 57→54 and set react `19.2.3` → `19.1.8`, reasoning that RN *"peers react at ^19.1.0, so 19.1.8 satisfies BOTH"*. That read RN's **peer range** as the constraint; the renderer's **runtime** check is exact equality. **react has never been 19.1.0 in this repo.**

**So this is not a regression from the Clerk key or MOB-6b..6f.** It dates to **#281 — the very commit that first made the app loadable in stock Expo Go** (SDK 57 couldn't load there at all). There was no working Expo Go state to regress from; both suspected changes were coincidental.

I also removed the `expo.install.exclude` for react/react-dom. It existed to stop `expo install --check` pulling them back to 19.1.0 — i.e. **it suppressed the SDK telling us the correct answer.** At 19.1.0 the SDK agrees and the exclude is gone.

## Q3 — verification

| Check | Result |
|---|---|
| `npm ls react react-dom` | **single `react@19.1.0` + `react-dom@19.1.0`, both `overridden`**, all nested deduped, no invalid peers |
| Renderer grep | dev/prod/profiling all demand `19.1.0` → `"19.1.0" !== "19.1.0"` is **false** → **no throw** |
| `npm run typecheck` | clean |
| `npm test` | **157/157** (+4) |
| `npx expo export --platform ios` | bundles, 3.64 MB |
| `npm ci` (the Mobile CI path) | reproduces 19.1.0 |

The only other react copies on disk live in `expo/node_modules/@expo/cli/static/canary-full/` — CLI **template** scaffolding (alongside `template`/`shims`), unreachable from the app's graph; `require.resolve('react')` from `apps/mobile` returns **19.1.0**.

**`src/reactVersion.test.ts`** is the tripwire we lacked: it reads the hardcoded constant out of the **installed** renderer (dev *and* prod) and asserts react matches exactly — plus `react-dom === react` and `react === the SDK's pin`. Dep-free (`node:fs`), so it runs under Mobile CI. A future SDK bump that drifts react now fails in CI instead of on the operator's phone.

## Confidence

**High** that this clears the "Incompatible React versions" check — the check is a literal string comparison against `"19.1.0"`, and react is now exactly `19.1.0`, verified post-`npm ci`. That error and the Animated `TypeError` cascading from it should both be gone.

Slightly lower — **but untested only on-device** — is Clerk on 19.1.0 vs its declared `~19.1.4` floor. It's a patch-level gap with a single deduped react, so I expect no issue; if Clerk misbehaves, the ErrorBoundary will now say so plainly rather than blanking.

Additive, `apps/mobile` only, still SDK 54, no new dependency.

**Web/mobile parity: N/A** — phone-only dependency pin, no web peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)