### PR TITLE
fix(MOB-7b audit): close the vision allowlist's two false positives (gemma3:1b, o3-mini)

### DIFF
--- a/backend/src/services/converse-images.ts
+++ b/backend/src/services/converse-images.ts
@@ -154,12 +154,27 @@ const VISION_MODEL_PATTERNS: Record<string, RegExp[]> = {
   // Every Claude from 3 onward is multimodal; claude-2 / instant are not.
   anthropic: [/^claude-(3|4|5|opus|sonnet|haiku)/i],
   // 4o-class, 4-turbo, 4.1, 5-class and the o-series reasoning models.
-  openai: [/^(gpt-4o|gpt-4-turbo|gpt-4\.1|gpt-5|o[34])/i],
+  //
+  // o3-mini is EXCLUDED, and it is the one that reads like a typo but isn't: the
+  // o-series is not uniformly sighted. o3, o3-pro and o4-mini take image input;
+  // o3-mini does not, and a bare /o[34]/ swept it in as sighted. It is a cheap
+  // reasoning model an operator would plausibly put first in the chain, so the
+  // hole was reachable. (o1 is absent for the opposite reason — it CAN see, but
+  // a false negative only costs a clear message, so it stays out until wanted.)
+  openai: [/^(gpt-4o|gpt-4-turbo|gpt-4\.1|gpt-5|o3(?!-mini)|o4)/i],
   // Gemini has been multimodal since 1.5; bare `gemini-pro` (1.0) was not.
   google: [/^gemini-(1\.5|[2-9])/i, /vision/i],
   // Local vision models people actually pull: llava/bakllava, the -vision and
   // -vl tags, moondream, minicpm-v, gemma3, llama4.
-  ollama: [/llava/i, /vision/i, /moondream/i, /minicpm-v/i, /[-.]vl\b/i, /qwen2\.?5?-?vl/i, /^gemma3/i, /^llama4/i],
+  //
+  // gemma3:1b is EXCLUDED and this is the sharpest edge on the list. Gemma 3 is
+  // multimodal at 4B/12B/27B but the 1B is TEXT-ONLY — and 1B is the smallest,
+  // fastest, most-pulled tag, i.e. exactly what an operator running local Ollama
+  // on modest hardware puts first. That is precisely the scenario visionChain
+  // exists for, so `/^gemma3/` matching it handed the image to a blind model in
+  // the story's own target case. The lookahead spares :4b/:12b/:27b (and the
+  // `-it-qat`-style suffixes) while refusing every 1b tag.
+  ollama: [/llava/i, /vision/i, /moondream/i, /minicpm-v/i, /[-.]vl\b/i, /qwen2\.?5?-?vl/i, /^gemma3(?![\w.]*[:-]1b)/i, /^llama4/i],
   // Groq's vision line is the llama-4 scout/maverick models + the -vision tags.
   groq: [/vision/i, /llama-4/i, /scout/i, /maverick/i],
   // Moonshot/Qwen ship vision under -vision-preview / -vl names; their default

--- a/backend/src/tests/converse-images.test.ts
+++ b/backend/src/tests/converse-images.test.ts
@@ -102,8 +102,51 @@ test('[MOB-7b] known vision models are recognised', () => {
     ['ollama', 'llama3.2-vision'],
     ['ollama', 'llava:13b'],
     ['groq', 'llama-3.2-11b-vision-preview'],
+    // The multimodal Gemma 3 tags must survive the :1b exclusion below — a fix
+    // that blinded the whole family would trade one bug for another.
+    ['ollama', 'gemma3:4b'],
+    ['ollama', 'gemma3:12b'],
+    ['ollama', 'gemma3:27b'],
+    ['ollama', 'gemma3:27b-it-qat'],
+    // o-series models that really do take image input, guarding the o3-mini
+    // exclusion from over-reaching.
+    ['openai', 'o3'],
+    ['openai', 'o3-pro'],
+    ['openai', 'o4-mini'],
   ]
   for (const [p, m] of sighted) assert.equal(supportsVision(p, m), true, `${p}/${m} should see`)
+})
+
+test('[MOB-7b] a text-only member of an otherwise-sighted family is NOT waved through', () => {
+  // AUDIT REGRESSION. The allowlist matched these two as sighted, so an image
+  // reached a model that cannot see it — the exact silent-drop this module
+  // exists to prevent, and reachable through ordinary operator config rather
+  // than anything exotic. Family-prefix patterns are the trap: "gemma3 is
+  // multimodal" and "the o-series sees" are both true of the family and false
+  // of a specific member.
+  const blindMembers: Array<[string, string, string]> = [
+    // Gemma 3 is multimodal at 4B+; the 1B is text-only. It is also the tag a
+    // local-Ollama operator is most likely to run.
+    ['ollama', 'gemma3:1b', 'Gemma 3 1B is text-only'],
+    ['ollama', 'gemma3:1b-it-qat', 'every 1b tag, suffixed or not'],
+    // o3 and o4-mini take images; o3-mini does not.
+    ['openai', 'o3-mini', 'o3-mini has no vision'],
+    ['openai', 'o3-mini-2025-01-31', 'pinned o3-mini snapshots too'],
+  ]
+  for (const [p, m, why] of blindMembers) {
+    assert.equal(supportsVision(p, m), false, `${p}/${m} must fail closed — ${why}`)
+  }
+})
+
+test('[MOB-7b] a blind family member is pruned out of a real chain', () => {
+  // The unit above proves the predicate; this proves the consequence, which is
+  // what actually protects the operator: gemma3:1b first in the chain must not
+  // be the hop an image lands on.
+  const chain = [
+    { provider: 'ollama', model: 'gemma3:1b' },
+    { provider: 'anthropic', model: 'claude-sonnet-4' },
+  ]
+  assert.deepEqual(visionChain(chain), [{ provider: 'anthropic', model: 'claude-sonnet-4' }])
 })
 
 test('[MOB-7b] text-only models are NOT treated as sighted', () => {


### PR DESCRIPTION
Independent security audit of #301. **Do not merge without the MOB-7b author's review** — targets `mob-7b-photo-attach`, not `main`, so #301 stays the merge unit.

## The finding (High)

`supportsVision()` is the **only** gate between an attached photo and a blind model — nothing downstream re-checks. Two patterns matched a text-only **member** of an otherwise-sighted **family**:

| pattern | swept in | reality |
|---|---|---|
| `ollama: /^gemma3/i` | `gemma3:1b` | Gemma 3 is multimodal at 4B/12B/27B — the **1B is text-only** |
| `openai: /o[34]/i` | `o3-mini` | `o3`, `o3-pro`, `o4-mini` take images — **`o3-mini` does not** |

The allowlist's fail-closed *direction* is right, and its reasoning is the reason this matters: it argues an unknown model must be assumed blind because the bad case is "a confident answer about an image the model never received." These two aren't unknown — they're **wrongly known**, which routes straight past that protection.

Neither needs exotic config. `gemma3:1b` is the smallest and most-pulled Gemma tag, i.e. what a local-Ollama operator on modest hardware puts first in the chain — precisely the scenario `visionChain` was written for. On Ollama a text-only model handed an image can simply ignore it and answer anyway.

## The fix

Negative lookaheads, in the direction the module already argues for. Every genuinely sighted variant is preserved (`gemma3:4b/12b/27b` incl. `-it-qat`, `o3`, `o3-pro`, `o4-mini`); `o1` stays out as a deliberate false negative, which only costs a clear message.

## Verification

- New tests pin both members **and the consequence** (a chain led by `gemma3:1b` prunes to the Claude hop). Mutation-checked: they **fail against the pre-fix source**, pass after.
- `backend 1407/1407` · typecheck clean · `evals 11/11`.

## Audit result for #301

Everything else in #301 verified **PASS** — the default chain, the `custom` provider and unknown providers all correctly fail closed; the image is never persisted or logged (the captured-log-stream test is real and bites); auth/tenancy are under the existing `secured` scope; text turns short-circuit byte-identically; react pinned at 19.1.0; `expo-image-picker` boot-safe via `lazyNativeModule`. This is the only High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)