### PR TITLE
fix(MOB-7d audit): trust & model-profile saves blank the agent on success

### DIFF
--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -555,6 +555,11 @@ export const Api = {
 
   // PUT …/model-profile — primary/cheap model + reasoning effort. A model swap
   // changes spend + capability, so the screen CONFIRMS before calling this.
+  // The route answers `{ agentId, profile, resolved }` — NOT `{ agent }` (the web
+  // re-loads the roster after this call rather than reading the body). Return the
+  // authoritative `profile` so the screen reconciles the row from the server's
+  // answer; reading a non-existent `.agent` here yielded `undefined` and blanked
+  // the agent on a SUCCESSFUL save (audit MOB-7d fix).
   updateModelProfile: (
     base: string,
     token: string,
@@ -562,14 +567,19 @@ export const Api = {
     agentId: string,
     body: { primaryModel: string; cheapModel: string; cheapModelEnabled: boolean; reasoningEffort: string },
   ) =>
-    api<{ agent: Agent }>(base, `/api/orgs/${orgId}/agents/${agentId}/model-profile`, {
+    api<{
+      agentId: string
+      profile: { primaryModel: string | null; cheapModel: string | null; cheapModelEnabled: boolean; reasoningEffort: string | null }
+    }>(base, `/api/orgs/${orgId}/agents/${agentId}/model-profile`, {
       token,
       method: 'PUT',
       body: JSON.stringify(body),
-    }).then((r) => r.agent),
+    }).then((r) => r.profile),
 
   // PUT …/trust — the trust MODE (boundary editing stays on the desk). Safety-
-  // critical, so the screen CONFIRMS before calling this.
+  // critical, so the screen CONFIRMS before calling this. The route answers
+  // `{ agentId, trustMode, boundary }` — NOT `{ agent }` — so return the new
+  // `trustMode` for the screen to reconcile (same audit fix as model-profile).
   updateAgentTrust: (
     base: string,
     token: string,
@@ -577,11 +587,11 @@ export const Api = {
     agentId: string,
     body: { trustMode: string },
   ) =>
-    api<{ agent: Agent }>(base, `/api/orgs/${orgId}/agents/${agentId}/trust`, {
-      token,
-      method: 'PUT',
-      body: JSON.stringify(body),
-    }).then((r) => r.agent),
+    api<{ agentId: string; trustMode: string; boundary: unknown }>(
+      base,
+      `/api/orgs/${orgId}/agents/${agentId}/trust`,
+      { token, method: 'PUT', body: JSON.stringify(body) },
+    ).then((r) => r.trustMode),
 
   // GET …/skills — the split payload the SkillsTab renders (member-readable).
   agentSkills: (base: string, token: string, orgId: string, agentId: string) =>

--- a/apps/mobile/src/screens/AgentDetailScreen.tsx
+++ b/apps/mobile/src/screens/AgentDetailScreen.tsx
@@ -599,7 +599,16 @@ function ModelProfileSection({
     setErr(null)
     setSaved(false)
     try {
-      const updated = await Api.updateModelProfile(apiUrl, token, orgId, agentId, buildModelProfileBody(form))
+      // The route answers with the new profile (not a full agent row); merge it
+      // onto the agent we already have so on-screen state IS the server's answer.
+      const profile = await Api.updateModelProfile(apiUrl, token, orgId, agentId, buildModelProfileBody(form))
+      const updated: Agent = {
+        ...agent,
+        primaryModel: profile.primaryModel,
+        cheapModel: profile.cheapModel,
+        cheapModelEnabled: profile.cheapModelEnabled,
+        reasoningEffort: profile.reasoningEffort,
+      }
       onAgentUpdated(updated)
       setForm(emptyModelForm(updated))
       setSaved(true)
@@ -694,8 +703,10 @@ function TrustSection({
     setBusy(true)
     setErr(null)
     try {
-      const updated = await Api.updateAgentTrust(apiUrl, token, orgId, agentId, buildTrustBody(target))
-      onAgentUpdated(updated)
+      // The route answers `{ trustMode }`, not a full agent row — merge the new
+      // mode onto the current agent so the card reconciles to the server's answer.
+      const trustMode = await Api.updateAgentTrust(apiUrl, token, orgId, agentId, buildTrustBody(target))
+      onAgentUpdated({ ...agent, trustMode })
     } catch (e: any) {
       setErr(e?.message ?? 'Could not change the trust tier.')
     }


### PR DESCRIPTION
**Independent security/correctness audit of #304 surfaced one High-severity functional bug.** This PR fixes it against the feature branch so it lands with the feature (do not merge to `main` directly).

## The bug
`apps/mobile/src/api.ts` `updateModelProfile` and `updateAgentTrust` read `r.agent` from the PUT response. But the two backend routes they call return:

- `PUT …/model-profile` → `{ agentId, profile, resolved }`
- `PUT …/trust` → `{ agentId, trustMode, boundary }`

Neither returns `agent` (the web ignores the body and re-loads). So on a **successful** save `.then(r => r.agent)` resolved to `undefined`:

- `onAgentUpdated(undefined)` set the parent `agent` state to `undefined` → the identity card **and the entire Edit panel unmounted** (both gated on `agent ?`).
- model-profile additionally hit `emptyModelForm(undefined)` → `TypeError` → caught → a **false** "…Your changes are still here" error, even though the write landed on the server.

`config` (returns `{ agent }`) and `skills` were unaffected — only 2 of the 4 write surfaces.

Neither typecheck nor the 254 unit tests caught it: the `api<{ agent: Agent }>()` generic is an unchecked assertion about the response, and the pure tests never exercise the real response envelope.

## The fix
Return the authoritative `profile` / `trustMode` the routes actually send, and reconcile them onto the agent the screen already holds — so on-screen state **is** the server's answer (the "reconcile to the server response" guarantee the feature claims).

## Verification
- `npm run typecheck` clean
- `npm test` → 254/254
- `npm run export` bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)