### PR TITLE
fix(sec): owner-gate the config-rollback route (perms-authz residual)

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -19,7 +19,7 @@ import { validatePermissions } from '../services/agent-permissions'
 import { resolveModelProfile, buildModelProfilePatch, flattenModelOptions, parseReasoningEffort } from '../services/model-profile'
 import { parseLlmChain } from '../services/arturita-pipeline'
 import { parseCustomModels } from '../services/custom-model'
-import { requireOrgRole } from '../middleware/rbac'
+import { requireOrgRole, enforceOrgRole } from '../middleware/rbac'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -246,6 +246,17 @@ export async function agentRoutes(app: FastifyInstance) {
     const { id } = req.params as any
     const rev = await db.query.configRevisions.findFirst({ where: eq(schema.configRevisions.id, id) })
     if (!rev || !rev.before) return reply.code(404).send({ error: 'Revision not found' })
+    // SEC (audit/perms-authz) — a rollback RESTORES owner-controlled agent config:
+    // `permissions` (capability caps), plus `role`, `status`, `llmProvider/llmModel`,
+    // `reportsTo` — the very fields the sibling write routes (permissions / trust /
+    // model-profile / config) gate to the org OWNER. Left member-gated, this route is
+    // a side door around all of them: a member could revert an owner's tightening —
+    // e.g. restore an agent's caps to a prior allow-all snapshot — with no owner role.
+    // The path carries no `:orgId`, so a `requireOrgRole` preHandler would silently
+    // no-op (the R-4 trap); derive the org from the revision row and enforce OWNER
+    // in-handler, matching how multi-org transfer/clone guard their data-derived org.
+    const gate = await enforceOrgRole({ userId: (req as any).auth?.userId, orgId: rev.orgId, minRole: 'owner' })
+    if (!gate.ok) return reply.code(gate.code).send({ error: gate.error })
     let before: any; try { before = JSON.parse(rev.before) } catch { return reply.code(400).send({ error: 'corrupt snapshot' }) }
     if (rev.entity === 'agent') {
       const patch: any = {}

--- a/backend/src/tests/agent-rollback-authz.test.ts
+++ b/backend/src/tests/agent-rollback-authz.test.ts
@@ -1,0 +1,95 @@
+// SEC (audit/perms-authz) — the config-rollback route is owner-gated.
+//
+// `POST /api/revisions/:id/rollback` restores a prior agent snapshot, and the
+// restored field set includes `permissions` (capability caps) plus `role`,
+// `status`, `llmProvider/llmModel`, `reportsTo` — every one an OWNER-gated field
+// on the sibling write routes. The route carries no `:orgId`, so it ran behind
+// only the surface-wide MEMBER membership gate: a plain member could pick any
+// revision and revert it, defeating the owner gate on the permissions write this
+// audit hardened (owner tightens caps → member rolls the tightening back to the
+// prior allow-all snapshot). The fix enforces OWNER in-handler off `rev.orgId`.
+//
+// These drive the REAL handler against a REAL SQLite file.
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+const tmp = mkdtempSync(join(tmpdir(), 'ag-rollback-'))
+process.env.DATABASE_URL = `file:${join(tmp, 'test.db')}`
+delete process.env.DATABASE_AUTH_TOKEN
+
+const { db, schema } = await import('../db/client')
+const { setupDatabase } = await import('../db/setup')
+const { agentRoutes } = await import('../routes/all')
+const { eq } = await import('drizzle-orm')
+
+const ORG = 'org-rb', OWNER = 'user-owner-rb', MEMBER = 'user-member-rb', AGENT = 'agent-rb'
+
+let app: FastifyInstance
+
+function appAs(userId: string) {
+  const a = Fastify({ logger: false })
+  a.addHook('onRequest', async (req) => { (req as any).auth = { userId }; (req as any).userId = userId })
+  a.register(agentRoutes)
+  return a
+}
+
+const permsOf = async (id: string) => (await db.query.agents.findFirst({ where: eq(schema.agents.id, id) }))!.permissions
+
+// A revision whose `before` snapshot carries a LOOSER permissions state (allow-all)
+// than the agent's current tightened caps — the exact shape an owner tightening
+// produces, and the payload a member-driven rollback would use to escalate.
+async function seedLooseRevision(): Promise<string> {
+  const revId = randomUUID()
+  await db.insert(schema.configRevisions).values({
+    id: revId, orgId: ORG, entity: 'agent', entityId: AGENT,
+    before: JSON.stringify({ permissions: JSON.stringify([]), role: 'Analyst' }),        // allow-all
+    after: JSON.stringify({ permissions: JSON.stringify(['memory:write']), role: 'Analyst' }),
+    actor: OWNER, createdAt: new Date(),
+  } as any)
+  return revId
+}
+
+before(async () => {
+  await setupDatabase()
+  const now = new Date()
+  await db.insert(schema.organisations).values([{ id: ORG, name: 'Sevenei', ownerId: OWNER, createdAt: now }] as any)
+  await db.insert(schema.orgMembers).values([
+    { id: randomUUID(), orgId: ORG, userId: OWNER, role: 'owner', createdAt: now },
+    { id: randomUUID(), orgId: ORG, userId: MEMBER, role: 'member', createdAt: now },
+  ] as any)
+  await db.insert(schema.agents).values([
+    // Agent currently tightened to a single cap; rollback would widen it to allow-all.
+    { id: AGENT, orgId: ORG, name: 'Vera', role: 'Analyst', skills: [], runtime: 'internal', permissions: JSON.stringify(['memory:write']), createdAt: now },
+  ] as any)
+  app = appAs(OWNER)
+  await app.ready()
+})
+
+after(async () => {
+  await app?.close()
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+test('[ROLLBACK-AUTHZ] a non-owner MEMBER cannot roll back an agent revision → 403, permissions unchanged', async () => {
+  const revId = await seedLooseRevision()
+  const before = await permsOf(AGENT)
+  const member = appAs(MEMBER)
+  await member.ready()
+  const res = await member.inject({ method: 'POST', url: `/api/revisions/${revId}/rollback`, payload: {} })
+  assert.equal(res.statusCode, 403, res.body)
+  assert.equal(await permsOf(AGENT), before, 'a refused rollback must not restore the looser (allow-all) caps')
+  await member.close()
+})
+
+test('[ROLLBACK-AUTHZ] an OWNER can still roll back → 200, snapshot restored', async () => {
+  const revId = await seedLooseRevision()
+  const res = await app.inject({ method: 'POST', url: `/api/revisions/${revId}/rollback`, payload: {} })
+  assert.equal(res.statusCode, 200, res.body)
+  assert.ok(res.json().restored.includes('permissions'), 'the owner rollback restores the permissions field')
+  assert.equal(await permsOf(AGENT), JSON.stringify([]), 'owner rollback restored the allow-all snapshot')
+})


### PR DESCRIPTION
## What

Independent security audit of PR #306 (`fix-agent-permissions-authz`) surfaced one **HIGH residual** the PR does not close. This stacks on #306 to close it.

## The residual

#306 correctly closes the **direct** member-writable permissions vector:
- new `PUT /api/orgs/:orgId/agents/:agentId/permissions` is `requireOrgRole('owner')` + validated (verified it 403s a member and is **not** the R-4 no-op trap — the `:orgId` path lets `requireOrgRole` read the org),
- the legacy `PATCH /api/agents/:agentId` strips `permissions`,
- no other create/clone/config/trust/model-profile route lets a member set an existing agent's caps.

**But** `POST /api/revisions/:id/rollback` restores a prior agent snapshot, and the restored field set includes `permissions` — plus `role`, `status`, `llmProvider/llmModel`, `reportsTo`, every one an OWNER-gated field on the sibling write routes. The route carries no `:orgId`, so it ran behind only the surface-wide **MEMBER** membership gate (`requireOrgMembership`).

### Exploit
1. Owner tightens agent Vera's caps from allow-all `[]` → `['memory:write']` via the new owner route. This writes a `config_revisions` row whose `before` snapshot = the looser allow-all state.
2. A plain **member** calls `GET /api/orgs/:orgId/revisions` (member-readable), picks that revision, and `POST /api/revisions/:id/rollback`.
3. The handler restores `permissions` from `before` → Vera is back to unrestricted. A non-owner just widened a safety-critical cap the owner restricted.

Bounded to historical values (not arbitrary), but a prior *looser* value is exactly the escalation, and every owner tightening reliably produces such a revision — so the new owner gate is trivially reversible without this fix. The same route also lets a member revert `role`/`status`/`llmModel`, bypassing the config/trust/model-profile owner gates.

## Fix

Enforce OWNER in-handler off `rev.orgId`. The path has no `:orgId`, so a `requireOrgRole` preHandler would silently no-op (the R-4 trap the sibling routes were re-pathed to avoid); deriving the org from the loaded revision row and calling `enforceOrgRole` mirrors how multi-org transfer/clone guard their data-derived org.

- Non-member: still 403 (unchanged).
- Member: now 403 (was: full rollback).
- Owner: still 200, snapshot restored.

Existing `membership-scoping.test.ts` unaffected — its "member NOT blocked" loop deliberately excludes rollback; its non-member loop only asserts 403, which owner-gating preserves.

## Tests
- New `agent-rollback-authz.test.ts`: member→403 (caps unchanged), owner→200 (snapshot restored).
- Full backend suite green (1422/1422), `tsc --noEmit` clean.

Do **not** merge without review. A broader alternative is to re-path rollback to `/api/orgs/:orgId/revisions/:id/rollback` for a preHandler gate + update the web/mobile callers; the in-handler check is the minimal, client-compatible closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)