### PR TITLE
fix(CONN-4a): parity tripwire is subset, not equality — backend may lead client

### DIFF
--- a/apps/mobile/src/agentConnectors.test.ts
+++ b/apps/mobile/src/agentConnectors.test.ts
@@ -102,16 +102,23 @@ test('[CONN-3] every non-available connector carries an honest note pointing at 
   }
 })
 
-// ─── Backend parity tripwire: client "available" set == backend AGENT_CONNECTORS ─
-
-test('[CONN-3] AVAILABLE_CONNECTOR_IDS matches the backend AGENT_CONNECTORS catalog', () => {
+// ─── Backend parity tripwire: client "available" set ⊆ backend AGENT_CONNECTORS ─
+//
+// A SUBSET check, not equality: the backend legitimately LEADS the client (a
+// connector ships in the backend catalog at its CONN-Na stage; the client enables
+// the row in the following CONN-Nb — github/jira land in the backend at CONN-4a, the
+// phone rows at CONN-4b). The dangerous drift is the other direction — the phone
+// offering a connectorId the backend lacks would POST an unknown id and 404 — and
+// THAT is what this fails on. Mirrors web/lib/agentConnectors.test.ts.
+test('[CONN-3] AVAILABLE_CONNECTOR_IDS is a subset of the backend AGENT_CONNECTORS catalog', () => {
   const src = readFileSync(new URL('../../../backend/src/services/agent-connectors.ts', import.meta.url), 'utf8')
   const block = /AGENT_CONNECTORS[^=]*=\s*\[([\s\S]*?)\n\]/.exec(src)
   assert.ok(block, 'could not locate the AGENT_CONNECTORS array in the backend source')
   const backendIds = [...block![1].matchAll(/id:\s*'([^']+)'/g)].map((m) => m[1])
   assert.ok(backendIds.length > 0, 'backend catalog parsed empty — parity check would be vacuous')
-  assert.deepEqual([...AVAILABLE_CONNECTOR_IDS].sort(), [...backendIds].sort(),
-    'client "available" connectors drifted from the backend catalog — reconcile before merging')
+  const offeredButUnserved = [...AVAILABLE_CONNECTOR_IDS].filter((id) => !backendIds.includes(id))
+  assert.deepEqual(offeredButUnserved, [],
+    'phone offers a connector the backend catalog lacks — it would 404; reconcile before merging')
 })
 
 // ─── Masked-only display: the read state carries no credential ────────────────

--- a/web/lib/agentConnectors.test.ts
+++ b/web/lib/agentConnectors.test.ts
@@ -41,20 +41,26 @@ test('[CONN-2] every non-available connector carries an honest note pointing at 
   }
 })
 
-// ─── Parity tripwire: the client "available" set == backend AGENT_CONNECTORS ──
+// ─── Parity tripwire: the client "available" set ⊆ backend AGENT_CONNECTORS ───
 //
 // The client catalog is hand-copied (Next.js can't import backend source that
 // pulls in drizzle). Read the backend source as TEXT (dep-free) and assert the
-// two catalogs agree — the standing rule for any list copied across the boundary.
-
-test('[CONN-2] AVAILABLE_CONNECTOR_IDS matches the backend AGENT_CONNECTORS catalog', () => {
+// client can only ever offer a connector the backend actually serves. The check is
+// a SUBSET, not equality: the backend legitimately LEADS the client (a connector
+// ships in the backend catalog at its CONN-Na stage and the client enables the row
+// in the following CONN-Nb stage — e.g. github/jira land in the backend at CONN-4a,
+// the client rows at CONN-4b). The dangerous drift is the other direction — a client
+// offering a connectorId the backend lacks would POST to an unknown id and 404 —
+// and THAT is what this fails on.
+test('[CONN-2] AVAILABLE_CONNECTOR_IDS is a subset of the backend AGENT_CONNECTORS catalog', () => {
   const src = readFileSync(new URL('../../backend/src/services/agent-connectors.ts', import.meta.url), 'utf8')
   const block = /AGENT_CONNECTORS[^=]*=\s*\[([\s\S]*?)\n\]/.exec(src)
   assert.ok(block, 'could not locate the AGENT_CONNECTORS array in the backend source')
   const backendIds = [...block![1].matchAll(/id:\s*'([^']+)'/g)].map(m => m[1])
   assert.ok(backendIds.length > 0, 'backend catalog parsed empty — parity check would be vacuous')
-  assert.deepEqual([...AVAILABLE_CONNECTOR_IDS].sort(), [...backendIds].sort(),
-    'client "available" connectors drifted from the backend catalog — reconcile before merging')
+  const offeredButUnserved = [...AVAILABLE_CONNECTOR_IDS].filter(id => !backendIds.includes(id))
+  assert.deepEqual(offeredButUnserved, [],
+    'client offers a connector the backend catalog lacks — it would 404; reconcile before merging')
 })
 
 // ─── Masked-only display: the read state carries no credential ────────────────


### PR DESCRIPTION
## Follow-up to #311 — restore green main (Mobile CI job)

Adding `github`/`jira` to the backend `AGENT_CONNECTORS` catalog (CONN-4a, #311) turned the **Mobile CI job red on main**: the CONN-2/CONN-3 parity tripwires asserted the client's `AVAILABLE_CONNECTOR_IDS` **equals** the backend catalog. That equality is wrong for the staged plan — the backend deliberately **leads** the client (a connector ships in the backend catalog at its `CONN-Na` stage; the web/mobile rows follow at `CONN-Nb`). github/jira are backend-real at CONN-4a; the client rows are CONN-4b.

**Fix:** both tripwires (`web/lib/agentConnectors.test.ts` + `apps/mobile/src/agentConnectors.test.ts`) now assert **subset** — the client must never offer a `connectorId` the backend lacks (that would POST an unknown id and 404). The backend having *more* is normal staging. The display rows stay `coming_soon` until CONN-4b (unchanged).

- Mobile: **275/275** · typecheck clean · expo export bundles.
- Web: **234/234**.

No source/behavior change — test-guard semantics only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)