### PR TITLE
fix(CONN-7): close destructive-verb evasion in connector classifier (audit)

### DIFF
--- a/backend/src/services/connector-authz.ts
+++ b/backend/src/services/connector-authz.ts
@@ -110,7 +110,30 @@ export const CONNECTOR_ACTION_TAXONOMY: Record<string, ConnectorActionMap> = {
 
 // A verb that LOOKS destructive is forced to 'destructive' even if it isn't in the
 // explicit set — a trusted connector must never auto-approve a stray "delete_*"/"purge".
-const DESTRUCTIVE_KEYWORD = /(^|[._:\- ])(delete|destroy|drop|purge|remove|wipe|revoke|truncate)([._:\- ]|$)/
+const DESTRUCTIVE_VERBS = ['delete', 'destroy', 'drop', 'purge', 'remove', 'wipe', 'revoke', 'truncate'] as const
+const DESTRUCTIVE_SET = new Set<string>(DESTRUCTIVE_VERBS)
+
+/**
+ * Does this action contain a destructive VERB as a whole token? Fail-closed backstop:
+ * a trusted connector must never auto-approve a destructive action just because its
+ * verb wasn't in the explicit set. Tokenizes across BOTH separators (`.` `_` `:` `-`
+ * space) AND camelCase boundaries, so `delete_file`, `deleteFile`, `forceDelete`,
+ * `dropTable` and `purgeAll` all surface their destructive verb — the separator-only
+ * regex this replaces missed every camelCase / concatenated spelling, letting e.g.
+ * `deleteFile` on a trusted `auto_write` connector classify as WRITE and auto-approve.
+ * Token-level (not substring) so benign words that merely CONTAIN a verb — `undelete`,
+ * `backdrop`, `dropdown`, `get_deleted_items` — are NOT swept up (over-approval only
+ * on genuine destructive verbs). Matches the ORIGINAL casing to see camelCase.
+ */
+function hasDestructiveVerb(rawAction: string): boolean {
+  const tokens = rawAction
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // split camelCase: deleteFile → "delete File"
+    .split(/[._:\-\s]+/)
+    .map(t => t.toLowerCase())
+    .filter(Boolean)
+  return tokens.some(t => DESTRUCTIVE_SET.has(t) || DESTRUCTIVE_SET.has(t.replace(/s$/, '')))
+}
+
 const WRITE_KEYWORD = /(^|[._:\- ])(send|create|update|write|push|commit|comment|post|edit|modify|upload|insert|merge|transition|reply|forward|share|add)([._:\- ]|$)/
 const READ_KEYWORD = /(^|[._:\- ])(read|get|list|search|fetch|view|download|show)([._:\- ]|$)/
 
@@ -121,14 +144,15 @@ const READ_KEYWORD = /(^|[._:\- ])(read|get|list|search|fetch|view|download|show
  * connector's `defaultClass`. An unknown connector or a blank action → 'unknown'.
  */
 export function classifyConnectorAction(connectorId: string, action: unknown): ConnectorActionClass {
-  const norm = String(action ?? '').trim().toLowerCase()
+  const raw = String(action ?? '').trim()
+  const norm = raw.toLowerCase()
   const map = CONNECTOR_ACTION_TAXONOMY[connectorId]
   if (!map) return 'unknown'          // unknown connector → fail closed
   if (!norm) return 'unknown'         // no action given → fail closed
   if (map.destructive.includes(norm)) return 'destructive'
   if (map.read.includes(norm)) return 'read'
   if (map.write.includes(norm)) return 'write'
-  if (DESTRUCTIVE_KEYWORD.test(norm)) return 'destructive'
+  if (hasDestructiveVerb(raw)) return 'destructive' // camelCase/sep-aware fail-closed backstop
   if (WRITE_KEYWORD.test(norm)) return 'write'
   if (READ_KEYWORD.test(norm)) return 'read'
   return map.defaultClass

--- a/backend/src/tests/connector-authz.test.ts
+++ b/backend/src/tests/connector-authz.test.ts
@@ -124,6 +124,29 @@ test('[CONN7-TAX] destructive keyword overrides even when not explicitly listed'
   assert.equal(classifyConnectorAction('google', 'wipe_mailbox'), 'destructive')
 })
 
+test('[CONN7-TAX] AUDIT: destructive verb survives camelCase / no-separator spelling', () => {
+  // Regression for the audit finding: the separator-only guard missed camelCase and
+  // concatenated destructive verbs, so on a defaultClass='write' connector (mcp/comms)
+  // a trusted `auto_write` pair auto-APPROVED a destructive action. Every spelling of a
+  // destructive verb must classify 'destructive' (→ always needs approval, even trusted).
+  for (const a of ['deleteFile', 'dropTable', 'purgeAll', 'wipeDatabase', 'revokeAccess',
+    'deleteAllRecords', 'forceDelete', 'hardDelete', 'bulkDrop']) {
+    assert.equal(classifyConnectorAction('mcp', a), 'destructive', `mcp '${a}' must be destructive`)
+  }
+  assert.equal(classifyConnectorAction('telegram', 'deleteMessage'), 'destructive')
+  assert.equal(classifyConnectorAction('whatsapp', 'deleteMessage'), 'destructive')
+  assert.equal(classifyConnectorAction('google_chat', 'deleteMessage'), 'destructive')
+  // …and a trusted connector STILL cannot auto-approve it (the whole point).
+  assert.equal(decideConnectorAuthorization({
+    hasCapability: true, connectorConfigured: true,
+    classification: classifyConnectorAction('mcp', 'deleteFile'), trustLevel: 'auto_write',
+  }).decision, 'needs_approval')
+  // Benign tokens that merely CONTAIN a verb are NOT swept up (token-level, not substring).
+  assert.equal(classifyConnectorAction('github', 'get_deleted_items'), 'read')
+  assert.equal(classifyConnectorAction('mcp', 'undelete'), 'write')
+  assert.equal(classifyConnectorAction('mcp', 'dropdown_options'), 'write')
+})
+
 test('[CONN7-CAP] connector capability grammar + wildcard matching', () => {
   assert.equal(connectorCapability('github'), 'connector:github')
   assert.equal(hasConnectorCapability(['connector:github'], 'github'), true)


### PR DESCRIPTION
## Security audit fix — do NOT merge without review

Independent audit of PR #317 (CONN-7 connector containment) found one **High** issue in the action classifier. This PR fixes it on a separate branch targeting `conn-7-connector-containment` (not `main`).

### Finding (High) — destructive verb evades the keyword backstop → auto-approved under trust
`classifyConnectorAction` (backend/src/services/connector-authz.ts) used a destructive-keyword guard that required a separator on **both** sides of the verb:

```
/(^|[._:\- ])(delete|destroy|drop|purge|remove|wipe|revoke|truncate)([._:\- ]|$)/
```

So every camelCase / concatenated spelling slipped through: `deleteFile`, `dropTable`, `purgeAll`, `wipeDatabase`, `revokeAccess`, `forceDelete`. On a connector whose `defaultClass` is `'write'` (`mcp`, `telegram`, `whatsapp`, `google_chat`) the verb then classified as **WRITE**, and a trusted (`auto_write`) `(agent, connector)` pair **auto-approved** it — breaking the layer's core invariant that *DESTRUCTIVE actions ALWAYS require approval, even when trusted*.

`mcp` is the worst case: empty explicit action lists, fully opaque, and camelCase tool names are ubiquitous in MCP servers — so the destructive gate rested entirely on this regex.

Confirmed by repro before the fix:
```
mcp   deleteFile     write  allow   <-- destructive, auto-approved
mcp   dropTable      write  allow
mcp   purgeAll       write  allow
telegram deleteMessage write allow
```

> Note: no execution path consumes `authorizeConnectorAction` yet (CONN-8 is unbuilt; the only caller is the owner-gated `/authorize` preview route), so this was **latent policy** — but it ships asserted-correct and CONN-8 would inherit it.

### Fix
Replace the separator-only regex with `hasDestructiveVerb()`, which tokenizes across **separators AND camelCase boundaries** and matches a destructive verb as a whole **token** (not a substring). Runs against the original casing so camelCase boundaries are visible. Token-level matching means benign words that merely *contain* a verb — `undelete`, `backdrop`, `dropdown`, `get_deleted_items` — are **not** swept up. Over-classifies only genuine destructive verbs → fail-safe (extra approval, never fewer).

### Verification
- New regression test `[CONN7-TAX] AUDIT: destructive verb survives camelCase / no-separator spelling`
- `cd backend && npm test` → **1508 pass / 0 fail**; `npm run typecheck` clean
- All camelCase destructive verbs now classify `destructive` → `needs_approval` even under `auto_write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)