### PR TITLE
fix(APPR-1 audit): allow x-arturita-session at CORS preflight — the desk's step-up is unreachable from a browser without it

### DIFF
--- a/backend/src/middleware/cors.ts
+++ b/backend/src/middleware/cors.ts
@@ -15,6 +15,30 @@
 /** Every HTTP verb the API exposes to a browser. */
 export const CORS_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'] as const
 
+/**
+ * Every request header a browser is allowed to send. This is a TRANSPORT
+ * allowance, not an authorization decision: a header absent from this list is
+ * refused by the BROWSER at preflight, so the request never reaches the route
+ * and the server-side gate that reads it can never fire.
+ *
+ * APPR-1 audit: `x-arturita-session` (the step-up token the decide route requires
+ * to approve a dangerous action — routes/tasks.ts) was missing here. The desk's
+ * new step-up dialog minted a real session and then sent the decide call with the
+ * header, and the browser blocked it at preflight — so the fix for "the desk
+ * cannot approve a dangerous action" was itself unreachable from a browser. The
+ * phone never hit this because React Native performs no CORS preflight, which is
+ * exactly why mirroring the phone's contract was necessary but NOT sufficient.
+ *
+ * Adding it WEAKENS NOTHING: it does not change who may approve or what the
+ * server verifies. It only lets the browser deliver a header the server already
+ * demands. Every entry here must be a header some client genuinely sends.
+ */
+export const CORS_ALLOWED_HEADERS = [
+  'Authorization',
+  'Content-Type',
+  'x-arturita-session',
+] as const
+
 export const DEFAULT_ORIGINS = [
   'http://localhost:3000',
   'http://localhost:8081',
@@ -27,8 +51,9 @@ export function corsOptions(env: NodeJS.ProcessEnv = process.env) {
     origin: env.ALLOWED_ORIGINS?.split(',').map(o => o.trim()).filter(Boolean) ?? DEFAULT_ORIGINS,
     methods: [...CORS_METHODS],
     // The dashboard sends the Clerk bearer token and JSON bodies; multipart
-    // avatar uploads let the browser set their own Content-Type boundary.
-    allowedHeaders: ['Authorization', 'Content-Type'],
+    // avatar uploads let the browser set their own Content-Type boundary. The
+    // step-up token rides in `x-arturita-session` — see CORS_ALLOWED_HEADERS.
+    allowedHeaders: [...CORS_ALLOWED_HEADERS],
     credentials: true,
   }
 }

--- a/backend/src/tests/cors.test.ts
+++ b/backend/src/tests/cors.test.ts
@@ -14,7 +14,7 @@ import cors from '@fastify/cors'
 // These tests exercise the actual preflight, not the options object, so a future
 // upgrade that changes the default cannot reintroduce the failure silently.
 
-import { CORS_METHODS, DEFAULT_ORIGINS, corsOptions } from '../middleware/cors'
+import { CORS_METHODS, CORS_ALLOWED_HEADERS, DEFAULT_ORIGINS, corsOptions } from '../middleware/cors'
 import { agentDetailRoutes } from '../routes/agent-detail'
 
 const ORIGIN = 'https://app.7ei.ai'
@@ -77,6 +77,55 @@ test('[AGFIX1] CORS_METHODS covers every verb the agent routes register', async 
   // Sanity: the guard is only meaningful if it actually saw the verbs at issue.
   assert.ok(seen.has('PUT') && seen.has('DELETE'))
   await app.close()
+})
+
+// ─── APPR-1 audit — the step-up header must survive preflight ────────────────
+//
+// The method bug above has an exact twin in the header axis: `allowedHeaders` is
+// an EXPLICIT list, so any custom header not named in it is refused by the
+// browser at preflight and the real request is never sent. Approving a dangerous
+// action from the desk requires `x-arturita-session` (routes/tasks.ts), so
+// omitting it made the entire web step-up flow unreachable from a browser while
+// every unit test passed — the phone was immune only because React Native does
+// no preflight.
+//
+// Note the `preflight()` helper above hardcodes 'authorization,content-type'.
+// That is why no existing test caught this: the probe never asked for the header
+// that was missing. These tests ask for the real thing.
+
+test('[APPR-1] preflight allows the x-arturita-session step-up header', async () => {
+  const app = await appWithCors()
+  const res = await app.inject({
+    method: 'OPTIONS',
+    url: '/api/orgs/o1/agents/a1/files',
+    headers: {
+      origin: ORIGIN,
+      'access-control-request-method': 'POST',
+      'access-control-request-headers': 'authorization,content-type,x-arturita-session',
+    },
+  })
+  assert.ok(res.statusCode < 300, `preflight status ${res.statusCode}`)
+  const allowed = String(res.headers['access-control-allow-headers'] ?? '')
+    .split(',').map(s => s.trim().toLowerCase())
+  assert.ok(
+    allowed.includes('x-arturita-session'),
+    'REGRESSION: the browser may not send x-arturita-session, so approving a dangerous ' +
+      'action from the desk fails at preflight — the request never reaches the step-up ' +
+      `gate. Allow-Headers was "${allowed.join(',')}".`,
+  )
+  await app.close()
+})
+
+test('[APPR-1] every header a client actually sends is in CORS_ALLOWED_HEADERS', () => {
+  // Kept as a named list rather than a source scan: web/ is a separate workspace
+  // the backend test run cannot import. Add a header here when a client starts
+  // sending one — the preflight test above proves the list is what ships.
+  for (const h of ['Authorization', 'Content-Type', 'x-arturita-session']) {
+    assert.ok(
+      (CORS_ALLOWED_HEADERS as readonly string[]).some(x => x.toLowerCase() === h.toLowerCase()),
+      `${h} is sent by a client but missing from CORS_ALLOWED_HEADERS`,
+    )
+  }
 })
 
 test('[AGFIX1] allowed origins come from ALLOWED_ORIGINS, trimmed', () => {


### PR DESCRIPTION
**Independent audit of #325 (`appr-1-web-stepup-parity`) — one CRITICAL finding, fixed here. Targets the PR branch, not `main`. Do not merge without the operator's call.**

## What #325 got right

I verified the whole APPR-1 story adversarially and it holds up. `git diff origin/main...HEAD -- backend/` is **empty**; the step-up dialog mints only after an explicit typed `APPROVE` (no auto-mint path exists); the card is cleared only on a 2xx; failures surface with `role=alert`; every caller of the decide endpoint in `web/` routes through the gate; the token never touches storage, logs, or a URL. I mutation-tested the tripwires in **both** directions — restoring the original buggy `decide()` verbatim turns all three facets red, removing a type from a client turns web+mobile red, and **adding** a type to the backend turns both clients red.

## The finding it could not have caught without a browser

The dialog mirrors the phone's MOB-4 contract exactly — same endpoint, same `{source:'desk'}` body, same header, per-approval mint. That mirroring is correct. It is also **not sufficient**, because the browser adds a constraint the phone does not have.

`corsOptions()` sets an **explicit** `allowedHeaders: ['Authorization','Content-Type']`. A custom request header absent from that list is refused by the **browser** at preflight — the real request is never sent. Verified against the real middleware, not inferred:

```
OPTIONS /api/approvals/:id/decide
Access-Control-Request-Headers: authorization,content-type,x-arturita-session
→ 204, Access-Control-Allow-Headers: Authorization, Content-Type      # dropped
```

Net effect on `main` + #325: the operator types `APPROVE`, a real session row **is** minted server-side, and then the decide request dies in the browser. `web/lib/api.ts` reports the generic transport error; `StepUpDialog`'s classifier looks for `/403/` or `/step-up/` and matches neither, so it renders as "Network error". **The desk still could not approve a dangerous action — it just failed louder.** The phone is immune because React Native performs no CORS preflight.

This is the one class of defect the builder's deferred live-browser run was the natural place to catch, and it is why I'd treat that deferral as material.

## The fix

- `CORS_ALLOWED_HEADERS` — a named export carrying the rationale, mirroring how `CORS_METHODS` was extracted after the **identical bug on the method axis** (@fastify/cors defaulting to `GET,HEAD,POST` silently broke every PUT/DELETE and read as "backend unreachable").
- Two regression tests. The existing `preflight()` helper hardcodes `'authorization,content-type'` — it never asked for the header that was missing, which is why the suite stayed green through all of this. The new test asks for the real thing. **Proven to bite:** reverting the one-line allowance turns both red.

## This weakens nothing

It does not change who may approve, what the server verifies, or any gate logic. `routes/tasks.ts`, `dangerous-approvals.ts`, and the freshness/TTL rules are untouched. It only lets the browser deliver a header the server **already demands** — without it, the gate is unreachable rather than enforced.

It does mean APPR-1 can no longer be described as client-only. If keeping that property matters more than contract uniformity, the alternative is zero-backend: the decide route already accepts a body `sessionToken` (`routes/tasks.ts:481`), so the web could send it there instead. I recommend **this** fix — the header is the primary contract and the one the phone uses, and a CORS allow-list that omits a header the API requires is a latent trap for the next client too.

**Verified:** backend 1605/1605 (+2) · evals 11/11 · tsc clean · web 258/258 · mobile 293/293. No route, schema, or authz change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)