### PR TITLE
feat(AAD-1): owner-gated soft-delete for agents + credential revocation (backend)

### DIFF
--- a/app/app/agents/[id].tsx
+++ b/app/app/agents/[id].tsx
@@ -94,7 +94,7 @@ export default function AgentDetailScreen() {
   const handleDelete = () => {
     Alert.alert('Delete Agent', `Remove ${agent?.name}?`, [
       { text: 'Cancel', style: 'cancel' },
-      { text: 'Delete', style: 'destructive', onPress: async () => { await api.agents.delete(id!); router.back() } },
+      { text: 'Delete', style: 'destructive', onPress: async () => { await api.agents.delete(agent!.orgId, id!); router.back() } },
     ])
   }
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -60,7 +60,9 @@ export const api = {
     create: (orgId: string, d: Partial<Agent>) => request<{ agent: Agent }>(`/api/orgs/${orgId}/agents`, { method: 'POST', body: JSON.stringify(d) }),
     update: (id: string, d: Partial<Agent>) => request<{ agent: Agent }>(`/api/agents/${id}`, { method: 'PATCH', body: JSON.stringify(d) }),
     setStatus: (id: string, status: string) => request(`/api/agents/${id}/status`, { method: 'PATCH', body: JSON.stringify({ status }) }),
-    delete: (id: string) => request(`/api/agents/${id}`, { method: 'DELETE' }),
+    // AAD-1: the legacy member-reachable hard-delete DELETE /api/agents/:id was retired
+    // to 410; deletion now goes through the owner-gated, org-scoped soft-delete route.
+    delete: (orgId: string, id: string) => request(`/api/orgs/${orgId}/agents/${id}`, { method: 'DELETE' }),
     templates: () => request<{ templates: Record<string, any> }>('/api/agent-templates'),
     messages: (id: string) => request<{ messages: Message[] }>(`/api/agents/${id}/messages`),
     assignSkill: (agentId: string, skillId: string) => request(`/api/agents/${agentId}/skills`, { method: 'POST', body: JSON.stringify({ skillId }) }),

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -89,6 +89,13 @@ export const agents = sqliteTable('agents', {
   cheapModelEnabled: integer('cheap_model_enabled', { mode: 'boolean' }).notNull().default(false),
   reasoningEffort: text('reasoning_effort'),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  // AAD-1 — soft delete. A deleted agent keeps its row (audit pre-image + the
+  // historical joins that render its name on past tasks) but is EXCLUDED from every
+  // enumeration/render path and can no longer act (its `apiTokenHash` is nulled and
+  // the token resolver filters `deletedAt IS NULL`). Both NULL for every existing
+  // agent → nothing changes until a delete lands. `deletedBy` is the acting user id.
+  deletedAt: integer('deleted_at', { mode: 'timestamp' }),
+  deletedBy: text('deleted_by'),
 })
 
 export const messages = sqliteTable('messages', {

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -6,7 +6,7 @@ export async function setupDatabase() {
     `CREATE TABLE IF NOT EXISTS organisations (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, logo_url TEXT, owner_id TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS departments (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, name TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS projects (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, description TEXT, created_at INTEGER NOT NULL)`,
-    `CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, role TEXT NOT NULL, personality TEXT, cv TEXT, terms_of_reference TEXT, llm_provider TEXT NOT NULL DEFAULT 'anthropic', llm_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514', skills TEXT DEFAULT '[]', status TEXT NOT NULL DEFAULT 'idle', avatar_emoji TEXT DEFAULT '🤖', agent_type TEXT NOT NULL DEFAULT 'standard', advisor_persona TEXT, memory_long_term TEXT, persona TEXT, expertise TEXT, advisor_ids TEXT, runtime TEXT NOT NULL DEFAULT 'internal', external_endpoint TEXT, api_token_hash TEXT, last_heartbeat_at INTEGER, heartbeat_status TEXT DEFAULT 'unknown', contact_channel TEXT, reports_to TEXT, title TEXT, job_description TEXT, created_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, role TEXT NOT NULL, personality TEXT, cv TEXT, terms_of_reference TEXT, llm_provider TEXT NOT NULL DEFAULT 'anthropic', llm_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514', skills TEXT DEFAULT '[]', status TEXT NOT NULL DEFAULT 'idle', avatar_emoji TEXT DEFAULT '🤖', agent_type TEXT NOT NULL DEFAULT 'standard', advisor_persona TEXT, memory_long_term TEXT, persona TEXT, expertise TEXT, advisor_ids TEXT, runtime TEXT NOT NULL DEFAULT 'internal', external_endpoint TEXT, api_token_hash TEXT, last_heartbeat_at INTEGER, heartbeat_status TEXT DEFAULT 'unknown', contact_channel TEXT, reports_to TEXT, title TEXT, job_description TEXT, deleted_at INTEGER, deleted_by TEXT, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS messages (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, task_id TEXT, role TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, org_id TEXT NOT NULL, project_id TEXT, title TEXT NOT NULL, input TEXT, output TEXT, status TEXT NOT NULL DEFAULT 'pending', priority TEXT NOT NULL DEFAULT 'medium', kanban_column TEXT DEFAULT 'todo', llm_model TEXT, tokens_used INTEGER, cost_usd REAL, duration_ms INTEGER, assigned_to TEXT, due_at INTEGER, parent_task_id TEXT, created_at INTEGER NOT NULL, completed_at INTEGER)`,
     `CREATE TABLE IF NOT EXISTS skills (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, domain TEXT NOT NULL, content TEXT NOT NULL, source TEXT NOT NULL DEFAULT 'github', github_path TEXT, org_id TEXT, last_synced_at INTEGER, created_at INTEGER NOT NULL)`,
@@ -174,6 +174,14 @@ export async function setupDatabase() {
     // 'auto_write' (owner-set) auto-approves WRITE actions for that (agent, connector);
     // DESTRUCTIVE always needs approval regardless. Additive + reversible; never a secret.
     `ALTER TABLE agent_connectors ADD COLUMN trust_level TEXT NOT NULL DEFAULT 'approval_required'`,
+    // AAD-1 — agent SOFT DELETE. Both nullable and NULL for every existing agent, so
+    // nothing changes until the owner-gated DELETE lands: `deleted_at` timestamps the
+    // deletion (read paths filter `deleted_at IS NULL`), `deleted_by` records the
+    // acting user. Additive + reversible (the row is retained for audit). NOTE: these
+    // are ALSO in the CREATE TABLE agents string above — a new column on a table whose
+    // CREATE lives before this loop must go in BOTH or fresh/test DBs miss it.
+    `ALTER TABLE agents ADD COLUMN deleted_at INTEGER`,
+    `ALTER TABLE agents ADD COLUMN deleted_by TEXT`,
   ]
   for (const sql of alterStatements) {
     try { await dbClient.execute(sql) } catch { /* column already exists */ }

--- a/backend/src/middleware/agent-token.ts
+++ b/backend/src/middleware/agent-token.ts
@@ -1,7 +1,7 @@
 import { FastifyReply, FastifyRequest } from 'fastify'
 import { createHash, randomBytes } from 'crypto'
 import { db, schema } from '../db/client'
-import { eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 
 // ─── AGENT TOKEN AUTH (MCA-EXT) ────────────────────────────────────────────
 //
@@ -36,8 +36,14 @@ export function extractBearerToken(req: FastifyRequest): string | null {
 
 export type AgentResolver = (hash: string) => Promise<typeof schema.agents.$inferSelect | null>
 
+// AAD-1: the resolver filters `deletedAt IS NULL`. The owner-gated soft delete also
+// nulls `apiTokenHash` (so the hash lookup already misses), but this is defence in
+// depth: a soft-deleted agent's row is retained, and its token must NEVER resolve —
+// the one property the old hard delete got right, kept under soft delete.
 const defaultResolver: AgentResolver = async (hash) =>
-  (await db.query.agents.findFirst({ where: eq(schema.agents.apiTokenHash, hash) })) ?? null
+  (await db.query.agents.findFirst({
+    where: and(eq(schema.agents.apiTokenHash, hash), isNull(schema.agents.deletedAt)),
+  })) ?? null
 
 /**
  * Build the agent-token onRequest hook. The resolver is injectable so tests can

--- a/backend/src/routes/agent-detail.ts
+++ b/backend/src/routes/agent-detail.ts
@@ -21,6 +21,7 @@ import { summariseAgentBudget } from '../services/agent-budget'
 import { buildStaffCards } from '../services/staff-grid'
 import { spendForScope } from '../services/budget'
 import { projectConnectorExecution } from '../services/connector-execution'
+import { revokeAgentCredentials, agentNotDeleted } from '../services/agent-deletion'
 
 /** The agent, but only if it belongs to this org. Null otherwise (→ 404). */
 export async function agentInOrg(orgId: string, agentId: string) {
@@ -37,7 +38,8 @@ export async function agentDetailRoutes(app: FastifyInstance) {
   app.get('/api/orgs/:orgId/staff', async (req) => {
     const { orgId } = req.params as { orgId: string }
     const [agents, tasks] = await Promise.all([
-      db.select().from(schema.agents).where(eq(schema.agents.orgId, orgId)),
+      // AAD-1 — the staff grid excludes soft-deleted agents.
+      db.select().from(schema.agents).where(and(eq(schema.agents.orgId, orgId), agentNotDeleted)),
       db.select({
         agentId: schema.tasks.agentId, status: schema.tasks.status, costUsd: schema.tasks.costUsd,
         tokensUsed: schema.tasks.tokensUsed, createdAt: schema.tasks.createdAt, completedAt: schema.tasks.completedAt,
@@ -266,7 +268,7 @@ export async function agentDetailRoutes(app: FastifyInstance) {
     if (!agent) return reply.code(404).send({ error: 'Agent not found' })
 
     const roster = await db.select({ id: schema.agents.id, reportsTo: schema.agents.reportsTo })
-      .from(schema.agents).where(eq(schema.agents.orgId, orgId))
+      .from(schema.agents).where(and(eq(schema.agents.orgId, orgId), agentNotDeleted))
 
     const result = validateConfigPatch((req.body ?? {}) as Record<string, unknown>, { agentId, agents: roster })
     if (result.ok === false) return reply.code(400).send({ error: result.error })
@@ -275,6 +277,67 @@ export async function agentDetailRoutes(app: FastifyInstance) {
     const after = await agentInOrg(orgId, agentId)
     await snapshot(orgId, agentId, agent, after, req)
     return { agent: after }
+  })
+
+  // ─── AAD-1 — owner-gated, org-scoped agent SOFT DELETE + credential revocation ──
+  //
+  // The legacy `DELETE /api/agents/:agentId` (routes/agents.ts) is a member-reachable
+  // HARD delete that orphans the agent's OAuth refresh tokens + secrets and writes its
+  // audit row with orgId:NULL (invisible in the org feed). This is its hardened
+  // replacement:
+  //   • owner-gated (requireOrgRole('owner')) — mirrors the config PUT above, so the
+  //     agent's two mutating surfaces share one authz story;
+  //   • org-scoped path → `requireOrgRole` actually fires (it no-ops without :orgId, the
+  //     R-4 trap) AND the audit hook records the correct orgId for free;
+  //   • SOFT delete — the row is retained for audit; read paths filter `deletedAt IS
+  //     NULL` and the token is revoked (apiTokenHash nulled + resolver filter);
+  //   • explicit credential revocation (revokeAgentCredentials) — no dangling Google
+  //     refresh token or connector secret.
+  //
+  // GC-0b gate-order note: the membership gate authorised the PRE-IMAGE via
+  // resolveRequestOrg; `agentInOrg(orgId, agentId)` re-reads the row under BOTH ids and
+  // the UPDATE's `where(and(id, orgId))` re-asserts the tenant on the row it mutates, so
+  // a cross-tenant delete cannot slip past. No agent id is read from the body.
+  app.delete('/api/orgs/:orgId/agents/:agentId', { preHandler: requireOrgRole('owner') }, async (req, reply) => {
+    const { orgId, agentId } = req.params as { orgId: string; agentId: string }
+    const agent = await agentInOrg(orgId, agentId)
+    if (!agent) return reply.code(404).send({ error: 'Agent not found' })
+    // Idempotency: a second delete is a clean 404, never a silent 204 or a 500.
+    if ((agent as any).deletedAt) return reply.code(404).send({ error: 'Agent not found' })
+
+    const userId = (req as any).auth?.userId ?? (req as any).userId ?? null
+
+    // Revoke credentials BEFORE flipping the row: if revocation throws, the agent stays
+    // visible + retryable rather than becoming a hidden agent with live tokens.
+    const cleanup = await revokeAgentCredentials(orgId, agentId)
+
+    // Soft delete: retain the row, stop it acting (null the token hash), mark it deleted.
+    const now = new Date()
+    await db.update(schema.agents)
+      .set({ deletedAt: now, deletedBy: userId, apiTokenHash: null, status: 'deleted' })
+      .where(and(eq(schema.agents.id, agentId), eq(schema.agents.orgId, orgId)))
+
+    const after = await agentInOrg(orgId, agentId)
+    await snapshot(orgId, agentId, agent, after, req)
+
+    // Explicit audit row: names WHICH agent died and WHAT was revoked, with the correct
+    // non-null orgId (visible in the org-filtered audit query). The onResponse audit
+    // hook also records a generic agent.delete for this request; this is the detailed,
+    // deterministic record the plan calls for.
+    await db.insert(schema.auditLogs).values({
+      id: randomUUID(), orgId, userId, action: 'agent.delete',
+      method: 'DELETE', path: `/api/orgs/${orgId}/agents/${agentId}`,
+      statusCode: 204, durationMs: 0,
+      metadata: {
+        agentId, agentName: agent.name,
+        oauthProvidersRevoked: cleanup.oauthProvidersRevoked,
+        secretsDeleted: cleanup.secretsDeleted,
+        connectorsDisabled: cleanup.connectorsDisabled,
+      },
+      createdAt: now,
+    }).catch(() => {})
+
+    return reply.code(204).send()
   })
 
   // Avatar upload (multipart). The image is stored as a capped data URI on the

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -385,7 +385,8 @@ export async function agentRoutes(app: FastifyInstance) {
   // wrote its audit row with orgId:NULL (invisible in the org feed). Deletion now goes
   // through the owner-gated, org-scoped SOFT delete with explicit credential revocation:
   //   DELETE /api/orgs/:orgId/agents/:agentId   (routes/agent-detail.ts)
-  // No client ever called this path (verified: no web/mobile/cli caller); it is refused
+  // No web/apps-mobile/cli caller hit this path; the frozen legacy `app/` did (its
+  // agents.delete), and has been repointed to the new route in the same PR. It is refused
   // with a 410 rather than removed, so a direct API caller gets a clear signal instead of
   // a generic 404, and the route table stays stable for boot.test. A non-member still
   // hits 403 at the membership gate before reaching here.

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -20,6 +20,7 @@ import { resolveModelProfile, buildModelProfilePatch, flattenModelOptions, parse
 import { parseLlmChain } from '../services/arturita-pipeline'
 import { parseCustomModels } from '../services/custom-model'
 import { requireOrgRole, enforceOrgRole } from '../middleware/rbac'
+import { agentNotDeleted } from '../services/agent-deletion'
 
 // ─── AGENT TEMPLATES ────────────────────────────────────────────────────────
 
@@ -72,7 +73,8 @@ export async function agentRoutes(app: FastifyInstance) {
   app.get('/api/agent-templates', async () => ({ templates: AGENT_TEMPLATES }))
   app.get('/api/orgs/:orgId/agents', async (req) => {
     const { orgId } = req.params as any
-    return { agents: await db.select().from(schema.agents).where(eq(schema.agents.orgId, orgId)) }
+    // AAD-1 — the roster read path: soft-deleted agents are excluded.
+    return { agents: await db.select().from(schema.agents).where(and(eq(schema.agents.orgId, orgId), agentNotDeleted)) }
   })
   app.post('/api/orgs/:orgId/agents', async (req, reply) => {
     const { orgId } = req.params as any
@@ -378,9 +380,17 @@ export async function agentRoutes(app: FastifyInstance) {
       return { ok: true, status }
     })
   }
-  app.delete('/api/agents/:agentId', async (req, reply) => {
-    await db.delete(schema.agents).where(eq(schema.agents.id, (req.params as any).agentId))
-    reply.code(204)
+  // AAD-1 — the legacy member-reachable HARD delete is RETIRED. It was a member-level
+  // `db.delete` that orphaned the agent's OAuth refresh tokens + agent-scoped secrets and
+  // wrote its audit row with orgId:NULL (invisible in the org feed). Deletion now goes
+  // through the owner-gated, org-scoped SOFT delete with explicit credential revocation:
+  //   DELETE /api/orgs/:orgId/agents/:agentId   (routes/agent-detail.ts)
+  // No client ever called this path (verified: no web/mobile/cli caller); it is refused
+  // with a 410 rather than removed, so a direct API caller gets a clear signal instead of
+  // a generic 404, and the route table stays stable for boot.test. A non-member still
+  // hits 403 at the membership gate before reaching here.
+  app.delete('/api/agents/:agentId', async (_req, reply) => {
+    return reply.code(410).send({ error: 'Gone. Use DELETE /api/orgs/:orgId/agents/:agentId (owner-gated).' })
   })
   app.get('/api/agents/:agentId/messages', async (req) => {
     const { agentId } = req.params as any
@@ -435,7 +445,7 @@ export async function agentRoutes(app: FastifyInstance) {
   app.get('/api/orgs/:orgId/agents/advisors', async (req) => {
     const { orgId } = req.params as any
     return { agents: await db.select().from(schema.agents)
-      .where(and(eq(schema.agents.orgId, orgId), eq(schema.agents.agentType, 'advisor'))) }
+      .where(and(eq(schema.agents.orgId, orgId), eq(schema.agents.agentType, 'advisor'), agentNotDeleted)) }
   })
   app.post('/api/orgs/:orgId/agents/propose', async (req, reply) => {
     const { orgId } = req.params as any
@@ -572,7 +582,7 @@ export async function agentRoutes(app: FastifyInstance) {
     // Propose path → ask the LLM to design an agent from the prompt + org chart.
     if (!body.prompt) return reply.code(400).send({ error: 'prompt is required' })
     const agents = await db.select({ id: schema.agents.id, name: schema.agents.name, role: schema.agents.role, title: schema.agents.title })
-      .from(schema.agents).where(eq(schema.agents.orgId, orgId))
+      .from(schema.agents).where(and(eq(schema.agents.orgId, orgId), agentNotDeleted))
     const { system, user } = buildHirePrompt(body.prompt, org, agents)
     let out = ''
     await streamLLM({ provider: 'anthropic', model: 'claude-sonnet-4-20250514', system, messages: [{ role: 'user', content: user }], maxTokens: 1024, onToken: (t) => { out += t } })
@@ -587,7 +597,7 @@ export async function agentRoutes(app: FastifyInstance) {
     const { orgId } = req.params as any
     const now = Date.now()
     const userId = (req as any).userId ?? 'anon'
-    const agents = await db.select().from(schema.agents).where(eq(schema.agents.orgId, orgId))
+    const agents = await db.select().from(schema.agents).where(and(eq(schema.agents.orgId, orgId), agentNotDeleted))
     const [rawTasks, reads] = await Promise.all([
       db.select().from(schema.tasks)
         .where(eq(schema.tasks.orgId, orgId)).orderBy(desc(schema.tasks.createdAt)).limit(200),
@@ -632,7 +642,7 @@ export async function agentRoutes(app: FastifyInstance) {
     const [org, agents] = await Promise.all([
       db.query.organisations.findFirst({ where: eq(schema.organisations.id, orgId), columns: { deployConfig: true } }),
       db.select({ id: schema.agents.id, name: schema.agents.name, llmModel: schema.agents.llmModel, llmProvider: schema.agents.llmProvider })
-        .from(schema.agents).where(eq(schema.agents.orgId, orgId)),
+        .from(schema.agents).where(and(eq(schema.agents.orgId, orgId), agentNotDeleted)),
     ])
     const { rows, warnCount } = validateRoster(agents as any)
     return {
@@ -663,7 +673,7 @@ export async function agentRoutes(app: FastifyInstance) {
     const { orgId } = req.params as any
     const now = Date.now()
     const windowStart = new Date(now - TIMELINE_WINDOW_MS)
-    const agents = await db.select().from(schema.agents).where(eq(schema.agents.orgId, orgId))
+    const agents = await db.select().from(schema.agents).where(and(eq(schema.agents.orgId, orgId), agentNotDeleted))
     const [runs, tasks] = await Promise.all([
       // Runs that touch the window: started within it, or still open (ongoing).
       db.select().from(schema.agentRuns).where(and(
@@ -693,7 +703,7 @@ export async function agentRoutes(app: FastifyInstance) {
       avatarEmoji: schema.agents.avatarEmoji, avatarUrl: schema.agents.avatarUrl,
       status: schema.agents.status, runtime: schema.agents.runtime,
       llmModel: schema.agents.llmModel, jobDescription: schema.agents.jobDescription,
-    }).from(schema.agents).where(eq(schema.agents.orgId, orgId))
+    }).from(schema.agents).where(and(eq(schema.agents.orgId, orgId), agentNotDeleted))
     // `agents` is the flat roster: the canvas derives its own tree (web/lib/orgLayout)
     // so layout and cycle-breaking are testable client-side. `tree` stays for callers
     // that want the nesting done for them.

--- a/backend/src/services/adapter-registry.ts
+++ b/backend/src/services/adapter-registry.ts
@@ -237,7 +237,7 @@ const ADAPTERS: AdapterEntry[] = [
       { key: 'model', type: 'string', description: 'Grok model id.' },
     ],
     example: { workdir: '/Users/you/checkout', model: 'grok-latest' },
-    note: 'Declared, not built. The API flavour is covered today by openai_generic via the LLM router.',
+    note: 'Declared, not built. The API flavour is reachable today via openai_generic — the operator points that adapter\'s host-side base URL at xAI\'s OpenAI-compatible endpoint; Mission Control makes no outbound call (dispatch stays pull-based). NOT via the LLM router — it has no xAI provider.',
   },
   {
     type: 'internal',

--- a/backend/src/services/agent-deletion.ts
+++ b/backend/src/services/agent-deletion.ts
@@ -1,0 +1,86 @@
+// AAD-1 — credential revocation for agent delete.
+//
+// Deleting an agent must not leave live credentials dangling. libSQL foreign keys are
+// OFF per connection and `schema.ts` declares no `references(...)`, so nothing cascades:
+// every credential an agent holds has to be revoked in explicit application code. The
+// dangerous one is `agent_oauth_tokens` — an ownerless Google REFRESH token that never
+// expires and stays valid at Google until revoked upstream.
+//
+// This helper is the single place that enumerates what a live agent holds. It is
+// deliberately a pure service (no route/req coupling) so the delete route and its tests
+// share one revocation path — the same reason `allSecretFieldKeys()` is the one source
+// of truth for audit redaction.
+
+import { db, schema } from '../db/client'
+import { and, eq, isNull } from 'drizzle-orm'
+import { deleteAgentGoogleToken } from './agent-google-auth'
+
+/**
+ * The reusable "not soft-deleted" condition. EVERY enumeration/render read path over
+ * `agents` (roster, staff grid, org chart, advisor & manager pickers) `and`s this in, so
+ * a soft-deleted agent cannot re-appear in a list through a query that forgot the filter.
+ * Historical single-row joins (rendering a deleted agent's name on a past task) do NOT
+ * use it — the row is retained on purpose.
+ */
+export const agentNotDeleted = isNull(schema.agents.deletedAt)
+
+export interface AgentCredentialCleanup {
+  /** OAuth providers whose tokens were revoked upstream (best-effort) and purged. */
+  oauthProvidersRevoked: string[]
+  /** Pending single-use OAuth state rows dropped. */
+  oauthStatesDeleted: number
+  /** Agent-scoped `secrets` rows (connector credentials) deleted. */
+  secretsDeleted: number
+  /** `agent_connectors` rows marked disabled. */
+  connectorsDisabled: number
+}
+
+const rowsAffected = (res: any): number =>
+  Number(res?.rowsAffected ?? res?.changes ?? res?.rows_affected ?? 0)
+
+/**
+ * Revoke and purge every live credential the agent holds. Local purges are AWAITED so a
+ * caller can assert them; upstream Google revocation is best-effort inside
+ * `deleteAgentGoogleToken` (a network failure there still deletes the local token row).
+ *
+ * The agent's own bearer token is NOT handled here — the delete route nulls
+ * `agents.apiTokenHash` as part of the soft-delete row write, and the token resolver
+ * also filters `deletedAt IS NULL` (middleware/agent-token.ts).
+ */
+export async function revokeAgentCredentials(orgId: string, agentId: string): Promise<AgentCredentialCleanup> {
+  // 1) Google (and any future provider) OAuth tokens — the refresh-token blast radius.
+  //    Revoke upstream + delete the encrypted row, per provider present.
+  const oauthRows = await db.select({ provider: schema.agentOauthTokens.provider })
+    .from(schema.agentOauthTokens)
+    .where(and(eq(schema.agentOauthTokens.orgId, orgId), eq(schema.agentOauthTokens.agentId, agentId)))
+  const oauthProvidersRevoked = [...new Set(oauthRows.map(r => r.provider))]
+  for (const provider of oauthProvidersRevoked) {
+    await deleteAgentGoogleToken(orgId, agentId, provider)
+  }
+  // Pending single-use CSRF/PKCE state rows — orphaned otherwise (they expire in 10min,
+  // but leave nothing behind).
+  const statesRes = await db.delete(schema.agentOauthStates)
+    .where(and(eq(schema.agentOauthStates.orgId, orgId), eq(schema.agentOauthStates.agentId, agentId)))
+
+  // 2) Agent-scoped secrets (connector credentials). NOTE the column is `scopeId`, not
+  //    `agentId` — a naive `agentId` sweep MISSES these, which is exactly how they were
+  //    orphaned by the legacy hard delete.
+  const secretsRes = await db.delete(schema.secrets)
+    .where(and(
+      eq(schema.secrets.orgId, orgId),
+      eq(schema.secrets.scope, 'agent'),
+      eq(schema.secrets.scopeId, agentId),
+    ))
+
+  // 3) Connectors — disable (retain the row for audit; its credential is now gone).
+  const connRes = await db.update(schema.agentConnectors)
+    .set({ status: 'disabled', updatedAt: new Date() })
+    .where(and(eq(schema.agentConnectors.orgId, orgId), eq(schema.agentConnectors.agentId, agentId)))
+
+  return {
+    oauthProvidersRevoked,
+    oauthStatesDeleted: rowsAffected(statesRes),
+    secretsDeleted: rowsAffected(secretsRes),
+    connectorsDisabled: rowsAffected(connRes),
+  }
+}

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -62,6 +62,13 @@ export async function executeAgentTask(opts: {
   const agent = await db.query.agents.findFirst({ where: eq(schema.agents.id, agentId) })
   if (!agent) throw new Error('Agent not found')
 
+  // ─── AAD-1 — a SOFT-DELETED agent never executes ────────────────────────────
+  // The authoritative choke point: every execution path (chat, scheduler, heartbeat
+  // wake, orchestrator delegation) resolves the agent through here, so guarding this
+  // one spot means a deleted agent can never be run even if a stale enumeration reaches
+  // it by id. Mirrors the tenant invariant below — one choke point, no per-caller check.
+  if ((agent as any).deletedAt) throw new Error('Agent has been deleted')
+
   // ─── GC-0b (audit) — THE TENANT INVARIANT, ENFORCED AT THE CHOKE POINT ──────
   //
   // A task must be executed by an agent in the TASK'S OWN ORG.

--- a/backend/src/services/agent-runtime.ts
+++ b/backend/src/services/agent-runtime.ts
@@ -28,8 +28,14 @@ export function heartbeatFreshness(last: Date | number | null | undefined, now: 
 }
 
 /** Notify an external runtime that a task is waiting. Best-effort, never throws:
- *  fires an outbound webhook the runtime (or a relay) can listen on. Telegram
- *  ping is handled separately by the comms layer when contactChannel is set. */
+ *  fires an ORG-LEVEL outbound webhook the runtime (or a relay) can listen on.
+ *  Telegram ping is handled separately by the comms layer when contactChannel is set.
+ *
+ *  NOTE: `agent.externalEndpoint` is accepted for signature symmetry but is NEVER read —
+ *  there is no per-agent push dispatch. Dispatch is entirely PULL: the agent's own poll
+ *  loop collects `assigned` tasks via GET /api/agent/tasks. This ping is only a broadcast
+ *  hint to operator-registered org webhooks; for an org with none it is a silent no-op.
+ *  (See docs/PLAN-agent-add-delete.md §2c — the unbuilt push half.) */
 export async function notifyExternalAgent(
   agent: Pick<Agent, 'id' | 'orgId' | 'name' | 'runtime' | 'externalEndpoint'>,
   task: { taskId: string; input: string },

--- a/backend/src/services/heartbeat-engine.ts
+++ b/backend/src/services/heartbeat-engine.ts
@@ -7,6 +7,7 @@ import { eq, and, inArray } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
 import { canAgentRun } from './governance'
 import { isExternalAgent, heartbeatFreshness } from './agent-runtime'
+import { agentNotDeleted } from './agent-deletion'
 
 export const ORPHAN_STALE_MS = 30 * 60 * 1000  // in_progress > 30 min = orphaned
 
@@ -45,9 +46,10 @@ export async function runHeartbeatSweep(orgId?: string): Promise<SweepResult> {
   const now = Date.now()
   const res: SweepResult = { orphansRecovered: 0, woken: 0, statusUpdated: 0 }
 
+  // AAD-1 — never sweep/wake a soft-deleted agent (the executor would refuse it anyway).
   const agents = await (orgId
-    ? db.select().from(schema.agents).where(eq(schema.agents.orgId, orgId))
-    : db.select().from(schema.agents))
+    ? db.select().from(schema.agents).where(and(eq(schema.agents.orgId, orgId), agentNotDeleted))
+    : db.select().from(schema.agents).where(agentNotDeleted))
 
   // 1. Orphan recovery — reset stuck in_progress tasks for these agents.
   const agentIds = agents.map(a => a.id)

--- a/backend/src/tests/adapter-registry.test.ts
+++ b/backend/src/tests/adapter-registry.test.ts
@@ -42,6 +42,41 @@ describe('[ONB1] adapter registry — the taxonomy', () => {
     }
   })
 
+  // ── AAD-1 — the readiness tripwire: flip an unbuilt runtime to available and CI red ──
+  it('[ADD-1] joinableAdapterTypes() is EXACTLY the four built runtimes', () => {
+    // Pins the set so the moment anyone flips openclaw_gateway / http_webhook /
+    // hermes_gateway / hermes_local / grok_local to `available: true`, this fails — a
+    // join would then be accepted for a runtime that can never be handed work (dispatch
+    // is pull-only; there is no outbound WS/Hermes/xAI client). See PLAN §2c.
+    assert.deepEqual(
+      [...joinableAdapterTypes()].sort(),
+      ['claude_code', 'cursor', 'openai_generic', 'openclaw_local'],
+      'the set of joinable (built) runtimes changed — if this is intentional, update the pin AND ship the dispatch half',
+    )
+  })
+
+  it('[ADD-1] the five requested-but-unbuilt runtimes are declared, invitable, and NOT available', () => {
+    for (const t of ['openclaw_gateway', 'http_webhook', 'hermes_gateway', 'hermes_local', 'grok_local']) {
+      const a = getAdapter(t)!
+      assert.ok(a, `missing adapter ${t}`)
+      assert.equal(a.available, false, `${t} must stay available:false until its dispatch half is built`)
+      assert.equal(a.invitable, true, `${t} stays declarable so the taxonomy is an honest map`)
+      assert.ok(!joinableAdapterTypes().includes(t), `${t} must not be joinable`)
+    }
+  })
+
+  it('[ADD-1] every unavailable adapter carries a non-empty note explaining WHY (declared ≠ available)', () => {
+    for (const a of listAdapters().filter((x) => !x.available && x.type !== 'internal')) {
+      assert.ok(a.note && a.note.trim().length > 0, `${a.type} is unavailable but has no note explaining why`)
+    }
+  })
+
+  it('[ADD-1] the pickable invariant holds: joinable = invitable && available && kind !== internal', () => {
+    const pickable = listAdapters().filter((a) => a.invitable && a.available && a.kind !== 'internal').map((a) => a.type).sort()
+    assert.deepEqual(pickable, [...joinableAdapterTypes()].sort(), 'joinableAdapterTypes drifted from the pickable definition')
+    assert.ok(!pickable.includes('internal'), 'internal must never be pickable')
+  })
+
   it('an unknown adapterType resolves to null, never a fallback', () => {
     assert.equal(getAdapter('nope'), null)
     assert.equal(getAdapter(''), null)

--- a/backend/src/tests/agent-delete.test.ts
+++ b/backend/src/tests/agent-delete.test.ts
@@ -1,0 +1,375 @@
+// ─── AAD-1 — the owner-gated, org-scoped agent SOFT DELETE ───────────────────
+//
+// DELETE /api/orgs/:orgId/agents/:agentId (routes/agent-detail.ts). Behavioural:
+// real routes, real membership + owner gate, real in-memory DB, real agent-token
+// resolver. Modelled on gc0b-agent-authz.test.ts (three identities, per-test reset).
+//
+// EVERY guard here is mutation-proven — the file plants the guard-removed shape and
+// shows it lets the exploit through, so a green assertion cannot pass for the wrong
+// reason:
+//   • the OWNER GATE — a planted copy of the handler WITHOUT requireOrgRole('owner')
+//     lets a plain member delete; the real route refuses them (403).
+//   • the TOKEN DELETED-STATE FILTER — a resolver that omits `isNull(deletedAt)` still
+//     finds the soft-deleted row by hash; the production resolver filters it out (401).
+
+import { test, before, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+process.env.DATABASE_URL = ':memory:'
+process.env.SECRETS_ENC_KEY = 'aad-agent-delete-key'
+delete process.env.MC_ENABLE_REMOTE_ONBOARDING
+
+let db: any, schema: any
+let app: FastifyInstance          // clerk-secured surface (delete + roster + orgchart + audit)
+let agentApp: FastifyInstance     // agent-token surface (the real resolver)
+let hashToken: (t: string) => string
+let requireOrgRole: any
+let agentInOrg: any
+let revokeAgentCredentials: any
+let eq: any, and: any, isNull: any
+
+const ORG_A = 'aad-org-a'
+const ORG_B = 'aad-org-b'
+const OWNER_A = 'aad-owner-a'
+const MEMBER_A = 'aad-member-a'   // plain member of ORG_A — the exploit identity
+const OWNER_B = 'aad-owner-b'
+const MEMBER_B = 'aad-member-b'
+const AGENT_A = 'aad-agent-a'     // lives in ORG_A — the delete target
+const MANAGER_A = 'aad-manager-a' // AGENT_A reportsTo this one (org-chart integrity)
+const AGENT_B = 'aad-agent-b'     // lives in ORG_B — isolation control
+const AGENT_TOKEN = 'mca_aad_agent_a_token_value_0123456789abcdef'
+
+const CREATED_AT = new Date('2020-01-01T00:00:00Z')
+
+const agentRow = (id: string, orgId: string, name: string, extra: Record<string, unknown> = {}) => ({
+  id, orgId, name, role: 'Engineer', personality: 'terse', llmProvider: 'anthropic',
+  llmModel: 'claude-sonnet-4-20250514', status: 'idle', agentType: 'standard',
+  runtime: 'internal', trustMode: 'standard', permissions: null, apiTokenHash: null,
+  deletedAt: null, deletedBy: null, createdAt: CREATED_AT, ...extra,
+})
+
+before(async () => {
+  ;({ db, schema } = await import('../db/client'))
+  await (await import('../db/setup')).setupDatabase()
+  ;({ hashToken } = await import('../middleware/agent-token'))
+  const { agentAuth } = await import('../middleware/agent-token')
+  ;({ requireOrgRole } = await import('../middleware/rbac'))
+  const { requireOrgMembership } = await import('../middleware/rbac')
+  ;({ agentInOrg } = await import('../routes/agent-detail'))
+  const { agentDetailRoutes } = await import('../routes/agent-detail')
+  ;({ revokeAgentCredentials } = await import('../services/agent-deletion'))
+  const { agentRoutes } = await import('../routes/agents')
+  const { auditLogQueryRoutes } = await import('../middleware/audit-log')
+  const { createClerkAuth } = await import('../middleware/clerk-auth')
+  const { registerJsonBodyParser } = await import('../middleware/body-parser')
+  ;({ eq, and, isNull } = await import('drizzle-orm'))
+
+  await db.insert(schema.organisations).values([
+    { id: ORG_A, name: 'Org A', ownerId: OWNER_A, createdAt: new Date() },
+    { id: ORG_B, name: 'Org B', ownerId: OWNER_B, createdAt: new Date() },
+  ])
+  await db.insert(schema.orgMembers).values([
+    { id: 'aad-o-a', orgId: ORG_A, userId: OWNER_A, role: 'owner', createdAt: new Date() },
+    { id: 'aad-m-a', orgId: ORG_A, userId: MEMBER_A, role: 'member', createdAt: new Date() },
+    { id: 'aad-o-b', orgId: ORG_B, userId: OWNER_B, role: 'owner', createdAt: new Date() },
+    { id: 'aad-m-b', orgId: ORG_B, userId: MEMBER_B, role: 'member', createdAt: new Date() },
+  ])
+
+  // ── The clerk-secured surface (mirrors index.ts: membership gate on the scope). ──
+  app = Fastify({ logger: false })
+  registerJsonBodyParser(app)
+  await app.register(async (secured) => {
+    secured.addHook('onRequest', createClerkAuth(async (token: string) => ({ sub: token })))
+    secured.addHook('preHandler', requireOrgMembership)
+    await secured.register(agentRoutes)
+    await secured.register(agentDetailRoutes)
+    await secured.register(auditLogQueryRoutes)
+
+    // PLANTED OFFENDER (mutation proof for the owner gate): the SAME soft-delete, but
+    // WITHOUT requireOrgRole('owner'). If the owner gate is what stops a member, a
+    // member must succeed HERE and be refused on the real route. Kept in-test so the
+    // "member is refused" assertion cannot pass merely because delete is broken.
+    secured.delete('/planted/orgs/:orgId/agents/:agentId', async (req: any, reply: any) => {
+      const { orgId, agentId } = req.params
+      const agent = await agentInOrg(orgId, agentId)
+      if (!agent) return reply.code(404).send({ error: 'Agent not found' })
+      await db.update(schema.agents)
+        .set({ deletedAt: new Date(), deletedBy: 'planted', status: 'deleted' })
+        .where(and(eq(schema.agents.id, agentId), eq(schema.agents.orgId, orgId)))
+      return reply.code(204).send()
+    })
+  })
+  await app.ready()
+
+  // ── The agent-token surface: the REAL production resolver against the real DB. ──
+  agentApp = Fastify({ logger: false })
+  agentApp.addHook('onRequest', agentAuth)
+  agentApp.get('/api/agent/whoami', async (req: any) => ({ agentId: req.agent?.id ?? null }))
+  await agentApp.ready()
+})
+
+const as = (user: string | null, method: string, url: string, body?: unknown) =>
+  app.inject({
+    method: method as any, url,
+    headers: {
+      ...(user ? { authorization: `Bearer ${user}` } : {}),
+      'content-type': 'application/json',
+    },
+    payload: body === undefined ? undefined : JSON.stringify(body),
+  })
+
+const whoami = (token: string) =>
+  agentApp.inject({ method: 'GET', url: '/api/agent/whoami', headers: { authorization: `Bearer ${token}` } })
+
+const row = async (id: string) =>
+  (await db.select().from(schema.agents).where(eq(schema.agents.id, id)))[0]
+
+// ── PER-TEST RESET — the load-bearing isolation tripwire (see gc0b-agent-authz). ──
+// Without it the first successful delete soft-deletes AGENT_A and every later probe
+// 404s, passing for the wrong reason and hiding exactly what this file exists to prove.
+beforeEach(async () => {
+  await db.delete(schema.agents)
+  await db.delete(schema.agentOauthTokens)
+  await db.delete(schema.agentOauthStates)
+  await db.delete(schema.secrets)
+  await db.delete(schema.agentConnectors)
+  await db.delete(schema.auditLogs)
+  await db.delete(schema.configRevisions)
+
+  await db.insert(schema.agents).values([
+    agentRow(MANAGER_A, ORG_A, 'Manager A'),
+    agentRow(AGENT_A, ORG_A, 'Agent A', { apiTokenHash: hashToken(AGENT_TOKEN), reportsTo: MANAGER_A }),
+    agentRow(AGENT_B, ORG_B, 'Agent B', { apiTokenHash: hashToken('mca_org_b_other_token_value_00000000') }),
+  ] as any)
+
+  // AGENT_A holds live credentials: a Google OAuth token, an agent-scoped secret, a
+  // connector. The OAuth token's enc value is deliberately UNDECRYPTABLE so the delete
+  // path's best-effort upstream revoke short-circuits (loadAgentGoogleToken → null) and
+  // NO real network call to Google is made — the local row-purge is what we assert.
+  const now = new Date()
+  await db.insert(schema.agentOauthTokens).values({
+    id: 'aad-tok-a', orgId: ORG_A, agentId: AGENT_A, provider: 'google',
+    accessTokenEnc: 'undecryptable-garbage', refreshTokenEnc: 'undecryptable-garbage',
+    expiresAt: new Date(now.getTime() + 3600_000), scopes: 'openid', accountEmail: 'a@x.com',
+    createdAt: now, updatedAt: now,
+  })
+  await db.insert(schema.secrets).values([
+    { id: 'aad-sec-a', orgId: ORG_A, scope: 'agent', scopeId: AGENT_A, key: 'API_KEY', valueEncrypted: 'enc', createdAt: now },
+    { id: 'aad-sec-company', orgId: ORG_A, scope: 'company', scopeId: null, key: 'COMPANY', valueEncrypted: 'enc', createdAt: now },
+    { id: 'aad-sec-b', orgId: ORG_A, scope: 'agent', scopeId: MANAGER_A, key: 'OTHER', valueEncrypted: 'enc', createdAt: now },
+  ] as any)
+  await db.insert(schema.agentConnectors).values({
+    id: 'aad-conn-a', orgId: ORG_A, agentId: AGENT_A, connectorId: 'mcp', status: 'configured',
+    secretRef: 'aad-sec-a', createdAt: now, updatedAt: now,
+  } as any)
+})
+
+// ══ PROOF THE ISOLATION IS REAL ═══════════════════════════════════════════════
+
+test('[AAD-1] per-test isolation — step 1 legitimately deletes the agent', async () => {
+  const res = await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+  assert.equal(res.statusCode, 204)
+  assert.ok((await row(AGENT_A)).deletedAt, 'the delete did not take effect')
+})
+
+test('[AAD-1] per-test isolation is real — step 2 sees a PRISTINE agent', async () => {
+  const a = await row(AGENT_A)
+  assert.equal(a.deletedAt, null, 'PER-TEST RESET IS NOT RUNNING: this suite would pass for the wrong reason')
+  assert.equal(a.apiTokenHash, hashToken(AGENT_TOKEN), 'credential state leaked across tests')
+})
+
+// ══ AUTHZ — the owner gate and cross-tenant fail-closed ═══════════════════════
+
+test('[AAD-1] a plain MEMBER cannot delete an agent (owner-gated) → 403, agent intact', async () => {
+  const res = await as(MEMBER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+  assert.equal(res.statusCode, 403)
+  assert.equal((await row(AGENT_A)).deletedAt, null, 'a member soft-deleted an agent — the owner gate is not enforcing')
+})
+
+test('[AAD-1] MUTATION PROOF: without the owner gate, that same member DELETE succeeds', async () => {
+  // The planted route is the handler MINUS requireOrgRole('owner'). A member deleting
+  // here proves the gate above is the ONLY thing stopping them — so the 403 test is
+  // load-bearing, not a coincidence of some other refusal.
+  const res = await as(MEMBER_A, 'DELETE', `/planted/orgs/${ORG_A}/agents/${AGENT_A}`)
+  assert.equal(res.statusCode, 204, 'the guard-removed shape should let a member delete — else this proves nothing')
+  assert.ok((await row(AGENT_A)).deletedAt, 'the planted handler did not delete')
+})
+
+test('[AAD-1] cross-tenant: a member of org B cannot delete org A\'s agent → 403, zero rows touched in A', async () => {
+  const res = await as(MEMBER_B, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+  assert.ok(res.statusCode === 403 || res.statusCode === 404, `expected 403/404, got ${res.statusCode}`)
+  assert.equal((await row(AGENT_A)).deletedAt, null, 'CROSS-TENANT DELETE: org A agent was soft-deleted by an outsider')
+  assert.equal((await row(AGENT_A)).apiTokenHash, hashToken(AGENT_TOKEN), 'org A agent credential was touched')
+})
+
+test('[AAD-1] cross-tenant via the OWNER of org B → 403, agent intact', async () => {
+  // Even an owner — but of the WRONG org — is refused (the membership gate fires first).
+  const res = await as(OWNER_B, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+  assert.equal(res.statusCode, 403)
+  assert.equal((await row(AGENT_A)).deletedAt, null)
+})
+
+test('[AAD-1] anonymous → 401', async () => {
+  const res = await as(null, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+  assert.equal(res.statusCode, 401)
+  assert.equal((await row(AGENT_A)).deletedAt, null)
+})
+
+test('[AAD-1] unknown agent id → 404 (no existence oracle — same shape as cross-tenant)', async () => {
+  const res = await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/does-not-exist`)
+  assert.equal(res.statusCode, 404)
+})
+
+test('[AAD-1] already-deleted → 404 (idempotent; not 500, not a silent 204)', async () => {
+  assert.equal((await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)).statusCode, 204)
+  const second = await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+  assert.equal(second.statusCode, 404, 'a second delete must be a clean 404')
+})
+
+test('[AAD-1] mass-assignment: a body supplying orgId/id/deletedBy is ignored (no writable column)', async () => {
+  const res = await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`, {
+    orgId: ORG_B, id: 'hijacked', deletedBy: 'attacker', apiTokenHash: 'a'.repeat(64),
+  })
+  assert.equal(res.statusCode, 204)
+  const a = await row(AGENT_A)
+  assert.equal(a.orgId, ORG_A, 'the DELETE body rewrote the tenant column')
+  assert.equal(a.id, AGENT_A, 'the DELETE body rewrote the primary key')
+  assert.equal(a.deletedBy, OWNER_A, 'deletedBy came from the body, not the authenticated caller')
+  assert.equal(a.apiTokenHash, null, 'the token hash must be nulled by the server, not set from the body')
+})
+
+// ══ THE LEGACY HARD-DELETE IS RETIRED ═════════════════════════════════════════
+
+test('[AAD-1] the legacy member-reachable HARD delete is retired — 410, agent NOT destroyed', async () => {
+  // A member hitting the old path must NOT hard-delete (it orphaned credentials + wrote a
+  // NULL-orgId audit row). It is refused with 410 and the row is untouched.
+  const res = await as(MEMBER_A, 'DELETE', `/api/agents/${AGENT_A}`)
+  assert.equal(res.statusCode, 410, 'the legacy hard-delete is still live — the credential-orphaning hole is open')
+  const a = await row(AGENT_A)
+  assert.ok(a, 'the legacy path hard-deleted the row')
+  assert.equal(a.deletedAt, null, 'the legacy path deleted the agent')
+  assert.equal(a.apiTokenHash, hashToken(AGENT_TOKEN), 'the legacy path touched the credential')
+})
+
+test('[AAD-1] the legacy path still 403s a NON-MEMBER (gate fires before the 410)', async () => {
+  const res = await as(MEMBER_B, 'DELETE', `/api/agents/${AGENT_A}`)
+  assert.equal(res.statusCode, 403, 'the membership gate must still refuse an outsider on the legacy path')
+})
+
+// ══ THE HAPPY PATH — soft delete + roster exclusion ═══════════════════════════
+
+test('[AAD-1] owner deletes → 204, agent soft-deleted and ABSENT from the roster read path', async () => {
+  const res = await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+  assert.equal(res.statusCode, 204)
+
+  const a = await row(AGENT_A)
+  assert.ok(a, 'the row must be RETAINED (soft delete), not hard-deleted')
+  assert.ok(a.deletedAt, 'deletedAt not set')
+  assert.equal(a.deletedBy, OWNER_A, 'deletedBy must be the acting owner')
+  assert.equal(a.status, 'deleted')
+
+  const roster = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents`)
+  const ids = JSON.parse(roster.body).agents.map((x: any) => x.id)
+  assert.ok(!ids.includes(AGENT_A), 'a soft-deleted agent still renders in the roster')
+  assert.ok(ids.includes(MANAGER_A), 'the roster dropped a live agent too')
+})
+
+// ══ CREDENTIAL REVOCATION — the security case ═════════════════════════════════
+
+test('[AAD-1] delete revokes ALL of: token hash · oauth tokens · agent secrets · connectors', async () => {
+  await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+
+  assert.equal((await row(AGENT_A)).apiTokenHash, null, 'apiTokenHash survived the delete')
+
+  const oauth = await db.select().from(schema.agentOauthTokens).where(eq(schema.agentOauthTokens.agentId, AGENT_A))
+  assert.equal(oauth.length, 0, 'agent_oauth_tokens (Google refresh token) survived — the security finding')
+
+  const agentSecrets = await db.select().from(schema.secrets)
+    .where(and(eq(schema.secrets.scope, 'agent'), eq(schema.secrets.scopeId, AGENT_A)))
+  assert.equal(agentSecrets.length, 0, 'agent-scoped secrets survived the delete')
+
+  const conn = (await db.select().from(schema.agentConnectors).where(eq(schema.agentConnectors.agentId, AGENT_A)))[0]
+  assert.equal(conn.status, 'disabled', 'agent_connectors was not disabled')
+})
+
+test('[AAD-1] revocation is SCOPED — company secrets and OTHER agents\' credentials are untouched', async () => {
+  await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+  const company = await db.select().from(schema.secrets).where(eq(schema.secrets.id, 'aad-sec-company'))
+  assert.equal(company.length, 1, 'a company-scoped secret was swept by the agent delete')
+  const otherAgentSecret = await db.select().from(schema.secrets).where(eq(schema.secrets.id, 'aad-sec-b'))
+  assert.equal(otherAgentSecret.length, 1, 'another agent\'s scoped secret was swept (scopeId precision failed)')
+  assert.equal((await row(MANAGER_A)).apiTokenHash, (await row(MANAGER_A)).apiTokenHash, 'sanity')
+  // AGENT_B (org B) is entirely untouched.
+  assert.equal((await row(AGENT_B)).deletedAt, null, 'a cross-org agent was affected')
+})
+
+// ══ THE TOKEN ACTUALLY STOPS WORKING — driven through the REAL resolver ═══════
+
+test('[AAD-1] the agent\'s bearer token works BEFORE delete and 401s AFTER (real resolver)', async () => {
+  const before = await whoami(AGENT_TOKEN)
+  assert.equal(before.statusCode, 200, 'precondition: the token must resolve before delete')
+  assert.equal(JSON.parse(before.body).agentId, AGENT_A)
+
+  await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+
+  const after = await whoami(AGENT_TOKEN)
+  assert.equal(after.statusCode, 401, 'THE SOFT-DELETE REGRESSION: the token still resolves after delete')
+})
+
+test('[AAD-1] MUTATION PROOF: the REAL resolver filters the deleted state even if the hash lingers', async () => {
+  // Soft-delete the agent but LEAVE its apiTokenHash in place, so the ONLY thing that can
+  // 401 the token through the PRODUCTION resolver (agentAuth) is `isNull(deletedAt)`. The
+  // delete route also nulls the hash; this isolates the defence-in-depth filter at
+  // agent-token.ts:40. Remove that filter and this test returns 200 — the regression the
+  // plan warns about (a soft-deleted agent's token keeps working).
+  const hash = hashToken(AGENT_TOKEN)
+  await db.update(schema.agents).set({ deletedAt: new Date() }).where(eq(schema.agents.id, AGENT_A))
+
+  // Precondition: the row is still findable by hash ALONE — so only the deleted-state
+  // filter can exclude it (else this test would prove nothing).
+  const foundByHashAlone = await db.query.agents.findFirst({ where: eq(schema.agents.apiTokenHash, hash) })
+  assert.ok(foundByHashAlone, 'precondition failed: the hash was already gone')
+
+  const res = await whoami(AGENT_TOKEN)
+  assert.equal(res.statusCode, 401, 'the REAL resolver still resolved a soft-deleted agent — the deleted-state filter is missing')
+})
+
+// ══ AUDIT + SNAPSHOT ══════════════════════════════════════════════════════════
+
+test('[AAD-1] audit: an agent.delete row lands with the correct non-null orgId, visible in the org feed, naming the agent', async () => {
+  await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+
+  // Direct: the row exists with the correct orgId (the NULL-orgId hole is closed).
+  const rows = await db.select().from(schema.auditLogs).where(eq(schema.auditLogs.action, 'agent.delete'))
+  assert.equal(rows.length, 1, 'expected exactly one explicit agent.delete audit row')
+  assert.equal(rows[0].orgId, ORG_A, 'audit row orgId is NULL/wrong — invisible in the org-scoped feed')
+  assert.equal((rows[0].metadata as any).agentId, AGENT_A, 'the audit row does not name the deleted agent')
+
+  // End-to-end: the owner-scoped audit query actually returns it.
+  const feed = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/audit-log?action=agent.delete`)
+  assert.equal(feed.statusCode, 200)
+  assert.equal(JSON.parse(feed.body).logs.length, 1, 'the deletion is not visible via the org-filtered audit query')
+})
+
+test('[AAD-1] snapshot: a config_revisions pre-image row exists for the deleted agent', async () => {
+  await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${AGENT_A}`)
+  const revs = await db.select().from(schema.configRevisions)
+    .where(and(eq(schema.configRevisions.entity, 'agent'), eq(schema.configRevisions.entityId, AGENT_A)))
+  assert.ok(revs.length >= 1, 'no config_revisions pre-image snapshot was written for the delete')
+})
+
+// ══ ORG-CHART INTEGRITY ═══════════════════════════════════════════════════════
+
+test('[AAD-1] deleting a manager does not orphan the chart — the report still renders, manager is gone', async () => {
+  // AGENT_A reportsTo MANAGER_A. Delete MANAGER_A: the chart must still render AGENT_A,
+  // and must not include the deleted manager.
+  const del = await as(OWNER_A, 'DELETE', `/api/orgs/${ORG_A}/agents/${MANAGER_A}`)
+  assert.equal(del.statusCode, 204)
+
+  const chart = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/orgchart`)
+  assert.equal(chart.statusCode, 200)
+  const ids = JSON.parse(chart.body).agents.map((x: any) => x.id)
+  assert.ok(!ids.includes(MANAGER_A), 'the deleted manager still renders in the org chart')
+  assert.ok(ids.includes(AGENT_A), 'the report was dropped from the chart when its manager was deleted')
+})

--- a/backend/src/tests/agent-delete.test.ts
+++ b/backend/src/tests/agent-delete.test.ts
@@ -335,6 +335,28 @@ test('[AAD-1] MUTATION PROOF: the REAL resolver filters the deleted state even i
   assert.equal(res.statusCode, 401, 'the REAL resolver still resolved a soft-deleted agent — the deleted-state filter is missing')
 })
 
+// ══ THE EXECUTOR BACKSTOP — a deleted agent never executes ════════════════════
+
+test('[AAD-1] executeAgentTask REFUSES a soft-deleted agent (the authoritative execution backstop)', async () => {
+  // The read-path filters keep a deleted agent out of enumerations, but the AUTHORITATIVE
+  // "never runs" guarantee is at the executor choke point (agent-executor.ts). Removing it
+  // fails no other test — this is the one that bites. The agent is EXTERNAL runtime so
+  // that IF the backstop were removed, execution would reach the network-free external
+  // dispatch branch (not an LLM call), keeping the mutation-proof run deterministic +
+  // offline; with the backstop present it throws before any of that.
+  const { executeAgentTask } = await import('../services/agent-executor')
+  await db.insert(schema.agents).values(
+    agentRow('aad-exec-del', ORG_A, 'Deleted Exec', {
+      runtime: 'openclaw', status: 'deleted', deletedAt: new Date(), deletedBy: OWNER_A,
+    }) as any,
+  )
+  await assert.rejects(
+    () => executeAgentTask({ agentId: 'aad-exec-del', taskId: 'aad-exec-task', input: 'do work' }),
+    /deleted/i,
+    'a soft-deleted agent was allowed to execute — the executor backstop at agent-executor.ts is missing',
+  )
+})
+
 // ══ AUDIT + SNAPSHOT ══════════════════════════════════════════════════════════
 
 test('[AAD-1] audit: an agent.delete row lands with the correct non-null orgId, visible in the org feed, naming the agent', async () => {

--- a/backend/src/tests/auth-scoping.test.ts
+++ b/backend/src/tests/auth-scoping.test.ts
@@ -20,6 +20,7 @@ import multipart from '@fastify/multipart'
 //     moved route returns 401, while a public webhook receiver is not gated.
 
 import { orgRoutes, agentRoutes, taskRoutes, projectRoutes, costRoutes, skillRoutes, authRoutes, credentialRoutes } from '../routes/all'
+import { agentDetailRoutes } from '../routes/agent-detail'
 import { knowledgeRoutes } from '../routes/knowledge'
 import { commsRoutes, commsWebhookRoutes } from '../routes/comms'
 import { connectorRoutes } from '../routes/connectors'
@@ -78,6 +79,7 @@ async function bootLikeIndex() {
     secured.addHook('preHandler', requireOrgMembership)
     await secured.register(orgRoutes)
     await secured.register(agentRoutes)
+    await secured.register(agentDetailRoutes)   // Epic AG + AAD-1 — per-agent detail incl. owner-gated DELETE
     await secured.register(taskRoutes)
     await secured.register(projectRoutes)
     await secured.register(costRoutes)
@@ -169,6 +171,9 @@ test('[MCA-85] no tenant-scoped route is publicly reachable outside the allowlis
   secured('GET', '/api/orgs/:orgId/notifications')
   secured('GET', '/api/agents/:agentId/memory')
   secured('DELETE', '/api/agents/:agentId/memory')
+  // AAD-1 — the owner-gated agent soft delete must be Clerk-secured (not the public
+  // legacy top-level path). A route the leak-guard cannot see is one it cannot protect.
+  secured('DELETE', '/api/orgs/:orgId/agents/:agentId')
   secured('POST', '/api/orgs/:orgId/webhooks')
   secured('GET', '/api/orgs/:orgId/usage')
   // ONB2 audit H-2 — the two routes this guard used to be blind to. Both are now

--- a/backend/src/tests/gc0b-agent-authz.test.ts
+++ b/backend/src/tests/gc0b-agent-authz.test.ts
@@ -191,6 +191,11 @@ const NOT_MEMBER_WRITABLE: Record<string, string> = {
   lastHeartbeatAt: 'runtime-owned', heartbeatStatus: 'runtime-owned',
   nextWakeAt: 'runtime-owned', heartbeatEverySec: 'runtime-owned',
   skills: 'dedicated agent-skills route', memoryLongTerm: 'dedicated /memory routes',
+  // AAD-1 soft delete — server-owned lifecycle state, written ONLY by the owner-gated
+  // DELETE /api/orgs/:orgId/agents/:agentId. A member-writable deletedAt would let a
+  // member hide (or, by nulling it, resurrect) an agent through the legacy PATCH.
+  deletedAt: 'owner-gated soft-delete lifecycle (DELETE …/agents/:agentId)',
+  deletedBy: 'owner-gated soft-delete lifecycle (DELETE …/agents/:agentId)',
 }
 
 /** The partition check, as a pure function so it can be proven on synthetic input. */

--- a/docs/PLAN-agent-add-delete.md
+++ b/docs/PLAN-agent-add-delete.md
@@ -1,0 +1,386 @@
+# PLAN — "+ Agent" onboarding entry points & "Delete Agent"
+
+> **Phase 0 — PLAN ONLY. No code written.** Produced 2026-07-20 against `main` @ `ed180bd`.
+> Companions: `docs/DESIGN-agent-onboarding.md`, `docs/RUNBOOK-agent-onboarding.md`,
+> `docs/SECURITY-posture.md`, `docs/PLAN-arturita.md` §0 (ONB1–ONB7).
+>
+> **Headline finding:** the "+ Agent" half needs **no backend work at all** — Epic ONB
+> shipped the entire invite spine and the dialog. It is a pure placement/discoverability
+> change in `web/`. The "Delete Agent" half is where the real (backend-first) work is,
+> and the existing `DELETE /api/agents/:agentId` has **five concrete gaps**, one of which
+> (orphaned third-party OAuth refresh tokens) is a security finding rather than a nit.
+
+---
+
+## 0. Three premises in the brief that the source does not support
+
+Recorded up front, because each one changes the shape of the work.
+
+| Brief said | Source says |
+|---|---|
+| "agents soft-delete columns" in `schema.ts` | **They do not exist.** `agents` (`backend/src/db/schema.ts:36-92`) has no `deletedAt`/`archived` column, and `backend/src/db/setup.ts` adds none. The seam that *does* exist is the free-text `status` column (`schema.ts:48`), which already carries `'terminated'` via the governance verbs at `backend/src/routes/agents.ts:374-380`. |
+| The DELETE route may have a cross-tenant hole | **Cross-tenant delete is already closed.** `requireOrgMembership` is installed on the whole Clerk-secured scope (`backend/src/index.ts:183`) and derives the org *from the agent row* for any `:agentId` route (`backend/src/middleware/rbac.ts:161-164`); a missing agent yields `orgId: null` → 403 fail-closed. The missing `orgId` in the delete's WHERE clause is **not** exploitable — the gate read the same row by the same id one hop earlier. The real gap is the **role level** (member, not owner). |
+| `HANDOVER.md` at repo root | Missing at root; it is `docs/HANDOVER.md`. `HANDOFF.md` exists at root. All other referenced files exist. |
+
+**Docs referenced vs present:** `docs/DESIGN-agent-onboarding.md` ✅ · `docs/RUNBOOK-agent-onboarding.md` ✅ ·
+`docs/SECURITY-posture.md` ✅ · `docs/PLAN-arturita.md` ✅ · `STATUS.md` ✅ · `HANDOFF.md` ✅ ·
+`HANDOVER.md` ❌ (→ `docs/HANDOVER.md` ✅). All named source files exist.
+
+---
+
+## 1. Gap analysis vs existing ONB
+
+### 1a. "+ Agent" — the spine is complete; only *placement* is missing
+
+**Backend — 100% reuse, zero changes required.**
+
+| Capability | Where it already lives |
+|---|---|
+| Create invite (owner-gated, returns raw token once) | `backend/src/routes/agent-invites.ts:116` |
+| List invites (never returns token or hash) | `backend/src/routes/agent-invites.ts:167` |
+| Revoke invite (idempotent) | `backend/src/routes/agent-invites.ts:179` |
+| Onboarding posture + joinable types | `backend/src/routes/agent-invites.ts:200` |
+| Public join (rate-limited, profile-gated) | `backend/src/routes/agent-invites.ts:302` |
+| One-time claim | `backend/src/routes/agent-invites.ts:443` |
+| Owner-gated approve/reject | `backend/src/routes/agent-invites.ts:242` |
+| Public adapter registry | `backend/src/routes/agent-invites.ts:554` |
+
+**Web — the dialog is complete too.** `web/app/dashboard/cockpit/InviteAgentDialog.tsx`
+already fetches `GET /api/adapters` (`:65`) + posture (`:66`), creates via
+`POST /api/orgs/:orgId/agent-invites` (`:84-86`), renders the token + onboarding prompt
++ doc URL once with copy buttons (`:100-133`), lists invites with revoke (`:95`), and
+shows an honest "public join is closed" banner when `joinEnabled === false`
+(`:109-114`, `:202-206`). The adapter picker is registry-driven:
+`pickableAdapters()` = `invitable && available && kind !== 'internal'`
+(`web/lib/invites.logic.ts:28`).
+
+**What is actually missing — discoverability, and only that.** All three creation paths
+(Hire / Invite / Add) live in one toolbar, `web/app/dashboard/CockpitPanel.tsx:263-268`,
+**inside a `{!focused && …}` guard** (`:263`; `focused = !!only`, `:222`). So they render
+only in the full Operations stack and are **suppressed in every focused section view**:
+
+- **Org** (`navModel.ts:107`, `kind: 'section'` → `CockpitPanel only={['org']}`,
+  `web/app/dashboard/page.tsx:396-397`) — `OrgChart.tsx` toolbar has Import/Export/zoom
+  only (`:183-212`). **No add affordance.**
+- **Agents** (`navModel.ts:105`, `kind: 'tab'`, `page.tsx:450-488`) — only a Staff/Table
+  view toggle (`:455-465`). `StaffGrid.tsx` renders cards, no add button. **No add affordance.**
+
+⇒ **Scope for (a): mount an existing dialog in two more places.** No new endpoint, no
+new store, no contract change. This is the cheapest half of the wave by a wide margin.
+
+### 1b. "Delete Agent" — nothing exists on the client; the server route is unhardened
+
+- **`web/app/dashboard/agent/ConfigurationTab.tsx`** (286 lines) has **no delete/archive
+  control**. Its only destructive actions are avatar removal (`:139-147`) and custom-model
+  removal (`:124-137`). Sections today: Avatar (`:160-179`), Identity (`:182-214`),
+  Adapter + model (`:217-271`), Save bar (`:273-278`).
+- **No web client role signal.** `ConfigurationTab` receives `{ orgId, agentId, getToken, onSaved? }`
+  (`:25-30`) — no role. There is no `useRole`/`isOwner` hook anywhere in `web/`; the one
+  `isOwner` (`ActivityLogSection.tsx:140`) is read out of an API response body, not shared.
+  An owner-gated Delete button therefore needs a **net-new client role source**.
+  `apps/mobile/src/agentEdit.ts:36` (`isOwnerRole()`, fail-closed — `'admin'` → false,
+  locked by `agentEdit.test.ts:254`) is the shape to copy.
+- **Reusable server pattern already exists:** the Configuration tab's own write path,
+  `PUT /api/orgs/:orgId/agents/:agentId/config` (`backend/src/routes/agent-detail.ts:263`),
+  is owner-gated + org-scoped + snapshotted. `agentInOrg()` (`agent-detail.ts:26-31`) and
+  the `config_revisions` `snapshot()` helper (`agent-detail.ts:254-258`) are directly reusable.
+- **Adjacent, already wired:** `terminate` exists in `CockpitPanel.tsx:163`'s verb union
+  and as `POST /api/agents/:agentId/terminate` (`agents.ts:374-380`) — **with no UI caller.**
+
+---
+
+## 2. Backend API contract
+
+### 2a. Invite-create for "+ Agent" — reuse verbatim, add nothing
+
+**Endpoint:** `POST /api/orgs/:orgId/agent-invites` — owner-gated
+(`requireOrgRole('owner')`, `agent-invites.ts:116`).
+
+**Payload** (all optional; `web/lib/invites.logic.ts:67-76` already builds it sparsely so
+the server owns the defaults):
+
+```jsonc
+{
+  "allowedAdapterTypes": ["claude_code"],  // omit ⇒ any joinable adapter
+  "maxUses": 1,                            // omit ⇒ DEFAULT_MAX_USES = 1 (single-use)
+  "expiresInHours": 72,                    // omit ⇒ DEFAULT_INVITE_TTL_HOURS = 72
+  "message": "…"                           // optional, ≤2000 chars
+}
+```
+
+**Defaults are invariants, not UI choices** — single-use (`agent-invites.ts:44`), 72h
+(`:40`), max 168h (`:42`), max 50 uses (`:46`). Out-of-range values are **refused, not
+clamped** (`createInvite`, `services/agent-invites.ts:131-158`).
+
+> **No parallel store. No new endpoint.** A second invite table or a "quick add" path that
+> bypasses `createInvite()` would fork the hash-only/TTL/single-use state machine — exactly
+> the drift the epic was built to prevent.
+
+**Honesty requirement carried into the new entry points:** on hosted prod
+`MC_ENABLE_REMOTE_ONBOARDING` is unset, so join/claim/doc answer a **flat 404**
+(`docs/RUNBOOK-agent-onboarding.md:28-30`). A "+ Agent" button that mints an invite the
+agent cannot yet spend must keep the dialog's existing `joinEnabled === false` banner
+(`InviteAgentDialog.tsx:109-114`, `:202-206`). **Do not hide or soften that banner to make
+the new entry point feel complete.**
+
+### 2b. Delete-agent hardening — audit of `DELETE /api/agents/:agentId`
+
+Current implementation, in full (`backend/src/routes/agents.ts:381-384`):
+
+```ts
+app.delete('/api/agents/:agentId', async (req, reply) => {
+  await db.delete(schema.agents).where(eq(schema.agents.id, (req.params as any).agentId))
+  reply.code(204)
+})
+```
+
+| # | Property | Status | Evidence |
+|---|---|---|---|
+| 1 | **Org-scoped / cross-tenant safe** | ✅ **PASS** | `requireOrgMembership` on the Clerk scope (`index.ts:183`) derives org from the agent row (`rbac.ts:161-164`); missing agent → `orgId: null` → 403 (`rbac.ts:35`). Regression-covered by the `[MCA-R4]` sweeps (`tests/membership-scoping.test.ts:264`, `:292`). |
+| 2 | **Owner-gated** | ❌ **GAP** | Baseline is `minRole: 'member'` (`rbac.ts:213`). **Any member can delete any agent in their org.** Compare `DELETE /api/orgs/:orgId` (`routes/orgs.ts:207`), which carries an explicit `requireOrgRole('owner')`. |
+| 3 | **Soft delete** | ❌ **GAP** | Hard `db.delete`. No `deletedAt` column exists (`schema.ts:36-92`). Irreversible, and it destroys the audit pre-image. |
+| 4 | **Audit-logged** | ⚠️ **GAP (records into a hole)** | `shouldAudit` returns true (`DELETE` ∈ `SENSITIVE_METHODS`, `audit-log.ts:92`) and `classifyAction` has an `agent.delete` arm (`audit-log.ts:83`). **But** the row is written with `orgId: (req.params as any)?.orgId ?? null` (`audit-log.ts:254`) — this route has no `:orgId` param, so **`audit_logs.orgId` is NULL**, and the query route filters `eq(auditLogs.orgId, orgId)` (`audit-log.ts:277`). **The record never appears in any org's audit log.** A bodiless DELETE also yields no metadata, so nothing records *which* agent died. |
+| 5 | **Credential / connector revocation** | ❌ **GAP — the security finding** | See below. |
+| 6 | **Mass-assignment (GC-0b class)** | ✅ **N/A by shape** | The handler reads only `req.params.agentId`; no body is parsed, so there is no writable-column surface. The GC-0b guards (`tests/gc0b-mass-assignment-guard.test.ts:122`, `:230`) target `db.update/insert` body sinks and correctly do not fire here. **However** the GC-0b *gate-order* lesson still applies to the redesign: `resolveRequestOrg` authorises the **pre-image**, so any new handler must re-assert org membership on the row it actually mutates. |
+| 7 | **Fail-closed on already-deleted** | ✅ **PASS, accidentally** | A second delete 403s (gate can't resolve the row), never 500s. Semantically odd (403 for "gone") but not unsafe. |
+| 8 | **Existing tests** | ❌ **NONE** | No test exercises this route. Nearest: `auth-scoping.test.ts:171` (the `/memory` sub-route), `membership-scoping.test.ts:430-455` (DELETE list — does not include it). Tenancy is covered transitively; delete **behaviour** is untested. |
+| 9 | **Any client caller** | ℹ️ None | No `web/` or `apps/mobile/` code calls it. Reachable only by direct API call today. |
+
+#### The credential-revocation gap, in detail
+
+**Good news, and it is accidental:** the agent's own bearer token dies with the row. The
+resolver keys off `agents.apiTokenHash` (`middleware/agent-token.ts:39-40`) and 401s when
+no agent resolves (`:53`) — the token has no independent storage.
+
+> ⚠️ **This is the single most important consequence of switching to soft delete.** A
+> soft-deleted agent's `apiTokenHash` stays on the row, so **its token keeps working**
+> unless `agent-token.ts:40` also filters on the not-deleted state. Soft delete without
+> that change is a *regression* against the current hard delete.
+
+**Bad news — these survive a delete today, orphaned and unrevoked:**
+
+- `agent_oauth_tokens` — `accessTokenEnc` + `refreshTokenEnc` (`schema.ts:603-604`). A live
+  **Google refresh token for a real user account**, now ownerless, invisible to every UI,
+  never expiring, and never revoked upstream at Google.
+- `secrets` where `scope='agent' AND scopeId=<agentId>` (`schema.ts:302-305`) — reachable
+  from `agent_connectors.secretRef` (`schema.ts:217`). Note the column name contains no
+  "agent", so a naive `agentId` cascade **misses it**.
+
+**No FK will help.** `references(` appears **zero** times in `schema.ts`, and no
+`PRAGMA foreign_keys` appears in `backend/src` — libSQL defaults it OFF per connection.
+Every cascade must be explicit application code.
+
+**Full blast radius — 17 orphan sites.** Direct `agentId`: `messages` (`:96`), `tasks`
+(`:105`), `agent_files` (`:197`), `agent_connectors` (`:212`), `connector_executions`
+(`:237`), `agent_runs` (`:252`), `agent_join_requests` (`:418`), `scheduled_tasks` (`:554`),
+`agent_oauth_tokens` (`:602`), `agent_oauth_states` (`:622`). Aliased: `agents.reportsTo`
+(`:70` — orphans the org chart), `agents.advisorIds` (`:58`), `tasks.assignedTo` (`:124`),
+`task_attachments.createdByAgentId` (`:152`), `task_comments.authorAgentId` (`:269`),
+`approval_requests.requestedByAgentId` (`:327`), `goals.ownerAgentId` (`:482`).
+Untyped: `secrets.scopeId` (`:303`).
+
+#### Recommended shape (Phase 1)
+
+**Add a new owner-gated, org-scoped route; do not merely patch the legacy one.**
+
+```
+DELETE /api/orgs/:orgId/agents/:agentId   { preHandler: requireOrgRole('owner') }
+```
+
+Rationale, each point load-bearing:
+
+1. **`requireOrgRole` no-ops on a path without `:orgId`** (`rbac.ts:70-71` — the documented
+   R-4 trap, and a known repo landmine). Bolting the preHandler onto the legacy top-level
+   path would enforce **nothing**. The route must be *re-pathed*, not just decorated.
+2. It mirrors the Configuration tab's existing owner-gated write path exactly
+   (`agent-detail.ts:263`), so the tab's two mutations share one authz story.
+3. It **fixes the NULL-`orgId` audit hole for free** — `audit-log.ts:254` reads
+   `req.params.orgId`, which this path now carries.
+4. `agentInOrg(orgId, agentId)` (`agent-detail.ts:26-31`) gives a real **404** for
+   already-deleted / wrong-org, replacing the current semantically-odd 403.
+
+Handler outline (Phase 1 detail, not final code):
+- `agentInOrg()` → 404 if absent.
+- **Soft delete** via the existing `status` seam (`status='deleted'`, or reuse `'terminated'`
+  — decide in Phase 1) + a new `deletedAt` column added as an **idempotent ALTER in
+  `setup.ts`**. ⚠️ Per the known `setup.ts` trap, a new column must go in the **CREATE TABLE
+  string too**, not only the ALTER loop, or fresh/test DBs break.
+- **Revoke credentials explicitly**: null `apiTokenHash`; delete `agent_oauth_tokens` rows
+  (and attempt upstream Google revocation, best-effort, non-blocking); delete
+  `secrets WHERE scope='agent' AND scopeId=agentId`; disable `agent_connectors`.
+- **Filter the token resolver** (`agent-token.ts:40`) on the not-deleted state.
+- **Snapshot** the pre-image into `config_revisions` via the existing `snapshot()` helper.
+- **Exclude deleted agents from every read path** (roster, staff grid, org chart, advisor
+  pickers, `reportsTo` resolution) — a soft delete that still renders is a bug, not a feature.
+
+**Open decision for the operator (Phase 1):** `DELETE /api/orgs/:orgId` (`orgs.ts:207-210`)
+deletes only the `organisations` row and orphans **everything** in it — the same bug at
+larger blast radius. Should the cascade helper be agent-shaped, or built reusable? *(Out of
+scope for this wave either way — flagged, not scheduled.)*
+
+### 2c. Enabling Hermes / Grok / OpenClaw-gateway — **defer all five. Verified.**
+
+I checked the dispatch half directly rather than trusting the registry notes. **The notes
+are accurate, not stale.**
+
+**The mechanism that matters: Mission Control never pushes. Dispatch is entirely PULL.**
+`agent-executor.ts:125-129` flips the task row to `assigned`; the agent's own poll loop
+collects it via `GET /api/agent/tasks?state=assigned` (`routes/agent-api.ts:325-350`),
+claims it under an atomic CAS (`:353-383`), and posts a result (`:401`). All three shipped
+adapters are stdlib poll loops on the operator's host
+(`adapters/openclaw/mc_adapter.py:244-247`, `:277-279`; `adapters/cursor/`, `adapters/claude-code/`).
+
+The one MC→agent notification, `notifyExternalAgent` (`services/agent-runtime.ts:33-48`),
+**accepts `externalEndpoint` in its signature and never reads it** (verified at
+`agent-runtime.ts:34`). It calls `fireWebhook(…, agent.orgId, …)`
+(`services/outbound-webhooks.ts:30-48`), an **org-level event broadcast** to
+operator-registered URLs — not per-agent dispatch. For an org with no webhook rows it is a
+silent no-op, and the agent learns of the task only on its next poll.
+
+| Runtime | Dispatch | Evidence |
+|---|---|---|
+| `openclaw_gateway` | **ABSENT** | **No outbound WebSocket client anywhere in `backend/src`.** `ws://`/`wss://`/`new WebSocket`/`from 'ws'` hit only registry strings (`adapter-registry.ts:119`, `:125`) and a test fixture. `@fastify/websocket` (`package.json:28`) is **inbound-only** and cannot dial out. No `ws` client dep. |
+| `hermes_gateway` | **ABSENT** | No Hermes client, no `/api/v1/runs` call, no port-8642 code. Every `hermes` hit is a registry declaration (`adapter-registry.ts:197-211`) or a test asserting unavailability (`tests/agent-invites.test.ts:147`, `tests/join-requests.test.ts:193-194`). |
+| `hermes_local` | **ABSENT** + structurally impossible | Requires MC to spawn a host process; no `spawn`/`exec` of it exists. The backend runs on Fly and does not start host processes (`adapter-registry.ts:225`). |
+| `grok_local` | **ABSENT** | No `grok`/`xai`/`x.ai` outside the registry row + tests. **The LLM router has no xAI provider** — `llm-router.ts:364-379` switches on google/anthropic/openai/deepseek/moonshot/qwen/minimax/ollama/custom only. |
+| `http_webhook` | **ABSENT** | `agents.external_endpoint` (`schema.ts:63`) is **written** on join (`join-requests.ts:335`) and create (`agents.ts:485`, `:515`) and **never read into an HTTP call**. Dead weight w.r.t. dispatch. |
+
+**`openai_generic` is the precedent — and it inverts the naive reading.** It maps to
+`runtime: 'custom'` (`adapter-registry.ts:169`), and `isExternalAgent` is true for anything
+≠ `'internal'` (`agent-runtime.ts:10-12`), so it takes the **external branch and never
+reaches `streamLLM`**. MC does **not** call the endpoint. The operator runs the same
+OpenClaw poll adapter with `MC_EXECUTOR=llm`, and the *adapter*, on the operator's host,
+calls the OpenAI-compatible endpoint (`adapters/openclaw/mc_adapter.py:131-141`, gated `:215`);
+`adapters/presets/*.env` are literally this shape. **So `openai_generic` is honest as
+`available: true` precisely because it is still pull-based** — MC makes no outbound
+connection and needs no SSRF guard. It is **not** evidence that an `http`-kind adapter can
+dispatch; `http_webhook` inverts the direction, and that direction is the unbuilt half.
+
+**ONB5 does not exist.** No `ssrf`/`test-resolution`/`health-candidates`/`isPrivateIp`
+module in `backend/src`; `docs/PLAN-arturita.md:73` marks it `deferred` and names it a
+precondition for exactly these runtimes. The nearest reusable building block is the
+MCP connector's DNS-pinned guarded client (`services/connector-mcp.ts:133`, `:186`, `:212`),
+which is scoped to MCP only. Note `fireWebhook`'s delivery has **no SSRF guard at all** —
+a bare `fetch(hook.url)` with a 10s abort (`outbound-webhooks.ts:64`) — so building push
+dispatch on that path would inherit an unguarded egress primitive.
+
+#### Recommendation: **all five stay `available: false`.**
+
+Flipping any of them would be faking availability — a join would be accepted for a runtime
+that can never be handed work. Per-runtime criteria to lift the deferral:
+
+| Runtime | Recommendation | Criteria to lift |
+|---|---|---|
+| `openclaw_gateway` | **Defer** | (1) An outbound WS client (new dep) with auth, reconnect, backpressure; (2) a per-agent dispatch path replacing the org-broadcast `notifyExternalAgent`; (3) **ONB5 SSRF guard** on the operator-supplied `url`, `wss://` enforced; (4) a worked round-trip example in the onboarding doc; (5) a real dispatch integration test. |
+| `http_webhook` | **Defer** (closest to feasible) | (1) A per-agent HTTP pusher that actually **reads** `externalEndpoint`; (2) **ONB5** — private/loopback/link-local/multicast refused, no redirect into private space, timeout + body cap, DNS-pinned (extend `connector-mcp.ts:186`); (3) retry/idempotency semantics; (4) a decision on whether push *replaces* or *supplements* the poll claim CAS. **Do not build it on the unguarded `fireWebhook` path.** |
+| `hermes_gateway` | **Defer** | Blocked on having **no Hermes install to test against**. Needs a real instance, the client, ONB5, and a worked example. The `apiKey` field is the most confusable in the flow (Hermes key ≠ MC token, `adapter-registry.ts:210`) — the doc example must be unambiguous before any join is accepted. |
+| `hermes_local` | **Defer indefinitely** | Requires MC to spawn host processes. **Not meaningful for the hosted Fly deployment at all**; only revisit under the `packaged` profile (Epic H), and then only with the CC5 denylist + CC6 host guards applied. |
+| `grok_local` | **Defer** | Needs an xAI provider in `llm-router.ts:364-379` *plus* a local CLI spawn path. **Cheaper alternative that is already true today:** an operator points `MC_LLM_BASE_URL` at xAI's OpenAI-compatible endpoint via `openai_generic`. Recommend documenting that instead of building `grok_local`. |
+
+**Two small honesty corrections worth folding into this wave (docs/comment only, no behaviour):**
+- `adapter-registry.ts:240` claims grok is "covered today by `openai_generic` **via the LLM
+  router**" — the router half is **wrong**; coverage is via the host-side adapter.
+- `agent-runtime.ts:34` takes `externalEndpoint` and never uses it, which reads as though
+  push dispatch exists. Either drop it from the signature or comment why it is inert.
+
+---
+
+## 3. Security invariants that must stay green
+
+| # | Invariant | How this wave preserves it |
+|---|---|---|
+| 1 | **Hash-only invite tokens** | Untouched. `createInvite` stores `hashToken(token)` only (`services/agent-invites.ts:168`); the raw token exists solely in the create response (`routes/agent-invites.ts:146-163`). New entry points call the **same endpoint** — no second mint path, no persistence of the raw token client-side. |
+| 2 | **No existence oracle** | Untouched. Unknown/expired/revoked/exhausted/posture-closed all collapse to one flat 404 (`agent-invites.ts:303`, `:327`, `:329`, `:342`; claim `:444-456`). No new public route is added. The *delete* route's fail-closed behaviour improves (403-for-gone → a proper org-scoped 404 that still requires membership to reach). |
+| 3 | **Owner-gated approve** | Untouched — `requireOrgRole('owner')` on approve/reject (`agent-invites.ts:242`) and the generic decide door hardened by ONB3 H-1 (`services/approval-authz.ts`). **No new decision path is introduced.** |
+| 4 | **`low_trust_review` default** | Untouched. Set by `applyJoinDecision` → `secureRegistration()` regardless of runtime (ONB invariant #3, `docs/SECURITY-posture.md:59-60`). "+ Agent" changes *where the button is*, never what approval produces. |
+| 5 | **Shell OFF by default** | Untouched. `allowShell` defaults `false` in the registry (`adapter-registry.ts:104`). No new surface writes it. |
+| 6 | **`MC_ENABLE_REMOTE_ONBOARDING` 404-gate** | **Explicitly not weakened.** New entry points reuse the dialog unchanged, including its closed-join banner (`InviteAgentDialog.tsx:109-114`, `:202-206`). The posture stays *derived*, never asserted (`services/deployment-profile.ts`). No new code reads or sets the flag. |
+| 7 | **No cross-tenant leak on delete** | Already held by the membership gate (`rbac.ts:161-164`) and **strengthened**: the new path is `/api/orgs/:orgId/agents/:agentId` with `agentInOrg()` re-asserting org on the row being mutated — closing the GC-0b gate-order class by construction rather than by luck. |
+| 8 | **Credential/connector revocation on delete** | **The net-new invariant.** Delete must null `apiTokenHash`, purge `agent_oauth_tokens` (+ best-effort upstream Google revocation), purge `secrets WHERE scope='agent' AND scopeId=agentId`, and disable `agent_connectors`. **If soft delete lands, `agent-token.ts:40` must also filter the deleted state** or the token survives — the one property the current hard delete gets right. |
+| 9 | **Adapter picker stays registry-driven** | Untouched — `pickableAdapters()` = `invitable && available && kind !== 'internal'` (`web/lib/invites.logic.ts:28`), fed by `GET /api/adapters`. New entry points reuse the same dialog; **no hardcoded runtime list is introduced.** ⚠️ Note `ConfigurationTab.tsx:17-23` has a **hardcoded `ADAPTERS` const** — pre-existing drift, flagged but out of scope. |
+| 10 | **Audit trail records the sensitive write** | **Improved.** Today `agent.delete` writes with `orgId: NULL` (`audit-log.ts:254`) and is invisible to the org-filtered query (`:277`). The org-scoped path fixes it, plus an explicit in-handler record of *which* agent, with a `config_revisions` pre-image snapshot. |
+
+---
+
+## 4. Test plan (backend-first)
+
+Convention: `node --test` via tsx, `test('[TAG] description')`, per `backend/CLAUDE.md`.
+**Invariant: zero failures + 11/11 evals.**
+
+### 4a. Registry readiness — extend `tests/adapter-registry.test.ts`
+- `[ADD-1]` `joinableAdapterTypes()` is **exactly** `['openclaw_local','claude_code','cursor','openai_generic']` — a tripwire that fails the moment anyone flips an unbuilt runtime to `available: true`.
+- `[ADD-1]` every `available: false` adapter carries a non-empty `note` explaining *why* (keeps "declared ≠ available" honest).
+- `[ADD-1]` `internal` is never invitable.
+- **Fail-closed case:** a join naming each unavailable runtime is refused with a reason (`checkInviteAccepts`, `services/agent-invites.ts:221`) — already partly covered by `tests/join-requests.test.ts:193-194`; extend to all five.
+
+### 4b. Invite create — extend `tests/agent-invites.test.ts`
+- `[ADD-2]` non-owner (member) → **403**; anonymous → **401**.
+- `[ADD-2]` defaults applied when the body is empty: `maxUses=1`, TTL 72h, `allowedAdapterTypes=null`.
+- `[ADD-2]` out-of-range TTL/uses are **refused, not clamped** (400).
+- `[ADD-2]` **hash-only:** the created row's `tokenHash ≠ token`, and no column holds the raw token.
+- `[ADD-2]` the create response is the **only** place the raw token appears — list (`:167`) never returns token or hash.
+
+### 4c. Join + claim — regression only (`tests/onb3-join-flow.test.ts`, `tests/onb4-claim.test.ts`)
+- `[ADD-3]` **posture 404-gate intact:** with `MC_ENABLE_REMOTE_ONBOARDING` unset, join *and* claim return a flat 404 — the exact byte-identical shape as an unknown invite (no oracle).
+- `[ADD-3]` approve → agent is `low_trust_review` with `apiTokenHash = NULL`.
+- `[ADD-3]` the single-use CAS still holds (existing TOCTOU test must keep passing).
+
+### 4d. Delete — **new suite `tests/agent-delete.test.ts`**, driven against a real in-memory DB
+Modelled on `tests/gc0b-agent-authz.test.ts` (three real identities, per-test isolation).
+
+| Case | Expected |
+|---|---|
+| `[ADD-4]` **non-owner** (member of the same org) deletes | **403**, agent still present — *fail-closed* |
+| `[ADD-4]` **cross-tenant**: member of org B deletes org A's agent | **403/404**, agent still present, **zero rows touched in org A** |
+| `[ADD-4]` anonymous | **401** |
+| `[ADD-4]` **already-deleted** (idempotency) | **404** (not 500, not a silent 204) |
+| `[ADD-4]` unknown agent id | **404**, indistinguishable from cross-tenant — no existence oracle |
+| `[ADD-4]` **mass-assignment**: a body supplying `orgId`/`id`/`apiTokenHash` on the DELETE | ignored entirely; **no column is writable through this route** (asserted, not assumed) |
+| `[ADD-4]` owner deletes | 200/204, agent soft-deleted and **absent from the roster read path** |
+| `[ADD-4]` **credential revocation** (the security case) | after delete: `apiTokenHash` null · `agent_oauth_tokens` rows for that agent **gone** · `secrets WHERE scope='agent' AND scopeId=agentId` **gone** · `agent_connectors` disabled |
+| `[ADD-4]` **the token actually stops working** | the agent's pre-delete bearer token → **401** on `GET /api/agent/tasks`. ⚠️ *This is the test that catches the soft-delete regression at `agent-token.ts:40`. It must be driven through the real resolver, not a mock.* |
+| `[ADD-4]` **audit** | an `agent.delete` row exists **with the correct non-null `orgId`**, is visible via the org-filtered audit query, and names the deleted agent |
+| `[ADD-4]` **snapshot** | a `config_revisions` pre-image row exists for the deleted agent |
+| `[ADD-4]` **org-chart integrity** | an agent that `reportsTo` the deleted one does not orphan the chart render |
+
+**Guard tests (they must bite):**
+- `[ADD-5]` add the new route to the `auth-scoping.test.ts` / `membership-scoping.test.ts`
+  leak-guard nets **by name** — the ONB3-H1 precedent. A route the sweep cannot see is a
+  route the sweep cannot protect.
+- `[ADD-5]` a **planted offender** (a delete handler without the owner preHandler) is
+  detected — per the repo's "prove the guard bites" discipline, and per the
+  *fixture-sized-to-the-mechanism* lesson: the fixture must be able to fail.
+
+### 4e. Web + mobile
+- `web/` — pure logic only (Node 22 `node --test`, no jest/vitest): `pickableAdapters` unchanged; a new `canDeleteAgent(role)` helper **fail-closed** (unknown/`'admin'` → false), mirroring `apps/mobile/src/agentEdit.ts:36`.
+- `cd web && npm run build` must stay clean.
+- **Mobile parity:** both features are **greenfield** on `apps/mobile` (no invite surface, no agent delete — verified). Per the standing rule, Phase 1 must state **mirrored / deferred-to-a-named-story / N/A-with-reason**. Recommended: **defer to a named MOB story** and log it in `docs/DESIGN-mobile-parity.md` — the phone is the operator's remote and destructive agent lifecycle belongs there, but it should follow the hardened backend rather than ship beside it. ⚠️ Also resolve in Phase 1 which RN tree is canonical: `apps/mobile/` (maintained) vs `app/` (legacy/frozen per root `CLAUDE.md`, but it *does* contain `app/app/agents/create.tsx` and `app/app/onboarding/index.tsx`).
+
+---
+
+## 5. Explicit non-goals for this wave
+
+1. **Flipping any adapter to `available: true`.** All five stay false; criteria documented in §2c.
+2. **Building ONB5** (SSRF-hardened reachability). It is a precondition *for* the gateway/webhook runtimes, and those are deferred.
+3. **Building push/gateway dispatch** — outbound WS client, per-agent HTTP pusher, Hermes client, grok CLI, or an xAI provider in the LLM router.
+4. **Weakening `MC_ENABLE_REMOTE_ONBOARDING`** or any posture gate, and **not** setting it on Fly. That stays an operator console action (`GO-LIVE.md`).
+5. **Org-delete cascade** (`orgs.ts:207`) — the same orphaning bug at larger blast radius. **Flagged, not scheduled.**
+6. **Refactoring the legacy `PATCH /api/agents/:agentId`** or the hardcoded `ADAPTERS` const in `ConfigurationTab.tsx:17-23`. Both are pre-existing drift; noted, out of scope.
+7. **A bulk / multi-agent delete**, and **any un-delete/restore UI** (soft delete makes recovery *possible*; a restore flow is a separate story).
+8. **Changing invite defaults** (single-use, 72h) or adding invite-template presets.
+9. **Touching `.github/workflows/`**, the live adapter (`~/.openclaw/mc-adapter/`), or any vendor console setting.
+
+---
+
+## 6. Recommended phase order
+
+| Phase | Content | Gate |
+|---|---|---|
+| **1 — backend** | New owner-gated `DELETE /api/orgs/:orgId/agents/:agentId` + soft-delete column (idempotent ALTER **and** the CREATE string) + explicit credential revocation + `agent-token.ts` deleted-state filter + audit/snapshot + the `agent-delete` suite & leak-guard entries | `npm test` zero failures · 11/11 evals · typecheck clean |
+| **2 — web "+ Agent"** | Mount the existing `InviteAgentDialog` on the **Org** section view and the **Agents** roster; keep the closed-join banner honest. No backend change. | `npm run build` clean · web tests pass |
+| **3 — web Delete** | Delete control in `ConfigurationTab`, owner-gated client-side via a new fail-closed role source, typed-name confirmation, wired to the Phase-1 route | build clean · logic tests pass |
+| **4 — mobile** | Named MOB story per the parity rule (or an explicit N/A with reason) | `npm test && npm run typecheck && npm run export` |
+
+**Every phase ships via a PR with green CI.** Branch protection is ON for `main`
+(`enforce_admins: true`, required status checks) as of `ed180bd` — `--admin` no longer
+bypasses red, and direct pushes to `main` are rejected.


### PR DESCRIPTION
Phase 1 (backend-only) of the "+ Agent / Delete Agent" wave, implementing exactly what `docs/PLAN-agent-add-delete.md` specifies. The "+ Agent" half needs zero backend (verified — the invite spine is complete); this PR is the hardened **Delete Agent** path.

## New route
```
DELETE /api/orgs/:orgId/agents/:agentId   { preHandler: requireOrgRole('owner') }
```
Org-scoped so `requireOrgRole` actually fires (it no-ops without `:orgId` — the R-4 trap) and the audit hook records the correct `orgId`. Mirrors the config PUT's authz story. Gate-order safe: `agentInOrg(orgId, agentId)` pre-check + the UPDATE's `where(and(id, orgId))` re-assert tenancy on the mutated row; no agent id is read from the body.

## What the delete now cleans up (the load-bearing safety fix)
libSQL FKs are OFF and nothing cascades, so revocation is explicit (`services/agent-deletion.ts`):
- **`apiTokenHash`** → nulled (agent can't call the agent API)
- **`agent_oauth_tokens`** → best-effort upstream Google revoke + row purge (the ownerless-refresh-token finding)
- **`agent_oauth_states`** → pending single-use rows dropped
- **`secrets` where `scope='agent' AND scopeId=agentId`** → deleted (the `scopeId` column a naive `agentId` sweep misses)
- **`agent_connectors`** → disabled

The token resolver (`agent-token.ts`) also filters `deletedAt IS NULL` (defence in depth — the one property the old hard delete got right, kept under soft delete).

## Soft delete
New nullable `deleted_at` / `deleted_by` columns — added to **both** the CREATE-TABLE string and the idempotent ALTER loop (per the `setup.ts` trap). The row is retained for audit; every enumeration/render path (roster, staff grid, org chart, advisor/manager pickers, preflight, timeline, heartbeat wake) excludes deleted agents via the shared `agentNotDeleted` condition, and `executeAgentTask` refuses a deleted agent at the single execution choke point.

## Audit
Explicit `agent.delete` row with the **correct non-null `orgId`**, naming the agent + what was revoked (fixes the `orgId:NULL` hole), plus a `config_revisions` pre-image snapshot.

## Legacy route retired
`DELETE /api/agents/:agentId` (member-reachable **hard** delete that orphaned credentials + wrote a NULL-orgId audit row) → **410 Gone** pointing at the new route. No web/apps-mobile/cli caller existed; the frozen legacy `app/` did call it and has been **repointed** to the new route in this PR. Non-members still hit 403 at the membership gate first. **Flagged for the audit session** — this closes the hole rather than merely shadowing it; trivially reversible if judged out of scope.

## Runtimes — all five stay unavailable (verified, not faked)
`joinableAdapterTypes()` is pinned to the four built runtimes by a new `[ADD-1]` tripwire; `openclaw_gateway`/`http_webhook`/`hermes_gateway`/`hermes_local`/`grok_local` stay `available:false` with documented lift criteria. Two doc/comment-only honesty corrections (grok note; `notifyExternalAgent`'s inert `externalEndpoint`). `pickable = invitable && available && !internal` re-asserted by test.

## Tests + mutation proofs
New `tests/agent-delete.test.ts` (real routes/gate/DB/token-resolver, per-test isolation). Both guards **mutation-proven**:
- **Owner gate** inverted to `member` → the member-403 test flips red (member deletes). Restored.
- **Resolver `isNull(deletedAt)` filter** removed → the "token dies after delete" test flips red (returns 200). Restored.

Plus an in-test **planted offender** (the handler minus the owner preHandler) showing a member succeeds without the gate. New route added to the `auth-scoping` leak-guard by name; membership-scoping's behavioural sweep auto-covers it. The `gc0b` completeness guard tripped on the two new columns (working as designed) and now classifies them as owner-gated lifecycle state.

## Verification
- `npm test` → **1897 pass / 0 fail**
- `npm run evals` → **11/11**
- `npm run typecheck` + `npm run build` → clean

## Mobile parity
**N/A for this PR** — backend hardening, no UI surface. Both features are greenfield on `apps/mobile`; the phone Delete mirror follows the hardened backend in a named MOB story (per plan §4e), not beside it.

## Not merging
Independent audit session runs before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
