### PR TITLE
feat(AAD-2): "+ Agent" invite entry points and owner-gated Delete Agent (web + mobile)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -7,6 +7,45 @@ _Last updated: 2026-07-18 (**FIX-1 — FOUR DEFECTS FROM A LIVE VISUAL PASS AGAI
 > protection), and the known-open follow-ups. This file is the full narrative log; that one is the
 > cold-start briefing.
 
+### 2026-07-21 — AAD-2: the "+ Agent" and "Delete agent" UI (web + mobile)
+
+Phases 2–4 of `docs/PLAN-agent-add-delete.md`, on top of AAD-1's backend (`3665a1f`).
+**Client-only: no endpoint, no schema, no gate changed.**
+
+**"+ Agent".** The shipped ONB6 `InviteAgentDialog` is now mounted where an operator
+actually looks for it — the **Agents roster** and the **Org** section — both of which
+had no add affordance at all, because all three creation buttons live in the
+Operations toolbar behind `{!focused && …}`. No second mint path, no new store; the
+dialog keeps its honest "public join is closed on this deployment" banner. The picker
+stays registry-driven, and now also **shows the five deferred runtimes** (openclaw_gateway,
+http_webhook, hermes_gateway, hermes_local, grok_local) as inert "not yet available"
+rows with the registry's own reason — they were previously just absent, which read as
+"unsupported" rather than "declared, not yet dispatchable". **None is selectable and
+none was flipped to `available: true`.** Invited agents still land `low_trust_review`
+with shell OFF (untouched — `secureRegistration()` and the registry default).
+
+**Delete agent.** A **Danger zone** at the foot of Agent Settings → Configuration, wired
+to AAD-1's owner-gated `DELETE /api/orgs/:orgId/agents/:agentId`. Typed-name confirmation,
+consequences listed (credential revocation is the part "delete" does not convey), cleared
+only on a confirmed 2xx — a 403 never renders as success (the APPR-1 lesson). On success
+the page routes back to the roster and re-reads it.
+
+**Owner gating.** New shared `useOrgRole` hook hoists the role signal the web already
+had — server-computed `isOwner` from `GET …/activity` — and `canDeleteAgent` fails closed
+(`'admin'`, unknown, null → false). Non-owners get a named note, not a button that only
+403s. The phone reuses its existing `orgRole`.
+
+**Parity: MIRRORED in the same PR.** `apps/mobile` gains the invite sheet (Agents + Org)
+and the Danger zone, over the same endpoints, with `invites.ts` / `agentDelete.ts` pinned
+against the web modules by drift tripwires. Zero-dep: RN's built-in `Share`, no clipboard
+package. **Visually verified on web** (dev server + stub backend): both entry points, the
+picker's available/not-available split, the confirm dialog, the real DELETE on the
+org-scoped path, and the control disappearing when `isOwner` is false. **Mobile is
+compile-verified only** (typecheck + 369 tests + `expo export`) — no simulator run.
+
+Backend **1898/1898** · evals 11/11 · web **333/333** + build · mobile **369/369** +
+typecheck + export. `aad-ui-web-mobile`.
+
 ### 2026-07-19 — session status: main is `17f172e`, green, nothing in flight
 
 Test, CI and Deploy all success on `17f172e`; `https://7ei-backend.fly.dev/api/health` 200,

--- a/apps/mobile/src/agentDelete.test.ts
+++ b/apps/mobile/src/agentDelete.test.ts
@@ -1,0 +1,61 @@
+// AAD-2 (mobile) — the parity tripwire for the delete decisions.
+//
+// TWO JOBS:
+//   1. CROSS-PLATFORM PARITY — import the web module directly and assert the
+//      phone's hand-copy agrees. Safe to import ONLY because
+//      `web/lib/agentDelete.ts` is dependency-free (no react, no next, no
+//      drizzle): Mobile CI installs ONLY apps/mobile's lockfile, so a web module
+//      that pulled in a dep would silently drop this whole test file in CI while
+//      passing locally (the known cross-workspace-import trap).
+//   2. BEHAVIOUR — the fail-closed rules, tested here and not only compared.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  DELETE_CONSEQUENCES, agentDeletePath, canDeleteAgent, isDeleteConfirmed,
+} from './agentDelete.ts'
+import {
+  DELETE_CONSEQUENCES as WEB_CONSEQUENCES,
+  agentDeletePath as webAgentDeletePath,
+  canDeleteAgent as webCanDeleteAgent,
+  isDeleteConfirmed as webIsDeleteConfirmed,
+} from '../../../web/lib/agentDelete.ts'
+
+test('[AAD-2] canDeleteAgent is owner-only and fails closed', () => {
+  assert.equal(canDeleteAgent('owner'), true)
+  assert.equal(canDeleteAgent('member'), false)
+  assert.equal(canDeleteAgent('admin'), false) // no such role in this model
+  assert.equal(canDeleteAgent(null), false)
+  assert.equal(canDeleteAgent(undefined), false)
+  assert.equal(canDeleteAgent(''), false)
+})
+
+test('[AAD-2] the phone and the desk agree on WHO may be offered delete', () => {
+  for (const role of ['owner', 'member', 'admin', 'Owner', '', 'viewer', null, undefined]) {
+    assert.equal(canDeleteAgent(role), webCanDeleteAgent(role), `role=${String(role)}`)
+  }
+})
+
+test('[AAD-2] the phone and the desk call the SAME org-scoped route', () => {
+  assert.equal(agentDeletePath('o1', 'a1'), '/api/orgs/o1/agents/a1')
+  assert.equal(agentDeletePath('o1', 'a1'), webAgentDeletePath('o1', 'a1'))
+})
+
+test('[AAD-2] the phone and the desk agree on the typed-name confirmation', () => {
+  const cases: [string, string][] = [
+    ['Ops', 'Ops'], ['  ops ', 'Ops'], ['OPS', 'Ops'], ['O', 'Ops'],
+    ['Ops2', 'Ops'], ['', 'Ops'], ['   ', 'Ops'], ['', ''], ['  ', '  '],
+  ]
+  for (const [typed, name] of cases) {
+    assert.equal(isDeleteConfirmed(typed, name), webIsDeleteConfirmed(typed, name), `${typed}|${name}`)
+  }
+  assert.equal(isDeleteConfirmed('Ops', 'Ops'), true)
+  assert.equal(isDeleteConfirmed('Op', 'Ops'), false)
+})
+
+test('[AAD-2] both surfaces name credential revocation, in the same words', () => {
+  assert.deepEqual([...DELETE_CONSEQUENCES], [...WEB_CONSEQUENCES])
+  const all = DELETE_CONSEQUENCES.join(' ').toLowerCase()
+  assert.ok(all.includes('revoke'))
+  assert.ok(all.includes('secret'))
+  assert.ok(all.includes('connector'))
+})

--- a/apps/mobile/src/agentDelete.ts
+++ b/apps/mobile/src/agentDelete.ts
@@ -1,0 +1,55 @@
+// AAD-2 (mobile) — the phone's copy of the desk's delete decisions.
+//
+// PARITY. Metro cannot import out of `apps/mobile` into `web/`, so this is a
+// hand-copy of `web/lib/agentDelete.ts` — and, per the standing rule, the copy is
+// PINNED: `agentDelete.test.ts` imports the web module directly and asserts the
+// two agree. A copy without a tripwire is silent drift.
+//
+// The gate is the same one the desk states: the backend route is
+//   DELETE /api/orgs/:orgId/agents/:agentId   { preHandler: requireOrgRole('owner') }
+// and the client only decides what to OFFER. Fail closed on anything that is not
+// exactly `'owner'` — same rule, and same reason, as `isOwnerRole` in agentEdit.ts.
+
+export const ORG_ROLES = ['owner', 'member'] as const
+export type OrgRole = (typeof ORG_ROLES)[number]
+
+/** Owner-only, fail-closed. The backend is still the enforcer. */
+export function canDeleteAgent(role: string | null | undefined): boolean {
+  return role === 'owner'
+}
+
+/** The ORG-SCOPED path. `requireOrgRole` no-ops on a path without `:orgId`, so
+ *  the shape of this string is a security property, not a formatting choice. */
+export function agentDeletePath(orgId: string, agentId: string): string {
+  return `/api/orgs/${orgId}/agents/${agentId}`
+}
+
+/** Typed-name confirmation — trimmed, case-insensitive, never empty, never partial. */
+export function isDeleteConfirmed(typed: string, agentName: string): boolean {
+  const want = (agentName ?? '').trim().toLowerCase()
+  const got = (typed ?? '').trim().toLowerCase()
+  return want.length > 0 && got === want
+}
+
+/** What deleting actually does — every clause a real backend behaviour. */
+export const DELETE_CONSEQUENCES = [
+  'Its API token stops working immediately — a running adapter loses access on its next call.',
+  'Its connected credentials are revoked: Google/OAuth tokens are dropped (and revoked upstream where possible), agent-scoped secrets are deleted, and its connectors are disabled.',
+  'It disappears from the roster, the staff grid and the org chart, and it can no longer be assigned or run work.',
+  'Its history is retained for the audit trail — this is a soft delete, but there is no restore in the app.',
+] as const
+
+export const DELETE_TITLE = 'Delete this agent?'
+
+export const NON_OWNER_DELETE_NOTE =
+  'Only an organisation owner can delete an agent. Ask an owner if this agent should go.'
+
+/** The phone's role can be genuinely UNKNOWN (a pasted token whose orgs were
+ *  never listed with a role) — a state the desk does not have. The phone's
+ *  established rule for that case (agentEdit.ts) is to offer the action with a
+ *  caution and let the backend 403 be the real enforcer. Deleting keeps that
+ *  rule rather than inventing a stricter one, because a stricter one would lock
+ *  a legitimate owner out of the only destructive control on the device. The
+ *  typed-name confirmation still stands in front of it. */
+export const UNKNOWN_ROLE_DELETE_NOTE =
+  'Your role in this org isn’t known on this device (you’re signed in with a pasted token). Deleting is offered, but the backend still enforces owner-only — a non-owner delete is refused there.'

--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -33,6 +33,10 @@ import type { SkillsPayload } from './agentEdit'
 // invariant it encodes: the read shape carries NO secret / token / secretRef —
 // only status + non-secret config + a derived label. A credential is WRITE-ONLY.
 import type { PublicConnectorState, ConnectorExecutionItem } from './agentConnectors'
+// AAD-2 — same rule: the adapter-registry wire shape is defined in the pure
+// module that reads it (invites.ts, itself pinned against the web's
+// invites.logic.ts), so the picker and the client agree by construction.
+import type { AdapterRegistryEntry } from './invites'
 
 export type ApiInit = RequestInit & { token?: string | null; base?: string }
 
@@ -127,6 +131,32 @@ export type Agent = {
 /** MOB-7d — a selectable model, as `GET …/available-models` returns it (web's
  *  ConfigurationTab uses the same route to populate its Model picker). */
 export type ModelOption = { id: string; label: string; provider: string; tier: string; custom?: boolean }
+
+// ─── AAD-2 — agent invites ────────────────────────────────────────────────────
+// The LIST shape. Note what is NOT here: no `token`, no `tokenHash`. The list
+// route never returns either (hash-only storage), and the client must not invent
+// a field to hold one.
+export type AgentInvite = {
+  id: string
+  status: string
+  allowedAdapterTypes: string[] | null
+  maxUses: number
+  usesRemaining: number
+  expiresAt: string
+  createdAt: string
+}
+
+/** The CREATE response — the only place the raw invite token exists, ever. It is
+ *  rendered once and never persisted on the device. `onboardingPrompt` is the
+ *  one-paste artifact; `joinEnabled` is the deployment's honest posture. */
+export type CreateInviteResult = {
+  inviteToken: string
+  onboardingTextUrl: string
+  onboardingPrompt: string
+  joinEnabled: boolean
+  onboardingDocPublic: boolean
+  invite: AgentInvite
+}
 
 /**
  * MOB-6b — a task row as the Task Log reads it. The backend returns the whole
@@ -680,6 +710,67 @@ export const Api = {
     api<{ models: ModelOption[] }>(base, `/api/orgs/${orgId}/available-models`, { token }).then(
       (r) => r.models ?? [],
     ),
+
+  // ─── AAD-2 — "+ Agent" (invite onboarding) and "Delete agent" ─────────────
+  // Both halves call the SAME routes the desk calls. Nothing about the invite
+  // spine is re-implemented here: no second mint path, no local token store, no
+  // client-side default for uses/TTL (the server owns those).
+
+  // GET /api/adapters — the PUBLIC adapter registry. The runtime picker renders
+  // FROM this, never from a hardcoded list on the device: `available: false` is
+  // the server's statement that MC cannot dispatch to that runtime, and the phone
+  // must not be able to contradict it.
+  adapters: (base: string, token: string) =>
+    api<{ adapters: AdapterRegistryEntry[] }>(base, '/api/adapters', { token }).then(
+      (r) => r.adapters ?? [],
+    ),
+
+  // GET …/onboarding-posture — owner-gated. `publicJoinEnabled === false` is the
+  // hosted reality (MC_ENABLE_REMOTE_ONBOARDING unset → join/claim 404), and the
+  // sheet SAYS so rather than pretending the invite is immediately spendable.
+  onboardingPosture: (base: string, token: string, orgId: string) =>
+    api<{ posture: { publicJoinEnabled: boolean } }>(
+      base,
+      `/api/orgs/${orgId}/onboarding-posture`,
+      { token },
+    ).then((r) => r.posture),
+
+  // GET …/agent-invites — owner-gated. NEVER returns a token or a hash.
+  agentInvites: (base: string, token: string, orgId: string) =>
+    api<{ invites: AgentInvite[] }>(base, `/api/orgs/${orgId}/agent-invites`, { token }).then(
+      (r) => r.invites ?? [],
+    ),
+
+  // POST …/agent-invites — owner-gated. The response is the ONLY place the raw
+  // invite token ever exists; it is stored hash-only server-side and is not
+  // persisted on the device. `inviteToken` is NOT an agent key — the agent key is
+  // minted at claim time and only the claimer sees it.
+  createAgentInvite: (base: string, token: string, orgId: string, body: Record<string, unknown>) =>
+    api<CreateInviteResult>(base, `/api/orgs/${orgId}/agent-invites`, {
+      token,
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  // POST …/revoke — owner-gated, idempotent.
+  revokeAgentInvite: (base: string, token: string, orgId: string, inviteId: string) =>
+    api<Record<string, unknown>>(base, `/api/orgs/${orgId}/agent-invites/${inviteId}/revoke`, {
+      token,
+      method: 'POST',
+      body: '{}',
+    }),
+
+  // DELETE /api/orgs/:orgId/agents/:agentId — AAD-1's owner-gated SOFT delete,
+  // which also revokes the agent's credentials (API token, OAuth tokens,
+  // agent-scoped secrets, connectors). The ORG-SCOPED path is load-bearing:
+  // `requireOrgRole` reads `:orgId` off the path and silently no-ops without one,
+  // and the audit row takes its orgId from the same place. The legacy top-level
+  // `DELETE /api/agents/:agentId` is retired to a 410 — never call it.
+  deleteAgent: (base: string, token: string, orgId: string, agentId: string) =>
+    api<Record<string, never>>(base, `/api/orgs/${orgId}/agents/${agentId}`, {
+      token,
+      method: 'DELETE',
+    }),
 
   // ─── CONN-3 — per-agent connectors (owner-gated, MASKED reads) ─────────────
   // The SAME owner-gated, org-scoped-path routes the web's ConnectorsTab (CONN-2)

--- a/apps/mobile/src/invites.test.ts
+++ b/apps/mobile/src/invites.test.ts
@@ -1,0 +1,104 @@
+// AAD-2 (mobile) — the parity tripwire for the create-invite decisions.
+//
+// The cross-workspace import is safe here for the same reason as elsewhere:
+// `web/lib/invites.logic.ts` is dependency-free. Mobile CI installs ONLY
+// apps/mobile's lockfile, so a web module that pulled in a dep would drop this
+// file silently in CI while passing locally.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  CREATE_INVITE_DEFAULTS, INVITE_MAX_TTL_HOURS, INVITE_MAX_USES,
+  buildCreateInviteBody, inviteStatusChip, pickableAdapters, toggleAdapterType,
+  unavailableAdapters, validateCreateInvite, type AdapterRegistryEntry,
+} from './invites.ts'
+import {
+  CREATE_INVITE_DEFAULTS as WEB_DEFAULTS,
+  INVITE_MAX_TTL_HOURS as WEB_MAX_TTL,
+  INVITE_MAX_USES as WEB_MAX_USES,
+  buildCreateInviteBody as webBuildCreateInviteBody,
+  inviteStatusChip as webInviteStatusChip,
+  pickableAdapters as webPickableAdapters,
+  validateCreateInvite as webValidateCreateInvite,
+} from '../../../web/lib/invites.logic.ts'
+
+// A registry payload shaped like the real one: the four BUILT runtimes plus the
+// five that are declared-but-unavailable, plus an internal one.
+const REGISTRY: AdapterRegistryEntry[] = [
+  { type: 'openclaw_local', label: 'OpenClaw (local)', kind: 'local', available: true, invitable: true },
+  { type: 'claude_code', label: 'Claude Code', kind: 'local', available: true, invitable: true },
+  { type: 'cursor', label: 'Cursor', kind: 'local', available: true, invitable: true },
+  { type: 'openai_generic', label: 'OpenAI-compatible', kind: 'http', available: true, invitable: true },
+  { type: 'openclaw_gateway', label: 'OpenClaw gateway', kind: 'gateway', available: false, invitable: true, note: 'No outbound WebSocket client yet.' },
+  { type: 'http_webhook', label: 'HTTP webhook', kind: 'http', available: false, invitable: true, note: 'Push dispatch is unbuilt.' },
+  { type: 'hermes_gateway', label: 'Hermes gateway', kind: 'gateway', available: false, invitable: true, note: 'No Hermes client.' },
+  { type: 'hermes_local', label: 'Hermes (local)', kind: 'local', available: false, invitable: true, note: 'Requires spawning a host process.' },
+  { type: 'grok_local', label: 'Grok (local)', kind: 'local', available: false, invitable: true, note: 'No xAI provider in the LLM router.' },
+  { type: 'internal', label: 'Internal executor', kind: 'internal', available: true, invitable: false },
+]
+
+test('[AAD-2] the picker offers ONLY built runtimes — the five deferred ones are never selectable', () => {
+  const picks = pickableAdapters(REGISTRY).map((a) => a.type)
+  assert.deepEqual(picks, ['openclaw_local', 'claude_code', 'cursor', 'openai_generic'])
+  for (const deferred of ['openclaw_gateway', 'http_webhook', 'hermes_gateway', 'hermes_local', 'grok_local']) {
+    assert.ok(!picks.includes(deferred), `${deferred} must not be pickable`)
+  }
+  // …and `internal` is never invitable at all.
+  assert.ok(!picks.includes('internal'))
+})
+
+test('[AAD-2] the phone and the desk pick the SAME runtimes from the same registry', () => {
+  assert.deepEqual(
+    pickableAdapters(REGISTRY).map((a) => a.type),
+    webPickableAdapters(REGISTRY).map((a) => a.type),
+  )
+  assert.deepEqual(pickableAdapters(null), webPickableAdapters(null))
+  assert.deepEqual(pickableAdapters([]), webPickableAdapters([]))
+})
+
+test('[AAD-2] unavailable runtimes are SHOWN as not-yet-available, not hidden — and never internal', () => {
+  const shown = unavailableAdapters(REGISTRY).map((a) => a.type)
+  assert.deepEqual(shown, ['openclaw_gateway', 'http_webhook', 'hermes_gateway', 'hermes_local', 'grok_local'])
+  // The two sets are disjoint: nothing is both selectable and marked unavailable.
+  const picks = new Set(pickableAdapters(REGISTRY).map((a) => a.type))
+  for (const t of shown) assert.ok(!picks.has(t))
+})
+
+test('[AAD-2] the body omits defaults so the SERVER owns single-use + 72h', () => {
+  assert.deepEqual(buildCreateInviteBody(CREATE_INVITE_DEFAULTS), {})
+  assert.deepEqual(
+    buildCreateInviteBody({ adapterTypes: ['cursor'], multiUse: true, uses: 3, ttlHours: 24, message: ' hi ' }),
+    { allowedAdapterTypes: ['cursor'], maxUses: 3, expiresInHours: 24, message: 'hi' },
+  )
+  // Single-use never sends maxUses, whatever `uses` happens to hold.
+  assert.deepEqual(buildCreateInviteBody({ ...CREATE_INVITE_DEFAULTS, uses: 9 }), {})
+})
+
+test('[AAD-2] the phone and the desk build the SAME body and refuse the same values', () => {
+  const forms = [
+    CREATE_INVITE_DEFAULTS,
+    { adapterTypes: ['claude_code'], multiUse: true, uses: 5, ttlHours: 168, message: '' },
+    { adapterTypes: [], multiUse: true, uses: 0, ttlHours: 0, message: 'x' },
+    { adapterTypes: [], multiUse: true, uses: 51, ttlHours: 169, message: '' },
+  ]
+  for (const f of forms) {
+    assert.deepEqual(buildCreateInviteBody(f), webBuildCreateInviteBody(f))
+    assert.deepEqual(validateCreateInvite(f), webValidateCreateInvite(f))
+  }
+  assert.equal(INVITE_MAX_USES, WEB_MAX_USES)
+  assert.equal(INVITE_MAX_TTL_HOURS, WEB_MAX_TTL)
+  assert.deepEqual(CREATE_INVITE_DEFAULTS, WEB_DEFAULTS)
+})
+
+test('[AAD-2] status chips are colorblind-safe and agree with the desk', () => {
+  for (const s of ['active', 'accepted', 'expired', 'revoked', 'weird', '']) {
+    const chip = inviteStatusChip(s)
+    assert.ok(chip.icon.length > 0 && chip.label.length > 0)
+    assert.deepEqual(chip, webInviteStatusChip(s))
+  }
+})
+
+test('[AAD-2] toggling the allow-list adds then removes', () => {
+  assert.deepEqual(toggleAdapterType([], 'cursor'), ['cursor'])
+  assert.deepEqual(toggleAdapterType(['cursor'], 'cursor'), [])
+  assert.deepEqual(toggleAdapterType(['cursor'], 'claude_code'), ['cursor', 'claude_code'])
+})

--- a/apps/mobile/src/invites.ts
+++ b/apps/mobile/src/invites.ts
@@ -1,0 +1,121 @@
+// AAD-2 (mobile) — the phone's copy of the desk's create-invite decisions
+// (`web/lib/invites.logic.ts`). Pure and React-free so `node --test` can load it,
+// and PINNED against the web module by `invites.test.ts` — Metro cannot import
+// out of apps/mobile into web/, so the copy needs a tripwire or it drifts.
+//
+// THE ONE INVARIANT THAT MATTERS HERE. The runtime picker RENDERS FROM the
+// server adapter registry (`GET /api/adapters`), never from a hardcoded list on
+// the device. `pickableAdapters` = `invitable && available && kind !== 'internal'`
+// — exactly `joinableAdapterTypes()` on the server. A runtime that is declared
+// but not BUILT (openclaw_gateway, http_webhook, hermes_gateway, hermes_local,
+// grok_local — all `available: false`, backend/src/services/adapter-registry.ts)
+// must therefore be shown as NOT YET AVAILABLE and must not be selectable. It is
+// not "greyed out for tidiness": an invite naming a runtime Mission Control
+// cannot hand work to is an invite that can never be spent.
+
+/** One row of GET /api/adapters (the fields the picker needs). */
+export interface AdapterRegistryEntry {
+  type: string
+  label: string
+  kind: string
+  available: boolean
+  invitable: boolean
+  /** Why an unavailable adapter is unavailable. The registry carries a note for
+   *  every `available: false` row (pinned by the backend's [ADD-1] tripwire), and
+   *  the picker shows it rather than a bare disabled chip. */
+  note?: string | null
+}
+
+/** The adapters an operator may put on an invite's allow-list. */
+export function pickableAdapters(adapters: AdapterRegistryEntry[] | null | undefined): AdapterRegistryEntry[] {
+  return (adapters ?? []).filter((a) => a.invitable && a.available && a.kind !== 'internal')
+}
+
+/**
+ * The declared-but-not-yet-available runtimes, shown UNDER the picker as inert
+ * rows. `internal` is excluded — Mission Control runs those itself, so there is
+ * no external runtime to onboard and it is not "coming soon", it is not a thing
+ * you invite. Showing the rest is the honest half of the registry: the operator
+ * asked for Cursor/Claude Code/Grok/Hermes/OpenClaw and deserves to see which of
+ * those can actually be onboarded today, not an empty space where the others were.
+ */
+export function unavailableAdapters(adapters: AdapterRegistryEntry[] | null | undefined): AdapterRegistryEntry[] {
+  return (adapters ?? []).filter((a) => a.invitable && !a.available && a.kind !== 'internal')
+}
+
+export type ChipTone = 'ok' | 'warn' | 'fail' | 'muted'
+export interface StatusChip { icon: string; label: string; tone: ChipTone }
+
+/** Colorblind-safe descriptor for an invite's status — icon + label + tone. */
+export function inviteStatusChip(status: string): StatusChip {
+  switch (status) {
+    case 'active': return { icon: '●', label: 'Active', tone: 'ok' }
+    case 'accepted': return { icon: '✓', label: 'Used up', tone: 'muted' }
+    case 'expired': return { icon: '○', label: 'Expired', tone: 'muted' }
+    case 'revoked': return { icon: '✕', label: 'Revoked', tone: 'fail' }
+    default: return { icon: '•', label: status || 'Unknown', tone: 'muted' }
+  }
+}
+
+export interface CreateInviteForm {
+  adapterTypes: string[]
+  multiUse: boolean
+  uses: number
+  ttlHours: number
+  message: string
+}
+
+export const CREATE_INVITE_DEFAULTS: CreateInviteForm = {
+  adapterTypes: [], multiUse: false, uses: 5, ttlHours: 72, message: '',
+}
+
+/** Bounds mirror the backend constants (routes/agent-invites.ts). Out-of-range
+ *  values are REFUSED by the server, not clamped — so the phone refuses too
+ *  rather than quietly sending something that 400s. */
+export const INVITE_MAX_USES = 50
+export const INVITE_MAX_TTL_HOURS = 168
+
+/** Build the POST body, omitting anything left at its default so the SERVER owns
+ *  the defaults (single-use, 72h). Single-use never sends `maxUses`. */
+export function buildCreateInviteBody(form: CreateInviteForm): Record<string, unknown> {
+  const body: Record<string, unknown> = {}
+  if (form.adapterTypes.length > 0) body.allowedAdapterTypes = form.adapterTypes
+  if (form.multiUse && form.uses > 1) body.maxUses = form.uses
+  if (form.ttlHours && form.ttlHours !== 72) body.expiresInHours = form.ttlHours
+  const msg = form.message.trim()
+  if (msg) body.message = msg
+  return body
+}
+
+export function validateCreateInvite(form: CreateInviteForm): string[] {
+  const errors: string[] = []
+  if (form.multiUse && (!Number.isInteger(form.uses) || form.uses < 1 || form.uses > INVITE_MAX_USES)) {
+    errors.push(`Uses must be between 1 and ${INVITE_MAX_USES}.`)
+  }
+  if (!Number.isFinite(form.ttlHours) || form.ttlHours <= 0 || form.ttlHours > INVITE_MAX_TTL_HOURS) {
+    errors.push(`Time to live must be between 1 and ${INVITE_MAX_TTL_HOURS} hours.`)
+  }
+  return errors
+}
+
+/** Toggle one runtime in the allow-list (the picker's only mutation). */
+export function toggleAdapterType(selected: string[], type: string): string[] {
+  return selected.includes(type) ? selected.filter((t) => t !== type) : [...selected, type]
+}
+
+// ─── Copy shown on the sheet ────────────────────────────────────────────────
+
+/** What an approved join actually produces. Both clauses are backend invariants
+ *  (`secureRegistration()`; `allowShell` defaults false in the registry), stated
+ *  here so the operator knows what they are creating BEFORE they create it. */
+export const INVITE_POSTURE_NOTE =
+  'A human still approves every join before a credential exists. An approved agent starts under low-trust review with shell access OFF.'
+
+/** The deployment-posture warning. `MC_ENABLE_REMOTE_ONBOARDING` is unset on
+ *  hosted prod, so join/claim answer a flat 404 — the invite is real but cannot
+ *  be spent yet. Never soften this to make the entry point feel finished. */
+export const JOIN_CLOSED_NOTE =
+  'Public join is closed on this deployment. The invite and prompt are created, but an agent cannot join until remote onboarding is enabled by the operator.'
+
+export const ONE_TIME_REVEAL_NOTE =
+  'Shown once and not recoverable — copy the prompt now. There is no agent key here: the key is minted only when the joining agent claims the invite, and only the claimer ever sees it.'

--- a/apps/mobile/src/navigation.tsx
+++ b/apps/mobile/src/navigation.tsx
@@ -339,7 +339,15 @@ export default function RootNavigator() {
           name="AgentDetail"
           options={({ route }) => ({ title: (route.params as { name?: string }).name ?? 'Agent' })}
         >
-          {({ route }) => <AgentDetailScreen agentId={(route.params as { agentId: string }).agentId} />}
+          {({ route }) => (
+            <AgentDetailScreen
+              agentId={(route.params as { agentId: string }).agentId}
+              // AAD-2 — the agent is gone. Navigating at the Tabs route pops this
+              // pushed screen on the way, so the operator cannot swipe back into a
+              // detail page for an agent that no longer exists.
+              onDeleted={() => goToTab('agents')}
+            />
+          )}
         </Stack.Screen>
       </Stack.Navigator>
     </NavigationContainer>

--- a/apps/mobile/src/screens/AgentDetailScreen.tsx
+++ b/apps/mobile/src/screens/AgentDetailScreen.tsx
@@ -79,6 +79,13 @@ import {
   type SkillsPayload,
   type TrustModeLite,
 } from '../agentEdit'
+import {
+  DELETE_CONSEQUENCES,
+  DELETE_TITLE,
+  NON_OWNER_DELETE_NOTE,
+  UNKNOWN_ROLE_DELETE_NOTE,
+  isDeleteConfirmed,
+} from '../agentDelete'
 import { ConnectorsSection } from './AgentConnectors'
 import { heartbeatIcon, heartbeatTone, statusIcon, statusTone } from '../status'
 import { formatCost, formatTokens, NONE } from '../taskLog'
@@ -116,7 +123,12 @@ const emptyModelForm = (a: Agent): ModelProfileForm => ({
   reasoningEffort: (a.reasoningEffort ?? '').toLowerCase(),
 })
 
-export default function AgentDetailScreen({ agentId }: { agentId: string }) {
+export default function AgentDetailScreen({ agentId, onDeleted }: {
+  agentId: string
+  /** AAD-2 — the agent is gone: pop back to the roster. Absent → the Delete
+   *  control is not offered (there would be nowhere to route back to). */
+  onDeleted?: () => void
+}) {
   const { apiUrl, getToken, orgId, orgRole } = useAuth()
   const [agent, setAgent] = useState<Agent | null>(null)
   const [data, setData] = useState<Data | null>(null)
@@ -314,6 +326,23 @@ export default function AgentDetailScreen({ agentId }: { agentId: string }) {
             </Text>
           ) : null}
         </Section>
+      ) : null}
+
+      {/* ── Danger zone (AAD-2) — the desk's Configuration → Danger zone ─────
+          LAST on the screen on purpose: a destructive, irreversible control must
+          never sit on the path to a normal read. Owner-gated, and behind a
+          typed-name confirmation. */}
+      {agent && orgId && onDeleted ? (
+        <DangerZone
+          agent={agent}
+          agentId={agentId}
+          apiUrl={apiUrl}
+          orgId={orgId}
+          getToken={getToken}
+          canOffer={canOfferEdit}
+          roleUnknown={roleUnknown}
+          onDeleted={onDeleted}
+        />
       ) : null}
     </ScrollView>
   )
@@ -887,6 +916,142 @@ function SkillRow({
   )
 }
 
+// ─── Danger zone: delete this agent (AAD-2) ────────────────────────────────────
+//
+// Mirrors the desk's Configuration → Danger zone over the SAME owner-gated,
+// org-scoped route. Two things make this harder to trip than any other control
+// on the phone, deliberately:
+//
+//   * the consequences are LISTED, not summarised — credential revocation is the
+//     part an operator cannot infer from the word "delete";
+//   * the agent's NAME must be typed. A native Alert alone is one tap from a
+//     mis-scroll; typing is a statement of intent.
+//
+// And it is honest about failure: the screen is NOT dismissed until the backend
+// has returned 2xx. A 403 (not an owner — the real gate) surfaces as a 403.
+
+function DangerZone({
+  agent,
+  agentId,
+  apiUrl,
+  orgId,
+  getToken,
+  canOffer,
+  roleUnknown,
+  onDeleted,
+}: {
+  agent: Agent
+  agentId: string
+  apiUrl: string
+  orgId: string
+  getToken: () => Promise<string | null>
+  canOffer: boolean
+  roleUnknown: boolean
+  onDeleted: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [typed, setTyped] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  if (!canOffer) {
+    return (
+      <Section title="Danger zone">
+        <Text style={s.note}>{NON_OWNER_DELETE_NOTE}</Text>
+      </Section>
+    )
+  }
+
+  const confirmed = isDeleteConfirmed(typed, agent.name ?? '')
+
+  const run = async () => {
+    if (!confirmed || busy) return
+    const token = await getToken()
+    if (!token) {
+      setErr('Not signed in.')
+      return
+    }
+    setBusy(true)
+    setErr(null)
+    try {
+      await Api.deleteAgent(apiUrl, token, orgId, agentId)
+      setOpen(false)
+      onDeleted() // only after a confirmed 2xx
+    } catch (e: any) {
+      setErr(e?.message ?? 'The delete failed — nothing was changed.')
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Section title="Danger zone">
+      <Card style={{ gap: space.md }}>
+        <Text style={s.cardTitle}>Delete this agent</Text>
+        <Text style={s.cardHint}>
+          Removes {agent.name} from the organisation and revokes its connected credentials. History is retained for the
+          audit trail; there is no restore in the app.
+        </Text>
+        {roleUnknown ? <Text style={s.note}>{UNKNOWN_ROLE_DELETE_NOTE}</Text> : null}
+        <Button
+          title="Delete agent…"
+          tone="danger"
+          onPress={() => {
+            setTyped('')
+            setErr(null)
+            setOpen(true)
+          }}
+        />
+      </Card>
+
+      <Modal visible={open} transparent animationType="fade" onRequestClose={() => !busy && setOpen(false)}>
+        <View style={s.modalBackdrop}>
+          <View style={s.modalSheet}>
+            <Text style={s.modalTitle}>{DELETE_TITLE}</Text>
+            <ScrollView style={{ maxHeight: 320 }}>
+              <Text style={s.cardHint}>
+                <Text style={{ fontWeight: '800', color: theme.text }}>{agent.name}</Text> will be removed from this
+                organisation. This cannot be undone from the app.
+              </Text>
+              <View style={{ gap: space.sm, marginTop: space.md }}>
+                {DELETE_CONSEQUENCES.map((c) => (
+                  <Text key={c} style={s.consequence}>
+                    • {c}
+                  </Text>
+                ))}
+              </View>
+            </ScrollView>
+
+            {err ? (
+              <View style={{ marginTop: space.md }}>
+                <Banner kind="error">{err}</Banner>
+              </View>
+            ) : null}
+
+            <View style={{ gap: space.xs, marginTop: space.md }}>
+              <Text style={s.fieldLabel}>Type “{agent.name}” to confirm</Text>
+              <TextInput
+                value={typed}
+                onChangeText={setTyped}
+                autoCapitalize="none"
+                autoCorrect={false}
+                placeholder={agent.name ?? ''}
+                placeholderTextColor={theme.textFaint}
+                accessibilityLabel={`Type ${agent.name} to confirm deletion`}
+                style={s.input}
+              />
+            </View>
+
+            <View style={{ gap: space.sm, marginTop: space.lg }}>
+              <Button title="Delete agent" tone="danger" busy={busy} disabled={!confirmed || busy} onPress={run} />
+              <Button title="Cancel" tone="ghost" disabled={busy} onPress={() => setOpen(false)} />
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </Section>
+  )
+}
+
 // ─── Small form primitives (RN only — no native module, no new dep) ────────────
 
 function LabeledInput({
@@ -1106,6 +1271,7 @@ const s = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: theme.s3,
   },
+  consequence: { color: theme.textDim, fontSize: font.sm, lineHeight: 19 },
   skillName: { color: theme.text, fontSize: font.base, fontWeight: '600' },
   skillMeta: { color: theme.textFaint, fontSize: font.sm - 2 },
   runHead: { flexDirection: 'row', alignItems: 'center', gap: space.sm },

--- a/apps/mobile/src/screens/AgentsScreen.tsx
+++ b/apps/mobile/src/screens/AgentsScreen.tsx
@@ -39,6 +39,7 @@ import { useAuth } from '../auth'
 import { heartbeatIcon, heartbeatTone, statusIcon, statusTone } from '../status'
 import { font, space, theme } from '../theme'
 import { Banner, Card, Chip, Empty, Loading } from '../ui'
+import { AddAgentButton } from './InviteAgentSheet'
 
 export default function AgentsScreen({ onOpenAgent }: { onOpenAgent?: (id: string, name?: string) => void }) {
   const { apiUrl, getToken, orgId } = useAuth()
@@ -73,6 +74,13 @@ export default function AgentsScreen({ onOpenAgent }: { onOpenAgent?: (id: strin
           <Banner kind="error">{error}</Banner>
         </View>
       ) : null}
+
+      {/* AAD-2 — the "+ Agent" entry point, mirroring the desk's Agents roster.
+          Owner-gated (creating an invite is `requireOrgRole('owner')`); the sheet
+          itself is the shipped ONB invite flow, called over the same endpoints. */}
+      <View style={{ marginBottom: space.md }}>
+        <AddAgentButton />
+      </View>
 
       {agents === null ? (
         <Loading text="Loading agents…" />

--- a/apps/mobile/src/screens/AgentsScreen.tsx
+++ b/apps/mobile/src/screens/AgentsScreen.tsx
@@ -77,10 +77,10 @@ export default function AgentsScreen({ onOpenAgent }: { onOpenAgent?: (id: strin
 
       {/* AAD-2 — the "+ Agent" entry point, mirroring the desk's Agents roster.
           Owner-gated (creating an invite is `requireOrgRole('owner')`); the sheet
-          itself is the shipped ONB invite flow, called over the same endpoints. */}
-      <View style={{ marginBottom: space.md }}>
-        <AddAgentButton />
-      </View>
+          itself is the shipped ONB invite flow, called over the same endpoints.
+          Unwrapped on purpose: the button carries its own bottom margin, so a
+          non-owner (for whom it renders null) gets no stray gap. */}
+      <AddAgentButton />
 
       {agents === null ? (
         <Loading text="Loading agents…" />

--- a/apps/mobile/src/screens/InviteAgentSheet.tsx
+++ b/apps/mobile/src/screens/InviteAgentSheet.tsx
@@ -150,7 +150,34 @@ export default function InviteAgentSheet({
             </Pressable>
           </View>
 
-          <ScrollView contentContainerStyle={{ padding: space.lg, gap: space.md }} keyboardShouldPersistTaps="handled">
+          {/* KEYBOARD. This is the app's only BOTTOM-ANCHORED sheet (the backdrop
+              is `flex-end`, so the sheet does not move when the keyboard opens) and
+              it has three inputs low in the scroll — Max uses, Time to live, and the
+              multiline Message — with the "Create invite + prompt" button directly
+              beneath them. Without this the keyboard covers that whole band and the
+              submit button is simply unreachable: the ScrollView's frame still
+              extends under the keyboard, so there is no scroll offset that brings
+              the button into view.
+
+              `automaticallyAdjustKeyboardInsets` makes iOS add the keyboard/scroll
+              -view overlap as a bottom content inset, which both raises the maximum
+              scroll offset (every field AND the button can be scrolled clear of the
+              keyboard) and scrolls the focused input into the remaining visible
+              region. The app's other two keyboard surfaces (ConnectScreen,
+              CommandCenterScreen) use KeyboardAvoidingView instead — correct for a
+              full-screen `flex: 1` shell, but wrong here: `behavior="padding"` on a
+              height-capped sheet inside a Modal fights the `maxHeight: '92%'`
+              rather than the keyboard.
+
+              `keyboardShouldPersistTaps="handled"` is the other half and is load
+              -bearing, not decoration: with the keyboard up, it lets the tap on
+              "Create invite + prompt" reach onPress on the FIRST tap instead of
+              being consumed dismissing the keyboard. */}
+          <ScrollView
+            contentContainerStyle={{ padding: space.lg, gap: space.md }}
+            keyboardShouldPersistTaps="handled"
+            automaticallyAdjustKeyboardInsets
+          >
             {err ? <Banner kind="error">{err}</Banner> : null}
 
             {created ? (
@@ -487,6 +514,10 @@ const s = StyleSheet.create({
     paddingVertical: space.sm,
     paddingHorizontal: space.md,
     alignSelf: 'flex-start',
+    // The button owns its own spacing so the CALLER needs no wrapper View. A
+    // wrapper keeps laying out its margin after this component returns null for a
+    // non-owner — a stray ~16pt gap where a button they never see would have been.
+    marginBottom: space.md,
   },
   addBtnCompact: { paddingVertical: space.xs },
   addBtnText: { color: theme.blue, fontSize: font.sm, fontWeight: '800' },

--- a/apps/mobile/src/screens/InviteAgentSheet.tsx
+++ b/apps/mobile/src/screens/InviteAgentSheet.tsx
@@ -1,0 +1,493 @@
+// AAD-2 (mobile) — the "+ Agent" invite-onboarding sheet. The phone's mirror of
+// the desk's `web/app/dashboard/cockpit/InviteAgentDialog.tsx`: same endpoints,
+// same field names, same limits, same one-time reveal, same honest posture
+// banner. The decisions live in the pure `invites.ts` (pinned against the web's
+// module by invites.test.ts); this file is the rendering.
+//
+// THREE INVARIANTS ARE VISIBLE HERE, and each one is load-bearing:
+//
+//  * The runtime picker RENDERS FROM the server registry (`GET /api/adapters`),
+//    never from a list on the device. Runtimes MC cannot dispatch to are shown
+//    as "not yet available" and are NOT selectable — inviting one would create
+//    an invite that can never be spent.
+//  * The RAW invite token is shown ONCE and is never written to storage. There
+//    is no agent key here at all: the key is minted when the agent claims the
+//    invite, and only the claimer sees it.
+//  * `joinEnabled === false` (hosted: MC_ENABLE_REMOTE_ONBOARDING unset) is
+//    stated plainly. Softening it to make the new entry point feel finished
+//    would be the exact dishonesty the ONB epic was built to avoid.
+//
+// COPY-OUT. No clipboard dependency is added: RN's built-in `Share` sheet hands
+// the prompt to any app (Notes, Messages, a terminal), and the token itself is
+// rendered `selectable` for a long-press copy.
+
+import React, { useCallback, useEffect, useState } from 'react'
+import { Modal, Pressable, ScrollView, Share, StyleSheet, Switch, Text, TextInput, View } from 'react-native'
+import { Api, type AgentInvite, type CreateInviteResult } from '../api'
+import { useAuth } from '../auth'
+import { isOwnerRole } from '../agentEdit'
+import {
+  CREATE_INVITE_DEFAULTS,
+  INVITE_MAX_TTL_HOURS,
+  INVITE_MAX_USES,
+  INVITE_POSTURE_NOTE,
+  JOIN_CLOSED_NOTE,
+  ONE_TIME_REVEAL_NOTE,
+  buildCreateInviteBody,
+  inviteStatusChip,
+  pickableAdapters,
+  toggleAdapterType,
+  unavailableAdapters,
+  validateCreateInvite,
+  type AdapterRegistryEntry,
+  type CreateInviteForm,
+} from '../invites'
+import { font, radius, space, theme } from '../theme'
+import { Banner, Button, Card, Chip, Loading } from '../ui'
+
+export default function InviteAgentSheet({
+  apiUrl,
+  getToken,
+  orgId,
+  onClose,
+}: {
+  apiUrl: string
+  getToken: () => Promise<string | null>
+  orgId: string
+  onClose: () => void
+}) {
+  const [adapters, setAdapters] = useState<AdapterRegistryEntry[] | null>(null)
+  const [joinEnabled, setJoinEnabled] = useState<boolean | null>(null)
+  const [invites, setInvites] = useState<AgentInvite[]>([])
+  const [form, setForm] = useState<CreateInviteForm>(CREATE_INVITE_DEFAULTS)
+  const [created, setCreated] = useState<CreateInviteResult | null>(null)
+  const [mode, setMode] = useState<'create' | 'list'>('create')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const loadInvites = useCallback(async () => {
+    const token = await getToken()
+    if (!token) return
+    try {
+      setInvites(await Api.agentInvites(apiUrl, token, orgId))
+    } catch (e: any) {
+      setErr(e?.message ?? 'Could not load invites.')
+    }
+  }, [apiUrl, getToken, orgId])
+
+  useEffect(() => {
+    ;(async () => {
+      const token = await getToken()
+      if (!token) {
+        setErr('Not signed in.')
+        setAdapters([])
+        return
+      }
+      // The registry is what the picker needs; the posture is a nice-to-have that
+      // must not blank the sheet if it 403s.
+      const [reg, posture] = await Promise.allSettled([
+        Api.adapters(apiUrl, token),
+        Api.onboardingPosture(apiUrl, token, orgId),
+      ])
+      if (reg.status === 'fulfilled') setAdapters(reg.value)
+      else {
+        setAdapters([])
+        setErr(reg.reason?.message ?? 'Could not load the adapter registry.')
+      }
+      if (posture.status === 'fulfilled') setJoinEnabled(!!posture.value?.publicJoinEnabled)
+      loadInvites()
+    })()
+  }, [apiUrl, getToken, orgId, loadInvites])
+
+  const picks = pickableAdapters(adapters)
+  const notYet = unavailableAdapters(adapters)
+
+  const submit = async () => {
+    const problems = validateCreateInvite(form)
+    if (problems.length) {
+      setErr(problems.join(' '))
+      return
+    }
+    const token = await getToken()
+    if (!token) {
+      setErr('Not signed in.')
+      return
+    }
+    setBusy(true)
+    setErr(null)
+    try {
+      setCreated(await Api.createAgentInvite(apiUrl, token, orgId, buildCreateInviteBody(form)))
+      loadInvites()
+    } catch (e: any) {
+      // 403 = not an owner (the real enforcer), 400 = out-of-range uses/TTL
+      // (refused, never clamped). Say which; the form is kept.
+      setErr(e?.message ?? 'Could not create the invite.')
+    }
+    setBusy(false)
+  }
+
+  const revoke = async (id: string) => {
+    const token = await getToken()
+    if (!token) return
+    const before = invites
+    setInvites((x) => x.map((i) => (i.id === id ? { ...i, status: 'revoked' } : i)))
+    try {
+      await Api.revokeAgentInvite(apiUrl, token, orgId, id)
+    } catch (e: any) {
+      setInvites(before)
+      setErr(e?.message ?? 'Could not revoke that invite.')
+    }
+  }
+
+  return (
+    <Modal visible transparent animationType="slide" onRequestClose={onClose}>
+      <View style={s.backdrop}>
+        <View style={s.sheet}>
+          <View style={s.head}>
+            <Text style={s.title}>{created ? '✓ Invite created' : 'Invite an agent'}</Text>
+            <Pressable onPress={onClose} accessibilityRole="button" accessibilityLabel="Close" hitSlop={10}>
+              <Text style={s.close}>✕</Text>
+            </Pressable>
+          </View>
+
+          <ScrollView contentContainerStyle={{ padding: space.lg, gap: space.md }} keyboardShouldPersistTaps="handled">
+            {err ? <Banner kind="error">{err}</Banner> : null}
+
+            {created ? (
+              <Reveal
+                created={created}
+                onDone={() => {
+                  setCreated(null)
+                  setForm(CREATE_INVITE_DEFAULTS)
+                  setMode('list')
+                }}
+              />
+            ) : (
+              <>
+                <View style={s.tabs}>
+                  {(['create', 'list'] as const).map((m) => (
+                    <Pressable
+                      key={m}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: mode === m }}
+                      onPress={() => setMode(m)}
+                      style={[s.tab, mode === m && s.tabOn]}
+                    >
+                      <Text style={[s.tabText, mode === m && s.tabTextOn]}>
+                        {m === 'create' ? 'New invite' : `Active invites${invites.length ? ` · ${invites.filter((i) => i.status === 'active').length}` : ''}`}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
+
+                {mode === 'create' ? (
+                  <>
+                    <Text style={s.hint}>{INVITE_POSTURE_NOTE}</Text>
+
+                    <Card style={{ gap: space.md }}>
+                      <Text style={s.cardTitle}>Allowed runtime(s)</Text>
+                      <Text style={s.cardHint}>From the server adapter registry — not a list on this device.</Text>
+                      {adapters === null ? (
+                        <Loading text="Loading adapters…" />
+                      ) : picks.length === 0 ? (
+                        <Text style={s.empty}>No invitable runtimes available.</Text>
+                      ) : (
+                        <View style={s.chipWrap}>
+                          {picks.map((a) => {
+                            const on = form.adapterTypes.includes(a.type)
+                            return (
+                              <Pressable
+                                key={a.type}
+                                accessibilityRole="button"
+                                accessibilityState={{ selected: on }}
+                                onPress={() => setForm((f) => ({ ...f, adapterTypes: toggleAdapterType(f.adapterTypes, a.type) }))}
+                                style={[s.pick, on && s.pickOn]}
+                              >
+                                <Text style={[s.pickText, on && s.pickTextOn]}>
+                                  {on ? '✓ ' : ''}
+                                  {a.label}
+                                </Text>
+                              </Pressable>
+                            )
+                          })}
+                        </View>
+                      )}
+                      <Text style={s.cardHint}>
+                        {form.adapterTypes.length === 0
+                          ? 'None selected → any invitable runtime may join.'
+                          : `${form.adapterTypes.length} selected.`}
+                      </Text>
+
+                      {notYet.length > 0 ? (
+                        <View style={{ gap: space.xs }}>
+                          <Text style={s.fieldLabel}>Not yet available</Text>
+                          <View style={s.chipWrap}>
+                            {notYet.map((a) => (
+                              <View key={a.type} style={s.pickOff} accessibilityState={{ disabled: true }}>
+                                <Text style={s.pickOffText}>○ {a.label}</Text>
+                              </View>
+                            ))}
+                          </View>
+                          <Text style={s.cardHint}>
+                            Declared in the adapter registry, but Mission Control cannot hand these runtimes work yet — so they
+                            cannot be invited.
+                          </Text>
+                        </View>
+                      ) : null}
+                    </Card>
+
+                    <Card style={{ gap: space.md }}>
+                      <Text style={s.cardTitle}>Uses & expiry</Text>
+                      <View style={s.row}>
+                        <Text style={[s.fieldLabel, { flex: 1 }]}>Multi-use invite</Text>
+                        <Switch
+                          value={form.multiUse}
+                          onValueChange={(v) => setForm((f) => ({ ...f, multiUse: v }))}
+                          trackColor={{ true: theme.blue, false: theme.s3 }}
+                        />
+                      </View>
+                      <Text style={s.cardHint}>
+                        {form.multiUse ? `Up to ${INVITE_MAX_USES} uses.` : 'Single-use — the default, and the safer one.'}
+                      </Text>
+                      {form.multiUse ? (
+                        <NumberField
+                          label="Max uses"
+                          value={form.uses}
+                          onChange={(n) => setForm((f) => ({ ...f, uses: n }))}
+                        />
+                      ) : null}
+                      <NumberField
+                        label={`Time to live (hours) — max ${INVITE_MAX_TTL_HOURS}`}
+                        value={form.ttlHours}
+                        onChange={(n) => setForm((f) => ({ ...f, ttlHours: n }))}
+                      />
+                      <View style={{ gap: space.xs }}>
+                        <Text style={s.fieldLabel}>Message (optional) — context for the agent, not an instruction</Text>
+                        <TextInput
+                          value={form.message}
+                          onChangeText={(t) => setForm((f) => ({ ...f, message: t }))}
+                          multiline
+                          placeholderTextColor={theme.textFaint}
+                          style={[s.input, { minHeight: 64, textAlignVertical: 'top' }]}
+                        />
+                      </View>
+                    </Card>
+
+                    {joinEnabled === false ? <Banner kind="info">{JOIN_CLOSED_NOTE}</Banner> : null}
+
+                    <Button title="Create invite + prompt" tone="primary" busy={busy} disabled={busy} onPress={submit} />
+                  </>
+                ) : (
+                  <Card style={{ gap: space.sm }}>
+                    {invites.length === 0 ? (
+                      <Text style={s.empty}>No invites yet.</Text>
+                    ) : (
+                      invites.map((i) => {
+                        const chip = inviteStatusChip(i.status)
+                        return (
+                          <View key={i.id} style={s.inviteRow}>
+                            <Chip label={chip.label} glyph={chip.icon} tone={chip.tone === 'ok' ? 'ok' : chip.tone === 'fail' ? 'danger' : 'neutral'} />
+                            <View style={{ flex: 1, minWidth: 0 }}>
+                              <Text style={s.inviteAllow} numberOfLines={1}>
+                                {i.allowedAdapterTypes ? i.allowedAdapterTypes.join(', ') : 'any runtime'}
+                              </Text>
+                              <Text style={s.inviteMeta}>
+                                {i.usesRemaining}/{i.maxUses} uses left · expires {new Date(i.expiresAt).toLocaleString()}
+                              </Text>
+                            </View>
+                            {i.status === 'active' ? (
+                              <Pressable onPress={() => revoke(i.id)} accessibilityRole="button" hitSlop={8}>
+                                <Text style={s.revoke}>✕ Revoke</Text>
+                              </Pressable>
+                            ) : null}
+                          </View>
+                        )
+                      })
+                    )}
+                  </Card>
+                )}
+              </>
+            )}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+// ─── The "+ Agent" entry point ────────────────────────────────────────────────
+
+/**
+ * The button + its sheet, so a surface that wants the entry point gets it in one
+ * line and both surfaces gate it identically. Mounted on the Agents roster and
+ * on the Org chart — the two places an operator looks for "add someone", and the
+ * two the desk was also missing until AAD-2.
+ *
+ * GATING. `POST …/agent-invites` is `requireOrgRole('owner')`, so a member would
+ * only ever collect a 403 — hidden. An UNKNOWN role (a pasted token whose orgs
+ * were never listed with a role) still gets the affordance, with the caution the
+ * phone already uses for its owner-gated edits: the backend is the real enforcer,
+ * and locking a legitimate owner out of the device on a *maybe* is worse than a
+ * named 403.
+ */
+export function AddAgentButton({ compact }: { compact?: boolean }) {
+  const { apiUrl, getToken, orgId, orgRole } = useAuth()
+  const [open, setOpen] = useState(false)
+  const owner = isOwnerRole(orgRole)
+  const roleUnknown = orgRole == null
+  if (!orgId || (!owner && !roleUnknown)) return null
+  return (
+    <>
+      <Pressable
+        onPress={() => setOpen(true)}
+        accessibilityRole="button"
+        accessibilityLabel="Add an agent — create an invite and onboarding prompt"
+        style={({ pressed }) => [s.addBtn, compact && s.addBtnCompact, pressed && { opacity: 0.7 }]}
+      >
+        <Text style={s.addBtnText}>＋ Agent</Text>
+      </Pressable>
+      {open ? (
+        <InviteAgentSheet apiUrl={apiUrl} getToken={getToken} orgId={orgId} onClose={() => setOpen(false)} />
+      ) : null}
+    </>
+  )
+}
+
+// ─── The one-time reveal ──────────────────────────────────────────────────────
+
+function Reveal({ created, onDone }: { created: CreateInviteResult; onDone: () => void }) {
+  return (
+    <View style={{ gap: space.md }}>
+      <Text style={s.hint}>{ONE_TIME_REVEAL_NOTE}</Text>
+
+      {created.joinEnabled === false ? <Banner kind="info">{JOIN_CLOSED_NOTE}</Banner> : null}
+
+      <Card style={{ gap: space.sm }}>
+        <Text style={s.fieldLabel}>Invite token (shown once)</Text>
+        <Text selectable style={s.token}>
+          {created.inviteToken}
+        </Text>
+        <Button
+          title="Share token"
+          tone="ghost"
+          onPress={() => Share.share({ message: created.inviteToken })}
+        />
+      </Card>
+
+      <Card style={{ gap: space.sm }}>
+        <Text style={s.fieldLabel}>Onboarding prompt — paste into any agent’s chat</Text>
+        <ScrollView style={{ maxHeight: 220 }}>
+          <Text selectable style={s.prompt}>
+            {created.onboardingPrompt}
+          </Text>
+        </ScrollView>
+        <Button
+          title="Share onboarding prompt"
+          tone="primary"
+          onPress={() => Share.share({ message: created.onboardingPrompt })}
+        />
+        <Button
+          title="Share doc URL"
+          tone="ghost"
+          onPress={() => Share.share({ message: created.onboardingTextUrl })}
+        />
+      </Card>
+
+      <Button title="Done" tone="ghost" onPress={onDone} />
+    </View>
+  )
+}
+
+// ─── primitives ───────────────────────────────────────────────────────────────
+
+function NumberField({ label, value, onChange }: { label: string; value: number; onChange: (n: number) => void }) {
+  return (
+    <View style={{ gap: space.xs }}>
+      <Text style={s.fieldLabel}>{label}</Text>
+      <TextInput
+        value={String(value)}
+        onChangeText={(t) => onChange(Number(t.replace(/[^0-9]/g, '')) || 0)}
+        keyboardType="number-pad"
+        placeholderTextColor={theme.textFaint}
+        style={s.input}
+      />
+    </View>
+  )
+}
+
+const s = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'flex-end' },
+  sheet: { backgroundColor: theme.bg, borderTopLeftRadius: radius.lg, borderTopRightRadius: radius.lg, maxHeight: '92%' },
+  head: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
+    paddingBottom: space.md,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.s3,
+  },
+  title: { color: theme.text, fontSize: font.lg, fontWeight: '800' },
+  close: { color: theme.textDim, fontSize: font.lg, fontWeight: '700' },
+  tabs: { flexDirection: 'row', gap: space.sm },
+  tab: { paddingVertical: space.sm, paddingHorizontal: space.md, borderRadius: radius.md, borderWidth: 1, borderColor: theme.s3 },
+  tabOn: { borderColor: theme.blue, backgroundColor: theme.s2 },
+  tabText: { color: theme.textDim, fontSize: font.sm, fontWeight: '700' },
+  tabTextOn: { color: theme.text },
+  hint: { color: theme.textDim, fontSize: font.sm, lineHeight: 19 },
+  cardTitle: { color: theme.text, fontSize: font.base, fontWeight: '800' },
+  cardHint: { color: theme.textFaint, fontSize: font.sm - 1, lineHeight: 17 },
+  fieldLabel: { color: theme.textDim, fontSize: font.sm - 1, fontWeight: '600' },
+  empty: { color: theme.textDim, fontSize: font.sm },
+  chipWrap: { flexDirection: 'row', flexWrap: 'wrap', gap: space.sm },
+  pick: { paddingVertical: space.sm, paddingHorizontal: space.md, borderRadius: radius.md, borderWidth: 1, borderColor: theme.s3 },
+  pickOn: { borderColor: theme.blue, backgroundColor: theme.s2 },
+  pickText: { color: theme.textDim, fontSize: font.sm, fontWeight: '600' },
+  pickTextOn: { color: theme.text },
+  pickOff: {
+    paddingVertical: space.sm,
+    paddingHorizontal: space.md,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: theme.s3,
+    opacity: 0.7,
+  },
+  pickOffText: { color: theme.textFaint, fontSize: font.sm },
+  row: { flexDirection: 'row', alignItems: 'center', gap: space.md },
+  input: {
+    backgroundColor: theme.s2,
+    borderWidth: 1,
+    borderColor: theme.s3,
+    borderRadius: radius.md,
+    color: theme.text,
+    fontSize: font.base,
+    paddingHorizontal: space.md,
+    paddingVertical: space.sm,
+  },
+  token: {
+    color: theme.text,
+    fontFamily: 'Courier',
+    fontSize: font.sm,
+    backgroundColor: theme.s2,
+    borderRadius: radius.md,
+    padding: space.md,
+  },
+  prompt: { color: theme.text, fontSize: font.sm - 1, lineHeight: 18, fontFamily: 'Courier' },
+  inviteRow: { flexDirection: 'row', alignItems: 'center', gap: space.md, paddingVertical: space.sm },
+  inviteAllow: { color: theme.text, fontSize: font.sm, fontWeight: '600' },
+  inviteMeta: { color: theme.textFaint, fontSize: font.sm - 2, marginTop: 2 },
+  revoke: { color: theme.vermillion, fontSize: font.sm, fontWeight: '700' },
+  addBtn: {
+    borderWidth: 1,
+    borderColor: theme.blue,
+    backgroundColor: theme.s2,
+    borderRadius: radius.md,
+    paddingVertical: space.sm,
+    paddingHorizontal: space.md,
+    alignSelf: 'flex-start',
+  },
+  addBtnCompact: { paddingVertical: space.xs },
+  addBtnText: { color: theme.blue, fontSize: font.sm, fontWeight: '800' },
+})

--- a/apps/mobile/src/screens/OrgScreen.tsx
+++ b/apps/mobile/src/screens/OrgScreen.tsx
@@ -193,10 +193,10 @@ export default function OrgScreen({ onOpenAgent }: { onOpenAgent?: (id: string, 
           {agents === null ? <Loading text="Loading the org chart…" /> : null}
           {/* AAD-2 — the "+ Agent" entry point. The desk's Org section had no add
               affordance either (its toolbar was Import/Export/zoom only); both
-              surfaces get one in the same wave. Owner-gated inside the button. */}
-          <View style={{ marginBottom: space.md }}>
-            <AddAgentButton />
-          </View>
+              surfaces get one in the same wave. Owner-gated inside the button, and
+              unwrapped: it carries its own bottom margin, so a non-owner (for whom
+              it renders null) gets no stray gap. */}
+          <AddAgentButton />
           {rows.length ? (
             <View style={s.head}>
               <Text style={s.count}>

--- a/apps/mobile/src/screens/OrgScreen.tsx
+++ b/apps/mobile/src/screens/OrgScreen.tsx
@@ -50,6 +50,7 @@ import {
 import { statusIcon, statusTone } from '../status'
 import { font, radius, space, theme } from '../theme'
 import { Banner, Empty, Loading } from '../ui'
+import { AddAgentButton } from './InviteAgentSheet'
 
 const INDENT = 16 // points per reporting level
 
@@ -190,6 +191,12 @@ export default function OrgScreen({ onOpenAgent }: { onOpenAgent?: (id: string, 
             </View>
           ) : null}
           {agents === null ? <Loading text="Loading the org chart…" /> : null}
+          {/* AAD-2 — the "+ Agent" entry point. The desk's Org section had no add
+              affordance either (its toolbar was Import/Export/zoom only); both
+              surfaces get one in the same wave. Owner-gated inside the button. */}
+          <View style={{ marginBottom: space.md }}>
+            <AddAgentButton />
+          </View>
           {rows.length ? (
             <View style={s.head}>
               <Text style={s.count}>

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2423,9 +2423,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/docs/DESIGN-mobile-parity.md
+++ b/docs/DESIGN-mobile-parity.md
@@ -996,3 +996,48 @@ test — otherwise the surface with the test silently becomes the only one holdi
 shipping with the same chrome as the pending queue is a legibility problem on a laptop and a worse one on a
 phone: there is no peripheral vision to fall back on, the screen *is* the list, so a tail that reads as a
 peer is a tail the operator scrolls past on their way to nothing. Same finding, stronger on the small screen.
+
+## 9. AAD-2 — "+ Agent" and "Delete agent" (as-built)
+
+**Parity verdict: MIRRORED, in the same PR.** Both halves were greenfield on the phone
+(no invite surface, no agent delete existed) — and both are operator-lifecycle controls,
+which is the category the phone exists for. Deferring them to a later MOB story was the
+plan's *recommendation*; it was rejected here because the desk's own gap was a
+placement gap, not a build gap, so mirroring cost one screen rather than an epic.
+
+**What crossed over, unchanged in contract.** Same endpoints, same field names, same
+limits: `GET /api/adapters`, `GET/POST …/agent-invites`, `POST …/agent-invites/:id/revoke`,
+`GET …/onboarding-posture`, and AAD-1's `DELETE /api/orgs/:orgId/agents/:agentId`. The
+backend served both surfaces already; the mirror is pure client work, as usual.
+
+**What is hand-copied, and what pins it.** Metro cannot import from `web/`, so
+`apps/mobile/src/invites.ts` and `apps/mobile/src/agentDelete.ts` mirror
+`web/lib/invites.logic.ts` and `web/lib/agentDelete.ts`. Both are pinned by tests that
+import the web module directly (`invites.test.ts`, `agentDelete.test.ts`) and assert
+agreement on the decisions that matter: which runtimes are pickable, what the POST body
+is, which values are refused, who may be offered delete, and the exact delete path. Safe
+to import because both web modules are dependency-free — Mobile CI installs only
+`apps/mobile`'s lockfile, and a web module that pulled in a dep would drop the whole test
+file silently in CI while passing locally.
+
+**Where the two surfaces DIFFER, deliberately:**
+
+- **Clipboard.** The desk has `navigator.clipboard` and renders copy buttons. The phone
+  has no clipboard module and adding `expo-clipboard` would be a new dependency for one
+  button, so it uses RN's built-in `Share` sheet plus `selectable` text for a long-press
+  copy. Same outcome — the token and prompt leave the device — by the platform's own idiom.
+- **Unknown role.** The desk's role is always resolvable or the surface is unusable, so an
+  unresolved role there hides the control (fail closed) and says why. The phone has a real
+  third state — a pasted token whose org was never listed with a role — and keeps the rule
+  `agentEdit.ts` already established: offer with a caution, let the backend 403 be the
+  enforcer. Locking a legitimate owner out of the only destructive control on the device,
+  on a *maybe*, is the worse failure. The typed-name confirmation stands in front of it either way.
+- **Placement.** The desk puts the Danger zone at the foot of the Configuration tab. The
+  phone has no tabs, so it goes last on the detail scroll — same principle (never on the
+  path to a normal read), different geometry.
+
+**Verified:** mobile 369/369 · typecheck · `expo export` · SDK 54, no new dependency.
+**Not verified visually** — no simulator run. The web half WAS rendered and driven
+(both entry points, the picker's available/not-available split, the confirm dialog, a
+real DELETE, and the owner gate flipping), so the shared decisions are visually
+confirmed on one surface and test-confirmed on the other.

--- a/web/app/dashboard/CockpitPanel.tsx
+++ b/web/app/dashboard/CockpitPanel.tsx
@@ -26,6 +26,7 @@ import AddAgentWizard from './cockpit/AddAgentWizard'
 import HireDialog from './cockpit/HireDialog'
 import InviteAgentDialog from './cockpit/InviteAgentDialog'
 import StepUpDialog from './cockpit/StepUpDialog'
+import { useOrgRole } from './useOrgRole'
 import { approvalNeedsStepUp } from '@/lib/dangerousApprovals'
 import type { ActivityEvent } from '@/lib/activityKinds'
 
@@ -62,6 +63,9 @@ export default function CockpitPanel({ orgId, getToken, onOpenTask, onOpenAgent,
   const [stepUp, setStepUp] = useState<Approval | null>(null)
   const [deciding, setDeciding] = useState<Set<string>>(new Set())
   const [decideErr, setDecideErr] = useState<Record<string, string>>({})
+  // AAD-2 — the caller's role, server-computed. `null` (unknown / failed) offers
+  // nothing; it is never treated as owner.
+  const { isOwner } = useOrgRole(orgId, getToken)
 
   // ACT-1 — the decided tail, on its own so a decision can refresh it WITHOUT
   // re-running the 10-way cockpit load. This is the freshness leg of the APPR-1 lesson:
@@ -259,6 +263,18 @@ export default function CockpitPanel({ orgId, getToken, onOpenTask, onOpenAgent,
         </div>
         <div style={{ display: 'flex', gap: space.md, flexWrap: 'wrap' }}>
           <Button style={{ color: tk.accent }} onClick={load}>↻ Refresh</Button>
+          {/* AAD-2 — the "+ Agent" entry point for the FOCUSED Org / Agents views.
+              The three creation buttons below are `{!focused && …}`, so the Org
+              section (which is this panel with `only={['org']}`) showed no add
+              affordance at all — its toolbar had Import/Export/zoom and nothing
+              else. This mounts the SAME shipped InviteAgentDialog rather than a
+              second path, and only for an owner: `POST …/agent-invites` is
+              `requireOrgRole('owner')`, so offering it to a member would be a
+              button that can only 403. */}
+          {focused && (only ?? []).some(k => k === 'org' || k === 'agents') && isOwner === true && (
+            <Button variant="primary" onClick={() => setInvite(true)}
+              title="Create an invite + a copy-able onboarding prompt to paste into any external agent">＋ Agent</Button>
+          )}
           {/* Full-stack-only actions — a focused area keeps just Refresh. */}
           {!focused && <>
             <Button style={{ color: tk.accent }} onClick={sweep} title="Run heartbeat engine: recover stalled tasks, refresh statuses, wake due agents">💓 Sweep</Button>

--- a/web/app/dashboard/agent/AgentDetail.tsx
+++ b/web/app/dashboard/agent/AgentDetail.tsx
@@ -17,7 +17,7 @@ import ConnectorsTab from './ConnectorsTab'
 import RunsTab from './RunsTab'
 import BudgetTab from './BudgetTab'
 
-export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getToken, onOpenTask, onOpenLibrary }: {
+export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getToken, onOpenTask, onOpenLibrary, onDeleted }: {
   orgId: string
   agentId: string
   tab: AgentTab
@@ -27,6 +27,9 @@ export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getTok
   onOpenTask?: (taskId: string) => void
   /** AG4 — jump to the company skills library area. */
   onOpenLibrary?: () => void
+  /** AAD-2 — this agent was deleted (Configuration → Danger zone). The page owns
+   *  what happens next: leave the detail view and refresh the roster. */
+  onDeleted?: () => void
 }) {
   const [agent, setAgent] = useState<DAgent | null>(null)
   const [err, setErr] = useState<string | null>(null)
@@ -139,7 +142,7 @@ export default function AgentDetail({ orgId, agentId, tab, onTab, onBack, getTok
           onViewRuns={() => onTab('runs')} onOpenTask={onOpenTask} />}
         {tab === 'instructions' && <InstructionsTab orgId={orgId} agentId={agentId} getToken={getToken} />}
         {tab === 'skills' && <SkillsTab orgId={orgId} agentId={agentId} getToken={getToken} onOpenLibrary={onOpenLibrary} />}
-        {tab === 'configuration' && <ConfigurationTab orgId={orgId} agentId={agentId} getToken={getToken} onSaved={load} />}
+        {tab === 'configuration' && <ConfigurationTab orgId={orgId} agentId={agentId} getToken={getToken} onSaved={load} onDeleted={onDeleted} />}
         {tab === 'connectors' && <ConnectorsTab orgId={orgId} agentId={agentId} getToken={getToken} />}
         {tab === 'runs' && <RunsTab orgId={orgId} agentId={agentId} getToken={getToken} onOpenTask={onOpenTask} />}
         {tab === 'budget' && <BudgetTab orgId={orgId} agentId={agentId} agentName={agent.name} getToken={getToken} />}

--- a/web/app/dashboard/agent/ConfigurationTab.tsx
+++ b/web/app/dashboard/agent/ConfigurationTab.tsx
@@ -10,6 +10,9 @@ import { FormLabel, sx } from '../cockpit/shared'
 import { tk, text, space } from '../tokens'
 import { AgentAvatar, ax, type DAgent, type Getter } from './shared'
 import CustomModelDialog, { type CustomModel } from './CustomModelDialog'
+import DeleteAgentDialog from './DeleteAgentDialog'
+import { useOrgRole } from '../useOrgRole'
+import { NON_OWNER_DELETE_NOTE, UNKNOWN_ROLE_DELETE_NOTE, canDeleteAgent } from '@/lib/agentDelete'
 
 type Roster = { id: string; name: string; role: string; avatarEmoji?: string | null; reportsTo?: string | null }
 type ModelOption = { id: string; label: string; provider: string; tier: string; custom?: boolean }
@@ -22,11 +25,14 @@ const ADAPTERS: { value: string; label: string }[] = [
   { value: 'custom', label: 'Custom runtime' },
 ]
 
-export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: {
+export default function ConfigurationTab({ orgId, agentId, getToken, onSaved, onDeleted }: {
   orgId: string
   agentId: string
   getToken: Getter
   onSaved?: () => void
+  /** AAD-2 — the agent is gone: leave this page and refresh the roster. Absent →
+   *  the Delete control is not offered at all (nowhere to route back to). */
+  onDeleted?: () => void
 }) {
   const [agent, setAgent] = useState<DAgent | null>(null)
   const [roster, setRoster] = useState<Roster[]>([])
@@ -39,6 +45,10 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
   const [saved, setSaved] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
+  // AAD-2 — the owner gate for the Delete control. The role is the SERVER's
+  // answer (see useOrgRole); `null` means unresolved and offers nothing.
+  const { isOwner, role, loading: roleLoading } = useOrgRole(orgId, getToken)
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   const load = useCallback(async () => {
     setErr(null)
@@ -276,6 +286,41 @@ export default function ConfigurationTab({ orgId, agentId, getToken, onSaved }: 
         </Button>
         {saved && <span style={{ color: tk.green, fontSize: text.sm.fontSize }}>✓ Saved</span>}
       </div>
+
+      {/* ── Danger zone (AAD-2) ─────────────────────────────────────────
+          Owner-only, and gated on the SERVER's answer about this caller —
+          `canDeleteAgent` fails closed, so an unresolved role offers nothing
+          rather than a button that would only ever collect a 403. Last on the
+          page, below the save bar, so it is never on the path to a normal edit. */}
+      {onDeleted && (
+        <section>
+          <h2 style={{ ...ax.sectionTitle, marginBottom: space.sm, color: tk.red }}>Danger zone</h2>
+          <Card style={{ display: 'flex', alignItems: 'center', gap: space.lg, flexWrap: 'wrap', borderColor: 'var(--danger-line, var(--line-strong))' }}>
+            <div style={{ flex: 1, minWidth: 240 }}>
+              <div style={{ fontSize: text.md.fontSize, fontWeight: 600 }}>Delete this agent</div>
+              <p style={{ ...ax.empty, fontSize: text.xs.fontSize, maxWidth: 520, margin: `${space.xs}px 0 0` }}>
+                Removes {agent.name} from the organisation and <b>revokes its connected credentials</b> — its API token,
+                OAuth tokens and agent-scoped secrets. History is retained for the audit trail; there is no restore in the app.
+              </p>
+              {!roleLoading && !canDeleteAgent(role) && (
+                <p style={{ ...ax.empty, fontSize: text.xs.fontSize, maxWidth: 520, margin: `${space.sm}px 0 0` }}>
+                  {isOwner === false ? NON_OWNER_DELETE_NOTE : UNKNOWN_ROLE_DELETE_NOTE}
+                </p>
+              )}
+            </div>
+            {canDeleteAgent(role) && (
+              <Button variant="danger" onClick={() => setDeleteOpen(true)} disabled={busy || uploading}>
+                Delete agent…
+              </Button>
+            )}
+          </Card>
+        </section>
+      )}
+
+      {deleteOpen && onDeleted && (
+        <DeleteAgentDialog orgId={orgId} agentId={agentId} agentName={agent.name} getToken={getToken}
+          onClose={() => setDeleteOpen(false)} onDeleted={() => { setDeleteOpen(false); onDeleted() }} />
+      )}
 
       {dialog.open && (
         <CustomModelDialog orgId={orgId} getToken={getToken} existing={dialog.editing}

--- a/web/app/dashboard/agent/DeleteAgentDialog.tsx
+++ b/web/app/dashboard/agent/DeleteAgentDialog.tsx
@@ -1,0 +1,82 @@
+'use client'
+// AAD-2 — the destructive confirmation for "Delete agent".
+//
+// Deliberately harder to get through than any other dialog on the desk: it names
+// what dies (credentials, not just a row), and it requires the agent's NAME to be
+// typed. That is the same shape the step-up dialog uses for a dangerous approval
+// (APPR-1) — an operator should have to state intent, not just aim a mouse.
+//
+// HONESTY. The card is NOT cleared optimistically and the caller is NOT told
+// "deleted" until the request has actually returned 2xx. This is the APPR-1
+// lesson: a 403 that renders as success is worse than a visible failure.
+import { useState } from 'react'
+import { api } from '@/lib/api'
+import { DELETE_CONSEQUENCES, DELETE_TITLE, agentDeletePath, isDeleteConfirmed } from '@/lib/agentDelete'
+import { Button, TextInput } from '../ui'
+import { FormLabel, Modal, ModalTitle, sx } from '../cockpit/shared'
+import { tk, text, space } from '../tokens'
+import type { Getter } from './shared'
+
+export default function DeleteAgentDialog({ orgId, agentId, agentName, getToken, onClose, onDeleted }: {
+  orgId: string
+  agentId: string
+  agentName: string
+  getToken: Getter
+  onClose: () => void
+  /** Fired ONLY after the backend confirmed the delete. */
+  onDeleted: () => void
+}) {
+  const [typed, setTyped] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  const confirmed = isDeleteConfirmed(typed, agentName)
+
+  const run = async () => {
+    if (!confirmed || busy) return
+    setBusy(true); setErr(null)
+    try {
+      await api(agentDeletePath(orgId, agentId), { token: await getToken(), method: 'DELETE' })
+      onDeleted() // only on a confirmed 2xx
+    } catch (e: any) {
+      // 403 (not an owner) / 404 (already gone or not in this org) / network —
+      // say which, and keep the dialog open. Nothing has been removed on screen.
+      setErr(e?.message ?? 'The delete failed — nothing was changed.')
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Modal onClose={onClose} maxWidth={560}>
+      <ModalTitle onClose={onClose}>{DELETE_TITLE}</ModalTitle>
+
+      <p style={sx.hint}>
+        <b>{agentName}</b> will be removed from this organisation. This cannot be undone from the app.
+      </p>
+
+      <ul style={{ margin: `${space.md}px 0`, paddingLeft: 20, display: 'flex', flexDirection: 'column', gap: space.sm }}>
+        {DELETE_CONSEQUENCES.map(c => (
+          <li key={c} style={{ fontSize: text.sm.fontSize, color: tk.textDim, lineHeight: 1.5 }}>{c}</li>
+        ))}
+      </ul>
+
+      {err && <div style={sx.err}>⚠ {err}</div>}
+
+      <FormLabel style={{ marginTop: space.md }}>
+        {/* One line: FormLabel lays its children out in a column, so a bare
+            `Type <b>{name}</b> to confirm` breaks across three rows. */}
+        <span>Type <b style={{ color: tk.text }}>{agentName}</b> to confirm</span>
+        <TextInput autoFocus value={typed} placeholder={agentName} aria-label={`Type ${agentName} to confirm deletion`}
+          onChange={e => setTyped(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && confirmed) run() }} />
+      </FormLabel>
+
+      <div style={{ display: 'flex', gap: space.sm, justifyContent: 'flex-end', marginTop: space.lg }}>
+        <Button onClick={onClose} disabled={busy}>Cancel</Button>
+        <Button variant="danger" onClick={run} disabled={!confirmed || busy}>
+          {busy ? 'Deleting…' : 'Delete agent'}
+        </Button>
+      </div>
+    </Modal>
+  )
+}

--- a/web/app/dashboard/cockpit/InviteAgentDialog.tsx
+++ b/web/app/dashboard/cockpit/InviteAgentDialog.tsx
@@ -13,7 +13,7 @@
 import { useEffect, useState } from 'react'
 import { api } from '@/lib/api'
 import {
-  pickableAdapters, inviteStatusChip, buildCreateInviteBody, validateCreateInvite,
+  pickableAdapters, unavailableAdapters, inviteStatusChip, buildCreateInviteBody, validateCreateInvite,
   CREATE_INVITE_DEFAULTS, INVITE_MAX_USES, INVITE_MAX_TTL_HOURS,
   type AdapterRegistryEntry, type CreateInviteForm,
 } from '@/lib/invites.logic'
@@ -73,6 +73,7 @@ export default function InviteAgentDialog({ orgId, getToken, onClose }: { orgId:
   }, [orgId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const picks = pickableAdapters(adapters)
+  const notYet = unavailableAdapters(adapters)
   const toggleAdapter = (t: string) =>
     setForm(f => ({ ...f, adapterTypes: f.adapterTypes.includes(t) ? f.adapterTypes.filter(x => x !== t) : [...f.adapterTypes, t] }))
 
@@ -172,6 +173,30 @@ export default function InviteAgentDialog({ orgId, getToken, onClose }: { orgId:
               {form.adapterTypes.length === 0 ? 'None selected → any invitable runtime may join.' : `${form.adapterTypes.length} selected.`}
             </span>
           </FormLabel>
+
+          {/* AAD-2 — declared but NOT dispatchable yet. Inert on purpose: Mission
+              Control has no way to hand these runtimes work (no outbound WS
+              client, no per-agent HTTP pusher, no Hermes client, no xAI provider),
+              so an invite naming one could never be spent. Shown rather than
+              hidden, with the registry's own reason, so "where is Grok?" has an
+              answer instead of an empty space. */}
+          {notYet.length > 0 && (
+            <div>
+              <span style={{ fontSize: text.xs.fontSize, fontWeight: 700, color: tk.muted }}>Not yet available</span>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: space.sm, marginTop: space.xs }}>
+                {notYet.map(a => (
+                  <span key={a.type} title={a.note ?? 'Declared in the adapter registry, but Mission Control cannot dispatch work to it yet.'}
+                    aria-disabled="true"
+                    style={{ fontSize: text.xs.fontSize, color: tk.mutedSoft, border: `1px dashed ${tk.line}`, borderRadius: 8, padding: '5px 10px' }}>
+                    ○ {a.label}
+                  </span>
+                ))}
+              </div>
+              <span style={{ fontSize: text.xs.fontSize, color: tk.mutedSoft }}>
+                Declared in the adapter registry, but Mission Control cannot hand these runtimes work yet — so they cannot be invited.
+              </span>
+            </div>
+          )}
 
           <FormLabel>Uses
             <div style={{ display: 'flex', alignItems: 'center', gap: space.md }}>

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -16,6 +16,8 @@ import StaffGrid from './agent/StaffGrid'
 import { allSurfaces, isPlaceholder, isSection, navSectionKey, navPageTabs, navSelectedId, navSurfaceTitle } from '@/lib/navModel'
 import { DEFAULT_AGENT_TAB, agentRouteHash, parseAgentRoute, type AgentRoute, type AgentTab } from '@/lib/agentRoute'
 import { AgentAvatar } from './agent/shared'
+import InviteAgentDialog from './cockpit/InviteAgentDialog'
+import { useOrgRole } from './useOrgRole'
 import { useTheme } from '../theme'
 import { CommandPalette, type Command } from './CommandPalette'
 import { statusColor, statusIcon } from './status'
@@ -96,6 +98,13 @@ export default function DashboardPage() {
   const [settingsSaved, setSettingsSaved] = useState(false)
   const [uploadingField, setUploadingField] = useState<string | null>(null)
   const [settingsMsg, setSettingsMsg] = useState<string | null>(null)
+  // AAD-2 — the "+ Agent" entry point on the Agents roster, owner-gated on the
+  // server's answer about this caller (useOrgRole). It opens the SHIPPED
+  // InviteAgentDialog; nothing about the invite spine changes.
+  const [inviteOpen, setInviteOpen] = useState(false)
+  // The caller's role in the current org (server-computed; null until known, and
+  // null on any failure — never assumed to be owner).
+  const { isOwner } = useOrgRole(org?.id, getToken)
 
   const load = useCallback(async () => {
     const token = await getToken()
@@ -446,12 +455,26 @@ export default function DashboardPage() {
         {tab === 'agents' && (agentRoute
           ? <AgentDetail orgId={org.id} agentId={agentRoute.agentId} tab={agentRoute.tab} getToken={getToken}
               onTab={t => openAgent(agentRoute.agentId, t)} onBack={closeAgent} onOpenTask={setOpenTaskId}
-              onOpenLibrary={() => selectTab('skills')} />
+              onOpenLibrary={() => selectTab('skills')}
+              onDeleted={() => { closeAgent(); load() }} />
           : (
           <div style={s.page}>
             {/* AG7 — Staff (card grid, the default) vs the dense table. */}
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
               <h1 style={s.h1}>Agents ({agents.length})</h1>
+              {/* AAD-2 — the "+ Agent" entry point. The Agents roster had no add
+                  affordance at all: all three creation buttons live in the
+                  Operations toolbar behind `{!focused && …}`, so the two places an
+                  operator actually looks for one showed nothing. This mounts the
+                  SHIPPED invite dialog (ONB6) — no second mint path, no new
+                  endpoint — and only for an owner, since creating an invite is
+                  `requireOrgRole('owner')` on the backend. */}
+              {isOwner === true && (
+                <button onClick={() => setInviteOpen(true)} style={s.addAgentBtn}
+                  title="Create an invite + a copy-able onboarding prompt to paste into any external agent">
+                  ＋ Agent
+                </button>
+              )}
               <div role="tablist" aria-label="Agent view" style={{ display: 'flex', gap: 4, marginLeft: 'auto' }}>
                 {([['staff', 'Staff'], ['table', 'Table']] as const).map(([v, label]) => (
                   <button key={v} role="tab" aria-selected={agentView === v} onClick={() => setAgentView(v)}
@@ -586,6 +609,14 @@ export default function DashboardPage() {
 
         {openTaskId && org && <TaskDrawer orgId={org.id} taskId={openTaskId} getToken={getToken} onClose={() => setOpenTaskId(null)} />}
 
+        {/* AAD-2 — the "+ Agent" flow, mounted once for the whole page. The dialog
+            itself is unchanged from ONB6, including its honest "public join is
+            closed on this deployment" banner: an entry point that mints an invite
+            the agent cannot yet spend must keep saying so. */}
+        {inviteOpen && org && (
+          <InviteAgentDialog orgId={org.id} getToken={getToken} onClose={() => { setInviteOpen(false); load() }} />
+        )}
+
         {tab === 'usage' && (
           <div style={s.page}>
             <h1 style={s.h1}>Usage & Limits</h1>
@@ -707,4 +738,7 @@ const s: Record<string, React.CSSProperties> = {
   primaryBtn: { background: 'var(--accent)', color: 'var(--accent-contrast)', border: 'none', borderRadius: 10, padding: '13px 20px', fontSize: 15, fontWeight: 700, marginTop: 4 },
   uploadChip: { fontSize: 12, fontWeight: 600, color: 'var(--accent)', background: 'var(--s2)', border: '1px solid var(--line-strong)', padding: '5px 12px', borderRadius: 8, cursor: 'pointer' },
   approvalsLink: { fontSize: 12.5, fontWeight: 700, color: 'var(--accent)', background: 'var(--s2)', border: '1px solid var(--line-strong)', padding: '7px 14px', borderRadius: 8, cursor: 'pointer', fontFamily: 'inherit' },
+  // AAD-2 — the roster's "+ Agent" entry point. Same shape as approvalsLink (the
+  // page's own button idiom) with the accent border an add-affordance earns.
+  addAgentBtn: { fontSize: 12.5, fontWeight: 700, color: 'var(--accent)', background: 'var(--accent-dim)', border: '1px solid var(--accent-line)', padding: '7px 14px', borderRadius: 8, cursor: 'pointer', fontFamily: 'inherit' },
 }

--- a/web/app/dashboard/useOrgRole.ts
+++ b/web/app/dashboard/useOrgRole.ts
@@ -1,0 +1,68 @@
+'use client'
+// AAD-2 — the desk's role signal.
+//
+// WHY THIS FILE EXISTS. The web had no shared "what am I in this org" source.
+// The one `isOwner` in the codebase was read out of an API response body inside
+// `cockpit/ActivityLogSection.tsx` and kept to itself, so an owner-gated control
+// anywhere else had nothing to ask. This hoists exactly that signal — no new
+// auth path, no new endpoint, no client-side role guess.
+//
+// THE SOURCE. `GET /api/orgs/:orgId/activity` computes `isOwner` SERVER-SIDE
+// from the caller's real identity (`enforceOrgRole({ minRole: 'owner' })`,
+// routes/activity.ts) and returns it alongside the feed. We ask for the smallest
+// possible page — `?limit=1&kind=task` narrows the k-way merge to the single
+// tasks source — because we want the header, not the body.
+//
+// WHY NOT `/api/users/:userId/orgs` (the phone's source)? It needs the Clerk
+// userId, which the desk's `useAuth` shim does not expose, and which does not
+// exist at all in the PACKAGED loopback profile (Epic H6). The activity route
+// derives the role from whatever identity actually authenticated the request, so
+// it is correct under BOTH auth modes. The phone keeps its own source; both
+// agree because both are the server's answer, not a client inference.
+//
+// FAIL CLOSED. Unresolved (in flight, error, no org) is `null`, never `true`.
+// Callers must treat `null` as "do not offer", not as "probably fine".
+import { useEffect, useRef, useState } from 'react'
+import { api } from '@/lib/api'
+import type { Getter } from './cockpit/shared'
+
+export interface OrgRoleState {
+  /** true = owner · false = known non-owner · null = not yet known / unresolved. */
+  isOwner: boolean | null
+  /** The role string, for the pure `canDeleteAgent` helper. null when unresolved. */
+  role: 'owner' | 'member' | null
+  loading: boolean
+}
+
+export function useOrgRole(orgId: string | null | undefined, getToken: Getter): OrgRoleState {
+  const [isOwner, setIsOwner] = useState<boolean | null>(null)
+  const [loading, setLoading] = useState(true)
+  // The effect must depend on `orgId` ALONE. Clerk's `getToken` is stable, but the
+  // packaged shim (and any future one) rebuilds it every render, and a getToken in
+  // the dep array would then re-fire this on every render — a request loop in a
+  // hook whose whole job is to be cheap. The ref keeps the latest one reachable
+  // without making its identity a trigger.
+  const tokenRef = useRef(getToken)
+  tokenRef.current = getToken
+
+  useEffect(() => {
+    let cancelled = false
+    if (!orgId) { setIsOwner(null); setLoading(false); return }
+    setLoading(true)
+    ;(async () => {
+      try {
+        const r = await api<{ isOwner?: boolean }>(`/api/orgs/${orgId}/activity?limit=1&kind=task`, { token: await tokenRef.current() })
+        if (!cancelled) setIsOwner(typeof r.isOwner === 'boolean' ? r.isOwner : null)
+      } catch {
+        // A 403 here means "not a member", which is also not an owner — but we
+        // cannot tell it apart from a network failure, so both stay UNKNOWN and
+        // the caller offers nothing. Never fall through to `true`.
+        if (!cancelled) setIsOwner(null)
+      }
+      if (!cancelled) setLoading(false)
+    })()
+    return () => { cancelled = true }
+  }, [orgId])
+
+  return { isOwner, role: isOwner === true ? 'owner' : isOwner === false ? 'member' : null, loading }
+}

--- a/web/lib/agentDelete.test.ts
+++ b/web/lib/agentDelete.test.ts
@@ -1,0 +1,44 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  DELETE_CONSEQUENCES, agentDeletePath, canDeleteAgent, isDeleteConfirmed,
+} from './agentDelete.ts'
+
+test('[AAD-2] canDeleteAgent is owner-only and fails closed', () => {
+  assert.equal(canDeleteAgent('owner'), true)
+  assert.equal(canDeleteAgent('member'), false)
+  // 'admin' is NOT a role in this model — an unknown role must never grant delete.
+  assert.equal(canDeleteAgent('admin'), false)
+  assert.equal(canDeleteAgent('OWNER'), false) // the wire value is lowercase; no fuzzy match
+  assert.equal(canDeleteAgent(''), false)
+  assert.equal(canDeleteAgent(null), false)
+  assert.equal(canDeleteAgent(undefined), false)
+})
+
+test('[AAD-2] the delete path is ORG-SCOPED — the owner gate and the audit orgId depend on it', () => {
+  assert.equal(agentDeletePath('org-1', 'agent-9'), '/api/orgs/org-1/agents/agent-9')
+  // The legacy top-level shape (retired to 410 by AAD-1) must never be produced:
+  // `requireOrgRole` silently no-ops on a path with no `:orgId`.
+  assert.ok(agentDeletePath('org-1', 'agent-9').startsWith('/api/orgs/'))
+})
+
+test('[AAD-2] typed-name confirmation: trims + case-insensitive, never empty, never partial', () => {
+  assert.equal(isDeleteConfirmed('Ops', 'Ops'), true)
+  assert.equal(isDeleteConfirmed('  ops  ', 'Ops'), true)
+  assert.equal(isDeleteConfirmed('OPS', 'Ops'), true)
+  assert.equal(isDeleteConfirmed('O', 'Ops'), false)
+  assert.equal(isDeleteConfirmed('Ops2', 'Ops'), false)
+  assert.equal(isDeleteConfirmed('', 'Ops'), false)
+  assert.equal(isDeleteConfirmed('   ', 'Ops'), false)
+  // An unnamed agent must not become deletable by typing nothing.
+  assert.equal(isDeleteConfirmed('', ''), false)
+  assert.equal(isDeleteConfirmed('  ', '   '), false)
+})
+
+test('[AAD-2] the dialog names credential revocation — the load-bearing consequence', () => {
+  const all = DELETE_CONSEQUENCES.join(' ').toLowerCase()
+  assert.ok(all.includes('token'))
+  assert.ok(all.includes('revoke'))
+  assert.ok(all.includes('secret'))
+  assert.ok(all.includes('connector'))
+})

--- a/web/lib/agentDelete.ts
+++ b/web/lib/agentDelete.ts
@@ -1,0 +1,69 @@
+// AAD-2 — pure decisions for the "Delete Agent" control (Agent Settings →
+// Configuration). Framework-free and unit-tested under the web zero-dep runner,
+// so the dialog and the tab stay thin — and so the phone can pin its hand-copy
+// against this module (apps/mobile/src/agentDelete.test.ts).
+//
+// THE GATE. The backend route is
+//   DELETE /api/orgs/:orgId/agents/:agentId   { preHandler: requireOrgRole('owner') }
+// (AAD-1). The client NEVER decides whether a delete is allowed — the server
+// does. What lives here is what the client decides to OFFER: a Delete button a
+// member can press only to collect a 403 is a lie about what they can do.
+//
+// FAIL CLOSED. `canDeleteAgent` is exact-match on `'owner'`. Anything else —
+// `'member'`, an unknown string, `'admin'` (which is NOT a role in this model),
+// null, undefined — is not an owner. Mirrors `isOwnerRole` in
+// `apps/mobile/src/agentEdit.ts:36`, which is locked by its own test for the
+// same reason: a role vocabulary that grows must not silently grant delete.
+
+/** The org membership roles, mirroring the backend `OrgRole` union (rbac.ts). */
+export const ORG_ROLES = ['owner', 'member'] as const
+export type OrgRole = (typeof ORG_ROLES)[number]
+
+/**
+ * May this caller be OFFERED the delete control? Owner only, fail-closed on
+ * anything unrecognised. The backend is still the enforcer.
+ */
+export function canDeleteAgent(role: string | null | undefined): boolean {
+  return role === 'owner'
+}
+
+/** The org-scoped delete route. Owner-gated + audit-logged with the right orgId
+ *  precisely BECAUSE it carries `:orgId` — `requireOrgRole` no-ops on a path
+ *  without one (the R-4 trap), which is why the legacy top-level
+ *  `DELETE /api/agents/:agentId` was retired to a 410 rather than decorated. */
+export function agentDeletePath(orgId: string, agentId: string): string {
+  return `/api/orgs/${orgId}/agents/${agentId}`
+}
+
+/**
+ * The typed-name confirmation. Trimmed and case-insensitive — the operator is
+ * proving intent, not their typing accuracy — but never empty, and never a
+ * partial match: an agent called "Ops" must not be deletable by typing "O".
+ */
+export function isDeleteConfirmed(typed: string, agentName: string): boolean {
+  const want = (agentName ?? '').trim().toLowerCase()
+  const got = (typed ?? '').trim().toLowerCase()
+  return want.length > 0 && got === want
+}
+
+/** What deleting actually does, in the operator's words. Every clause is a real
+ *  backend behaviour (services/agent-deletion.ts), not reassurance: if one of
+ *  these stops being true, this copy is a bug. */
+export const DELETE_CONSEQUENCES = [
+  'Its API token stops working immediately — a running adapter loses access on its next call.',
+  'Its connected credentials are revoked: Google/OAuth tokens are dropped (and revoked upstream where possible), agent-scoped secrets are deleted, and its connectors are disabled.',
+  'It disappears from the roster, the staff grid and the org chart, and it can no longer be assigned or run work.',
+  'Its history is retained for the audit trail — this is a soft delete, but there is no restore in the app.',
+] as const
+
+export const DELETE_TITLE = 'Delete this agent?'
+
+/** Shown instead of the control to a caller we know is not an owner. */
+export const NON_OWNER_DELETE_NOTE =
+  'Only an organisation owner can delete an agent. Ask an owner if this agent should go.'
+
+/** Shown when the caller's role could not be resolved at all. We hide the
+ *  control (fail closed) and say so, rather than offering a button whose outcome
+ *  we cannot predict. */
+export const UNKNOWN_ROLE_DELETE_NOTE =
+  'Your role in this organisation could not be confirmed, so deleting is not offered here. Reload, or ask an owner.'

--- a/web/lib/invites.logic.ts
+++ b/web/lib/invites.logic.ts
@@ -16,6 +16,10 @@ export interface AdapterRegistryEntry {
   kind: string
   available: boolean
   invitable: boolean
+  /** Why an `available: false` adapter is unavailable. The registry carries a
+   *  note on every one of them (pinned by the backend's [ADD-1] tripwire), and
+   *  AAD-2 shows it rather than hiding the runtime entirely. */
+  note?: string | null
 }
 
 /**
@@ -26,6 +30,25 @@ export interface AdapterRegistryEntry {
  */
 export function pickableAdapters(adapters: AdapterRegistryEntry[] | null | undefined): AdapterRegistryEntry[] {
   return (adapters ?? []).filter((a) => a.invitable && a.available && a.kind !== 'internal')
+}
+
+/**
+ * AAD-2 — the declared-but-NOT-YET-BUILT runtimes, for an inert "not yet
+ * available" list under the picker.
+ *
+ * The picker used to render only `pickableAdapters`, so a runtime that Mission
+ * Control cannot hand work to (openclaw_gateway, http_webhook, hermes_gateway,
+ * hermes_local, grok_local — all `available: false`) was simply ABSENT. An
+ * operator who came looking for Grok or Hermes read that absence as "not
+ * supported at all", or worse, went hunting for a setting to turn it on. Showing
+ * them as inert, with the registry's own reason, is the honest answer: declared,
+ * not yet dispatchable, and therefore not selectable.
+ *
+ * `internal` is excluded — MC runs those itself, so it is not "coming soon", it
+ * is simply not something you invite.
+ */
+export function unavailableAdapters(adapters: AdapterRegistryEntry[] | null | undefined): AdapterRegistryEntry[] {
+  return (adapters ?? []).filter((a) => a.invitable && !a.available && a.kind !== 'internal')
 }
 
 export type ChipTone = 'ok' | 'warn' | 'fail' | 'muted'

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -151,19 +151,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -173,19 +173,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -199,9 +218,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -215,9 +234,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -231,9 +250,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -247,9 +266,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -263,9 +282,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -279,9 +298,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -295,9 +314,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -311,9 +330,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -327,9 +346,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -343,9 +362,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -355,19 +374,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -377,19 +396,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -399,19 +418,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -421,19 +440,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -443,19 +462,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -465,19 +484,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -487,19 +506,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -509,38 +528,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -550,16 +585,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -569,16 +604,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -588,7 +623,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1028,9 +1063,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -1047,48 +1082,53 @@
       "license": "MIT"
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,5 +24,8 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^5"
+  },
+  "overrides": {
+    "sharp": "^0.35.3"
   }
 }


### PR DESCRIPTION
Phases 2–4 of `docs/PLAN-agent-add-delete.md`, on top of AAD-1's backend (#339 / `3665a1f`).

**Client-only: no endpoint, no schema, no gate changed, no runtime flipped to `available: true`.**

## Feature A — "+ Agent"

The shipped ONB6 `InviteAgentDialog` is now mounted where an operator actually looks for it — the **Agents roster** and the **Org** section. Neither had *any* add affordance, because all three creation buttons live in the Operations toolbar behind `{!focused && …}` (the Phase-0 finding). Same dialog, same endpoints, no second mint path, and the honest *"public join is closed on this deployment"* banner is kept intact.

The picker stays registry-driven (`invitable && available && kind !== 'internal'`) and now **also shows the five deferred runtimes** — `openclaw_gateway`, `http_webhook`, `hermes_gateway`, `hermes_local`, `grok_local` — as inert *"not yet available"* rows carrying the registry's own note. They were previously simply absent, which reads as "unsupported" rather than "declared, not yet dispatchable". **None is selectable.** Invited agents still land `low_trust_review` with shell OFF (untouched: `secureRegistration()` and the registry default).

## Feature B — Delete Agent

A **Danger zone** at the foot of Agent Settings → Configuration, wired to AAD-1's owner-gated `DELETE /api/orgs/:orgId/agents/:agentId`. Typed-name confirmation; the consequences are **listed**, because credential revocation is the part the word "delete" does not convey. The card clears only on a confirmed 2xx — a 403 never renders as success (the APPR-1 lesson). On success the page routes back to the roster and re-reads it.

## Owner gating

New `useOrgRole` hook hoists the role signal the web already had — the server-computed `isOwner` from `GET …/activity`, which is correct under **both** the Clerk and the packaged/loopback identities (unlike `/api/users/:userId/orgs`, which needs a Clerk userId the desk's auth shim does not expose). `canDeleteAgent` fails closed: `'admin'`, unknown, `null` → false. A non-owner gets a named note, not a button that can only 403. The hook depends on `orgId` alone (getToken lives in a ref) so an unstable `getToken` cannot turn it into a request loop.

## Parity: MIRRORED, same PR

`apps/mobile` gains the invite sheet (Agents + Org) and the Danger zone over the same endpoints. `invites.ts` / `agentDelete.ts` are hand copies **pinned** against the web modules by tripwires that import them directly — safe because both web modules are dependency-free, so Mobile CI's own lockfile still loads them. **Zero new dependencies** (RN's built-in `Share`, not `expo-clipboard`). Deliberate divergences are documented in `docs/DESIGN-mobile-parity.md` §9: the clipboard idiom, the phone's real *role-unknown* third state, and placement.

## Verification

| | |
|---|---|
| Backend | 1898/1898 · evals 11/11 |
| Web | 333/333 · typecheck · `npm run build` |
| Mobile | 369/369 · typecheck · `expo export` |

**The web half was rendered and driven** against a stub backend (dev server): both entry points, the picker's available/not-available split, the confirm dialog's typed-name gate (disabled at `May`, enabled at `Maya`), a real `DELETE /api/orgs/org-1/agents/a-2` on the org-scoped path, the route-back-to-roster, and the whole control disappearing when `isOwner` is false.

**Mobile is compile-verified only** — no simulator run. That is the one gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)