### PR TITLE
feat(MCC-1): chat with your agents — org-scoped threads, web Chat tab, mobile Chat segment

### DIFF
--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -37,6 +37,9 @@ import type { PublicConnectorState, ConnectorExecutionItem } from './agentConnec
 // module that reads it (invites.ts, itself pinned against the web's
 // invites.logic.ts), so the picker and the client agree by construction.
 import type { AdapterRegistryEntry } from './invites'
+// MCC-1 — the chat wire shape is defined in the pure module that reads it
+// (chat.ts, itself parity-pinned against web/lib/chat.logic.ts).
+import type { ChatMsgLite } from './chat'
 
 export type ApiInit = RequestInit & { token?: string | null; base?: string }
 
@@ -759,6 +762,24 @@ export const Api = {
       method: 'POST',
       body: '{}',
     }),
+
+  // ─── MCC-1 — agent chat (the same org-scoped routes the web's ChatPanel calls) ──
+  // GET returns the newest-N window ascending; POST sends. For an EXTERNAL agent
+  // the reply arrives later through its poll loop (the response says `async:
+  // true`), so the screen keeps polling the GET — never invents a reply.
+  agentChat: (base: string, token: string, orgId: string, agentId: string) =>
+    api<{ messages: ChatMsgLite[]; agent: { id: string; name: string; external: boolean } }>(
+      base,
+      `/api/orgs/${orgId}/agents/${agentId}/chat`,
+      { token },
+    ),
+
+  sendAgentChat: (base: string, token: string, orgId: string, agentId: string, content: string) =>
+    api<{ ok: boolean; async: boolean; taskId: string; message: ChatMsgLite; reply?: ChatMsgLite }>(
+      base,
+      `/api/orgs/${orgId}/agents/${agentId}/chat`,
+      { token, method: 'POST', body: JSON.stringify({ content }) },
+    ),
 
   // DELETE /api/orgs/:orgId/agents/:agentId — AAD-1's owner-gated SOFT delete,
   // which also revokes the agent's credentials (API token, OAuth tokens,

--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -775,7 +775,7 @@ export const Api = {
     ),
 
   sendAgentChat: (base: string, token: string, orgId: string, agentId: string, content: string) =>
-    api<{ ok: boolean; async: boolean; taskId: string; message: ChatMsgLite; reply?: ChatMsgLite }>(
+    api<{ ok: boolean; async: boolean; taskId: string; message: ChatMsgLite; reply?: ChatMsgLite; notice?: string }>(
       base,
       `/api/orgs/${orgId}/agents/${agentId}/chat`,
       { token, method: 'POST', body: JSON.stringify({ content }) },

--- a/apps/mobile/src/chat.test.ts
+++ b/apps/mobile/src/chat.test.ts
@@ -18,6 +18,9 @@ test('[MCC-1] mergeThread agrees with the web on dedupe, order and overlap', () 
     [[m('x', 'user', 'draft', 1)], [{ ...m('x', 'user', 'server', 1), taskId: 't' }]],
     [[m('a', 'user', '1', 1), m('b', 'assistant', '2', 2)], [m('b', 'assistant', '2', 2), m('c', 'user', '3', 3)]],
     [[m('z', 'user', 'z', 5)], [m('y', 'assistant', 'y', 5)]],
+    // same-second Q/A pair sharing a taskId — the question must sort first even
+    // though its id is lexicographically later (audit MCC-1 #1)
+    [[{ ...m('zz-q', 'user', 'Q', 7), taskId: 't1' }], [{ ...m('aa-a', 'assistant', 'A', 7), taskId: 't1' }]],
   ]
   for (const [a, b] of cases) {
     assert.deepEqual(phone.mergeThread(a as any, b as any), web.mergeThread(a as any, b as any))

--- a/apps/mobile/src/chat.test.ts
+++ b/apps/mobile/src/chat.test.ts
@@ -1,0 +1,43 @@
+// MCC-1 — the chat logic's parity pin. The phone's chat.ts is a hand-copy of
+// web/lib/chat.logic.ts (Metro can't bundle across packages), so this drives
+// BOTH with the same inputs and requires the same outputs — the same discipline
+// as inboxSegments.test.ts. The day one side changes alone, this fails.
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import * as phone from './chat.ts'
+import * as web from '../../../web/lib/chat.logic.ts'
+
+const m = (id: string, role: string, content: string, t: number) =>
+  ({ id, role, content, createdAt: new Date(2026, 0, 1, 0, 0, t).toISOString() })
+
+test('[MCC-1] mergeThread agrees with the web on dedupe, order and overlap', () => {
+  const cases: [any[], any[]][] = [
+    [[], []],
+    [[m('a', 'user', 'one', 1)], []],
+    [[m('x', 'user', 'draft', 1)], [{ ...m('x', 'user', 'server', 1), taskId: 't' }]],
+    [[m('a', 'user', '1', 1), m('b', 'assistant', '2', 2)], [m('b', 'assistant', '2', 2), m('c', 'user', '3', 3)]],
+    [[m('z', 'user', 'z', 5)], [m('y', 'assistant', 'y', 5)]],
+  ]
+  for (const [a, b] of cases) {
+    assert.deepEqual(phone.mergeThread(a as any, b as any), web.mergeThread(a as any, b as any))
+  }
+})
+
+test('[MCC-1] awaitingReply / threadPreview / chatSendError agree with the web', () => {
+  const threads: any[][] = [
+    [],
+    [m('a', 'user', 'hi', 1)],
+    [m('a', 'user', 'hi', 1), m('b', 'assistant', '  spaced   out\n\nreply ', 2)],
+    [m('a', 'user', 'x'.repeat(300), 1)],
+  ]
+  for (const t of threads) {
+    assert.equal(phone.awaitingReply(t as any), web.awaitingReply(t as any))
+    assert.equal(phone.threadPreview(t as any), web.threadPreview(t as any))
+    assert.equal(phone.threadPreview(t as any, 10), web.threadPreview(t as any, 10))
+  }
+  for (const c of ['', '   ', 'fine', 'x'.repeat(8000), 'x'.repeat(8001)]) {
+    assert.equal(phone.chatSendError(c), web.chatSendError(c))
+  }
+  assert.equal(phone.MAX_CHAT_CONTENT, web.MAX_CHAT_CONTENT)
+})

--- a/apps/mobile/src/chat.ts
+++ b/apps/mobile/src/chat.ts
@@ -14,13 +14,25 @@ export interface ChatMsgLite {
 
 export const msgTime = (m: ChatMsgLite): number => new Date(m.createdAt as any).getTime()
 
+const ROLE_ORDER: Record<string, number> = { user: 0, assistant: 1 }
+
 /** Merge a polled window into the on-screen thread: dedupe by id (server copy
- *  wins), order by (createdAt, id) so same-second rows don't flicker. */
+ *  wins), order by (createdAt, question-before-answer within a task, id).
+ *  createdAt is second-precision and ids are random UUIDs, so a same-second
+ *  Q/A pair needs the taskId+role tie-break to render in true order. */
 export function mergeThread(existing: ChatMsgLite[], incoming: ChatMsgLite[]): ChatMsgLite[] {
   const byId = new Map<string, ChatMsgLite>()
   for (const m of existing) byId.set(m.id, m)
   for (const m of incoming) byId.set(m.id, m)
-  return [...byId.values()].sort((a, b) => (msgTime(a) - msgTime(b)) || String(a.id).localeCompare(String(b.id)))
+  return [...byId.values()].sort((a, b) => {
+    const dt = msgTime(a) - msgTime(b)
+    if (dt) return dt
+    if (a.taskId && a.taskId === b.taskId) {
+      const dr = (ROLE_ORDER[a.role] ?? 2) - (ROLE_ORDER[b.role] ?? 2)
+      if (dr) return dr
+    }
+    return String(a.id).localeCompare(String(b.id))
+  })
 }
 
 /** Waiting on the agent? True when the user spoke last — drives the ⏳ row. */

--- a/apps/mobile/src/chat.ts
+++ b/apps/mobile/src/chat.ts
@@ -1,0 +1,47 @@
+// MCC-1 — the chat thread's pure logic, the phone's copy of web/lib/chat.logic.ts.
+//
+// COPIED, not imported: Metro only bundles inside apps/mobile, so the app cannot
+// import the web module at runtime. `chat.test.ts` imports BOTH and drives them
+// with the same inputs — the parity pin that fails the day these drift.
+
+export interface ChatMsgLite {
+  id: string
+  role: string
+  content: string
+  taskId?: string | null
+  createdAt: string | number | Date
+}
+
+export const msgTime = (m: ChatMsgLite): number => new Date(m.createdAt as any).getTime()
+
+/** Merge a polled window into the on-screen thread: dedupe by id (server copy
+ *  wins), order by (createdAt, id) so same-second rows don't flicker. */
+export function mergeThread(existing: ChatMsgLite[], incoming: ChatMsgLite[]): ChatMsgLite[] {
+  const byId = new Map<string, ChatMsgLite>()
+  for (const m of existing) byId.set(m.id, m)
+  for (const m of incoming) byId.set(m.id, m)
+  return [...byId.values()].sort((a, b) => (msgTime(a) - msgTime(b)) || String(a.id).localeCompare(String(b.id)))
+}
+
+/** Waiting on the agent? True when the user spoke last — drives the ⏳ row. */
+export function awaitingReply(messages: ChatMsgLite[]): boolean {
+  if (!messages.length) return false
+  return messages[messages.length - 1].role === 'user'
+}
+
+/** One-line preview for the agent strip — newest message, squeezed. */
+export function threadPreview(messages: ChatMsgLite[], max = 64): string {
+  const last = messages[messages.length - 1]
+  if (!last) return ''
+  const flat = String(last.content ?? '').replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
+}
+
+/** Validation mirror of the server's rules — refuse before the round-trip. */
+export const MAX_CHAT_CONTENT = 8000
+export function chatSendError(content: string): string | null {
+  const trimmed = content.trim()
+  if (!trimmed) return 'Message is empty.'
+  if (trimmed.length > MAX_CHAT_CONTENT) return `Message is too long (max ${MAX_CHAT_CONTENT} characters).`
+  return null
+}

--- a/apps/mobile/src/inboxSegments.ts
+++ b/apps/mobile/src/inboxSegments.ts
@@ -29,6 +29,7 @@ export interface InboxSegment {
  */
 export const INBOX_SEGMENTS: InboxSegment[] = [
   { id: 'inbox', label: 'Inbox' },
+  { id: 'chat', label: 'Chat' }, // MCC-1 — the web's Chat tab, foldable and ready
   { id: 'tasks', label: 'Tasks' },
 ]
 

--- a/apps/mobile/src/navModel.test.ts
+++ b/apps/mobile/src/navModel.test.ts
@@ -140,6 +140,7 @@ test("'ready' is exactly the set of screens that exist", () => {
       'agents',
       'assistant',
       'budgets',
+      'chat', // MCC-1 — the Inbox screen's Chat segment (ChatPane)
       'connectors',
       'costs',
       'governance',

--- a/apps/mobile/src/navModel.ts
+++ b/apps/mobile/src/navModel.ts
@@ -120,6 +120,17 @@ export const NAV_GROUPS: NavGroup[] = [
       // its Tasks segment (navigation.tsx `TasksEntry` → InboxScreen). The entry
       // stays: it is a web surface, so the model owes it a destination and More
       // still lists it. What changed is where it renders, not whether it exists.
+      // MCC-1 — Chat: direct conversation with an agent, replies included. A
+      // hosted tab under Inbox on the web (before Tasks in its bar), rendered
+      // here as a segment of the same Inbox screen.
+      {
+        id: 'chat',
+        label: 'Chat',
+        glyph: '💬',
+        status: 'ready',
+        blurb: 'Talk to an agent — thread and composer, replies included.',
+        webHosted: 'inbox',
+      },
       {
         id: 'tasks',
         label: 'Tasks',

--- a/apps/mobile/src/navigation.tsx
+++ b/apps/mobile/src/navigation.tsx
@@ -78,6 +78,9 @@ const SCREENS: Record<string, React.ComponentType<ScreenNav>> = {
   // with the Tasks segment selected, which is what the web's Tasks tab does too.
   // The Task Log component itself is unchanged; InboxScreen hosts it.
   tasks: TasksEntry,
+  // MCC-1 — Chat renders inside the Inbox too, on its own segment (the web hosts
+  // it as an Inbox tab). Same named-component rule as TasksEntry.
+  chat: ChatEntry,
   // MOB-6d — Delivery's cost pair (Budgets is the web's hosted tab under Costs,
   // so the two stay adjacent), plus the Activity feed.
   costs: CostsScreen,
@@ -106,6 +109,11 @@ const SCREENS: Record<string, React.ComponentType<ScreenNav>> = {
  */
 function TasksEntry(nav: ScreenNav) {
   return <InboxScreen {...nav} initialSegment="tasks" />
+}
+
+/** MCC-1 — the `chat` destination: the Inbox screen opened on its Chat segment. */
+function ChatEntry(nav: ScreenNav) {
+  return <InboxScreen {...nav} initialSegment="chat" />
 }
 
 /**

--- a/apps/mobile/src/screens/ChatPane.tsx
+++ b/apps/mobile/src/screens/ChatPane.tsx
@@ -1,0 +1,221 @@
+// MCC-1 — Chat: talk to any agent from the phone, replies included.
+//
+// MIRRORS the web's ChatPanel over the SAME org-scoped routes
+// (GET/POST /api/orgs/:orgId/agents/:agentId/chat). One contract, two runtimes:
+// an INTERNAL agent's reply is in the POST response; an EXTERNAL agent's reply
+// arrives later through its poll loop, so this pane keeps polling the GET.
+// Merging/awaiting/preview logic is ../chat.ts — the parity-pinned copy of
+// web/lib/chat.logic.ts, so both clients converge on the same thread.
+//
+// Layout: an agent strip (horizontal chips) over the thread over the composer,
+// inside a KeyboardAvoidingView — the full-screen `flex: 1` shell shape, the
+// same pattern CommandCenterScreen uses (and the AAD-2 keyboard lesson says a
+// composer the keyboard can cover is a bug, not a nit).
+// Colorblind rule: user/assistant sides read from ALIGNMENT + label, never hue.
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { Api, type Agent } from '../api'
+import { useAuth } from '../auth'
+import { awaitingReply, chatSendError, mergeThread, threadPreview, type ChatMsgLite } from '../chat'
+import { font, space, theme } from '../theme'
+import { Banner, Empty, Loading } from '../ui'
+
+const POLL_MS = 4000
+
+export default function ChatPane() {
+  const { apiUrl, getToken, orgId } = useAuth()
+  const [agents, setAgents] = useState<Agent[] | null>(null)
+  const [sel, setSel] = useState<string | null>(null)
+  const [threads, setThreads] = useState<Record<string, ChatMsgLite[]>>({})
+  const [external, setExternal] = useState<Record<string, boolean>>({})
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const scroller = useRef<ScrollView>(null)
+
+  // Roster once; select the first agent so the pane opens on a real thread.
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      try {
+        const token = await getToken()
+        if (!token || !orgId) return
+        const list = await Api.agents(apiUrl, token, orgId)
+        if (!alive) return
+        setAgents(list)
+        setSel((s) => s ?? list[0]?.id ?? null)
+      } catch (e: any) {
+        if (alive) { setAgents([]); setError(e?.message ?? 'Failed to load agents.') }
+      }
+    })()
+    return () => { alive = false }
+  }, [apiUrl, getToken, orgId])
+
+  const load = useCallback(async (agentId: string) => {
+    try {
+      const token = await getToken()
+      if (!token || !orgId) return
+      const r = await Api.agentChat(apiUrl, token, orgId, agentId)
+      setThreads((t) => ({ ...t, [agentId]: mergeThread(t[agentId] ?? [], r.messages) }))
+      setExternal((x) => ({ ...x, [agentId]: r.agent.external }))
+      setError(null)
+    } catch (e: any) { setError(e?.message ?? 'Failed to load the thread.') }
+  }, [apiUrl, getToken, orgId])
+
+  // Poll the selected thread — external replies arrive out-of-band.
+  useEffect(() => {
+    if (!sel) return
+    load(sel)
+    const t = setInterval(() => load(sel), POLL_MS)
+    return () => clearInterval(t)
+  }, [sel, load])
+
+  const msgs = sel ? threads[sel] ?? [] : []
+  useEffect(() => { scroller.current?.scrollToEnd({ animated: false }) }, [msgs.length, sel])
+
+  const send = useCallback(async () => {
+    if (!sel || sending) return
+    const problem = chatSendError(input)
+    if (problem) { setError(problem); return }
+    const content = input.trim()
+    setSending(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      if (!token || !orgId) return
+      const r = await Api.sendAgentChat(apiUrl, token, orgId, sel, content)
+      setInput('')
+      setThreads((t) => ({
+        ...t,
+        [sel]: mergeThread(t[sel] ?? [], [r.message, ...(r.reply ? [r.reply] : [])]),
+      }))
+    } catch (e: any) { setError(e?.message ?? 'Send failed.') }
+    finally { setSending(false) }
+  }, [sel, sending, input, apiUrl, getToken, orgId])
+
+  if (agents === null) return <Loading text="Loading agents…" />
+  if (agents.length === 0) return <Empty text="No agents yet — add one from the Agents tab." />
+
+  const selAgent = agents.find((a) => a.id === sel) ?? null
+  const waiting = awaitingReply(msgs) && (external[sel ?? ''] ?? false)
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={90}
+    >
+      {/* ── Agent strip ── */}
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.strip} contentContainerStyle={s.stripInner}>
+        {agents.map((a) => {
+          const active = a.id === sel
+          return (
+            <Pressable key={a.id} onPress={() => setSel(a.id)}
+              accessibilityRole="tab" accessibilityState={{ selected: active }}
+              style={({ pressed }) => [s.agentChip, active && s.agentChipOn, pressed && { opacity: 0.7 }]}>
+              <Text style={[s.agentChipText, active && s.agentChipTextOn]} numberOfLines={1}>
+                {a.avatarEmoji ? `${a.avatarEmoji} ` : ''}{a.name}
+              </Text>
+              {!!threadPreview(threads[a.id] ?? [], 24) && (
+                <Text style={s.agentChipPreview} numberOfLines={1}>{threadPreview(threads[a.id] ?? [], 24)}</Text>
+              )}
+            </Pressable>
+          )
+        })}
+      </ScrollView>
+
+      {/* ── Thread ── */}
+      <ScrollView ref={scroller} style={s.thread} contentContainerStyle={{ padding: space.lg }}>
+        {msgs.length === 0 && <Empty text={selAgent ? `No messages with ${selAgent.name} yet — say hello.` : 'Select an agent.'} />}
+        {msgs.map((m) => {
+          const mine = m.role === 'user'
+          return (
+            <View key={m.id} style={[s.bubbleRow, { justifyContent: mine ? 'flex-end' : 'flex-start' }]}>
+              <View style={[s.bubble, mine ? s.bubbleMine : s.bubbleTheirs]}>
+                <Text style={s.bubbleMeta}>
+                  {mine ? 'You' : selAgent?.name ?? 'Agent'} · {new Date(m.createdAt as any).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                </Text>
+                <Text style={s.bubbleText}>{m.content}</Text>
+              </View>
+            </View>
+          )
+        })}
+        {waiting && selAgent && (
+          <Text style={s.waiting}>⏳ Delivered — awaiting {selAgent.name}’s reply…</Text>
+        )}
+      </ScrollView>
+
+      {error && <View style={{ paddingHorizontal: space.lg }}><Banner kind="error">{error}</Banner></View>}
+
+      {/* ── Composer ── */}
+      <View style={s.composer}>
+        <TextInput
+          style={s.inputBox}
+          value={input}
+          onChangeText={setInput}
+          placeholder={selAgent ? `Message ${selAgent.name}…` : 'Message…'}
+          placeholderTextColor={theme.textDim}
+          multiline
+          accessibilityLabel={selAgent ? `Message ${selAgent.name}` : 'Message'}
+        />
+        <Pressable
+          onPress={send}
+          disabled={sending || !input.trim() || !sel}
+          accessibilityRole="button"
+          accessibilityLabel="Send message"
+          style={({ pressed }) => [s.sendBtn, (sending || !input.trim()) && { opacity: 0.4 }, pressed && { opacity: 0.7 }]}
+        >
+          <Text style={s.sendBtnText}>{sending ? '…' : '➤'}</Text>
+        </Pressable>
+      </View>
+    </KeyboardAvoidingView>
+  )
+}
+
+const s = StyleSheet.create({
+  strip: { flexGrow: 0, borderBottomWidth: 1, borderBottomColor: theme.s3 },
+  stripInner: { paddingHorizontal: space.lg, paddingVertical: space.md, gap: space.sm },
+  agentChip: {
+    paddingVertical: space.sm, paddingHorizontal: space.md,
+    borderRadius: 10, borderWidth: 1, borderColor: theme.s3, backgroundColor: theme.s1,
+    maxWidth: 180,
+  },
+  agentChipOn: { borderColor: theme.blue, backgroundColor: theme.s2 },
+  agentChipText: { color: theme.textDim, fontSize: font.base, fontWeight: '600' },
+  agentChipTextOn: { color: theme.text, fontWeight: '800' },
+  agentChipPreview: { color: theme.textDim, fontSize: font.sm },
+  thread: { flex: 1 },
+  bubbleRow: { flexDirection: 'row', marginBottom: space.sm },
+  bubble: { maxWidth: '80%', borderRadius: 12, paddingVertical: space.sm, paddingHorizontal: space.md, borderWidth: 1 },
+  bubbleMine: { backgroundColor: theme.s2, borderColor: theme.blue },
+  bubbleTheirs: { backgroundColor: theme.s1, borderColor: theme.s3 },
+  bubbleMeta: { color: theme.textDim, fontSize: font.sm, marginBottom: 2 },
+  bubbleText: { color: theme.text, fontSize: font.base, lineHeight: 20 },
+  waiting: { color: theme.textDim, fontSize: font.sm, paddingVertical: space.sm },
+  composer: {
+    flexDirection: 'row', alignItems: 'flex-end', gap: space.sm,
+    paddingHorizontal: space.lg, paddingVertical: space.md,
+    borderTopWidth: 1, borderTopColor: theme.s3, backgroundColor: theme.bg,
+  },
+  inputBox: {
+    flex: 1, minHeight: 40, maxHeight: 120,
+    borderWidth: 1, borderColor: theme.s3, borderRadius: 10,
+    paddingHorizontal: space.md, paddingVertical: space.sm,
+    color: theme.text, fontSize: font.base, backgroundColor: theme.s1,
+  },
+  sendBtn: {
+    width: 40, height: 40, borderRadius: 10, alignItems: 'center', justifyContent: 'center',
+    backgroundColor: theme.blue,
+  },
+  sendBtnText: { color: '#fff', fontSize: 18, fontWeight: '800' },
+})

--- a/apps/mobile/src/screens/ChatPane.tsx
+++ b/apps/mobile/src/screens/ChatPane.tsx
@@ -85,6 +85,7 @@ export default function ChatPane() {
 
   const send = useCallback(async () => {
     if (!sel || sending) return
+    if (!input.trim()) return // an empty composer is a no-op, not an error
     const problem = chatSendError(input)
     if (problem) { setError(problem); return }
     const content = input.trim()
@@ -99,6 +100,9 @@ export default function ChatPane() {
         ...t,
         [sel]: mergeThread(t[sel] ?? [], [r.message, ...(r.reply ? [r.reply] : [])]),
       }))
+      // A governance/budget refusal is a NOTICE, not a reply — the server does
+      // not persist it into the thread, so surface it here.
+      if (r.notice) setError(String(r.notice))
     } catch (e: any) { setError(e?.message ?? 'Send failed.') }
     finally { setSending(false) }
   }, [sel, sending, input, apiUrl, getToken, orgId])

--- a/apps/mobile/src/screens/InboxScreen.tsx
+++ b/apps/mobile/src/screens/InboxScreen.tsx
@@ -29,6 +29,7 @@ import { INBOX_SEGMENTS, isInboxSegment, resolveInboxSegment } from '../inboxSeg
 import { font, space, theme } from '../theme'
 import type { ScreenNav } from '../navigation'
 import ApprovalsPane from './ApprovalsPane'
+import ChatPane from './ChatPane'
 import TasksScreen from './TasksScreen'
 
 export default function InboxScreen({
@@ -79,7 +80,10 @@ export default function InboxScreen({
       <View style={s.pane}>
         {/* The Task Log is read-only and takes only `onOpenTab` — it drills into
             no agent, so there is no onOpenAgent to forward. */}
-        {segment === 'tasks' ? (
+        {/* MCC-1 — the Chat segment renders the agent-conversation pane. */}
+        {segment === 'chat' ? (
+          <ChatPane />
+        ) : segment === 'tasks' ? (
           <TasksScreen onOpenTab={openTab} />
         ) : (
           <ApprovalsPane />

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -24,6 +24,7 @@ import { usageRoutes } from './middleware/ratelimit'
 import { modelRoutes } from './routes/models'
 import { scheduledRoutes, routineTriggerRoutes } from './routes/scheduled'
 import { agentDetailRoutes } from './routes/agent-detail'
+import { agentChatRoutes } from './routes/agent-chat'
 import { webhookRoutes } from './routes/webhooks'
 import { telegramWebhookRoutes } from './routes/telegram-webhook'
 import { arturitaRoutes, arturitaPublicRoutes } from './routes/arturita'
@@ -184,6 +185,7 @@ async function start() {
     await secured.register(orgRoutes)
     await secured.register(agentRoutes)
     await secured.register(agentDetailRoutes)   // Epic AG — per-agent detail page (org-scoped)
+    await secured.register(agentChatRoutes)     // MCC-1 — org-scoped agent chat threads
     await secured.register(taskRoutes)
     await secured.register(projectRoutes)
     await secured.register(costRoutes)

--- a/backend/src/routes/agent-chat.ts
+++ b/backend/src/routes/agent-chat.ts
@@ -1,0 +1,110 @@
+// ─── MCC-1 — chat with an agent, replies included ────────────────────────────
+//
+// The thread IS the `messages` table (role user/assistant per agent) — no new
+// store. Sending rides the existing task machinery: an INTERNAL agent answers
+// synchronously through executeAgentTask (the legacy /api/agents/:agentId/chat
+// pattern), and an EXTERNAL agent gets the message as an assigned task its poll
+// loop claims — its POST /api/agent/tasks/:taskId/result already inserts the
+// assistant reply into this same thread, so the UI only has to poll the GET.
+//
+// Tenancy: both routes are org-scoped and re-assert the agent belongs to the org
+// via agentInOrg() (the AAD-1 pattern), 404 on wrong-org / unknown / soft-deleted
+// — indistinguishable, no existence oracle. The legacy top-level
+// GET /api/agents/:agentId/messages predates this and stays for compat; these are
+// the blessed paths.
+import { FastifyInstance } from 'fastify'
+import { randomUUID } from 'crypto'
+import { and, desc, eq, gt } from 'drizzle-orm'
+import { db, schema } from '../db/client'
+import { agentInOrg } from './agent-detail'
+import { executeAgentTask } from '../services/agent-executor'
+import { isExternalAgent } from '../services/agent-runtime'
+
+const MAX_LIMIT = 200
+const DEFAULT_LIMIT = 100
+const MAX_CONTENT_CHARS = 8000
+// How much prior thread the internal executor replays as context. Server-built:
+// the legacy /chat trusted a client-supplied history array, which let the caller
+// put words in the assistant's mouth; reading it back from the DB does not.
+const HISTORY_ROWS = 40
+
+export async function agentChatRoutes(app: FastifyInstance) {
+  // ── Read the thread ──────────────────────────────────────────────────────
+  // Newest-N returned in ascending render order. `since` (ms epoch) returns
+  // only strictly-newer rows so the UI can poll cheaply. An ascending LIMIT N
+  // without the desc-then-reverse would return the OLDEST N — wrong window.
+  app.get('/api/orgs/:orgId/agents/:agentId/chat', async (req, reply) => {
+    const { orgId, agentId } = req.params as any
+    const agent = await agentInOrg(orgId, agentId)
+    if (!agent || (agent as any).deletedAt) return reply.code(404).send({ error: 'Not found' })
+    const q = (req.query ?? {}) as any
+    const limit = Math.max(1, Math.min(Number(q.limit) || DEFAULT_LIMIT, MAX_LIMIT))
+    let since: number | null = null
+    if (q.since !== undefined) {
+      since = Number(q.since)
+      if (!Number.isFinite(since)) return reply.code(400).send({ error: 'since must be a millisecond timestamp' })
+    }
+    const where = since !== null
+      ? and(eq(schema.messages.agentId, agentId), gt(schema.messages.createdAt, new Date(since)))
+      : eq(schema.messages.agentId, agentId)
+    const rows = await db.select().from(schema.messages).where(where)
+      .orderBy(desc(schema.messages.createdAt), desc(schema.messages.id)).limit(limit)
+    rows.reverse()
+    return {
+      messages: rows,
+      agent: {
+        id: agent.id, name: agent.name,
+        avatarEmoji: (agent as any).avatarEmoji ?? null,
+        runtime: (agent as any).runtime ?? 'internal',
+        external: isExternalAgent(agent as any),
+      },
+    }
+  })
+
+  // ── Send into the thread ─────────────────────────────────────────────────
+  // Member-level deliberately (talking to staff is not a destructive act); the
+  // org-membership gate on the secured scope has already run.
+  app.post('/api/orgs/:orgId/agents/:agentId/chat', async (req, reply) => {
+    const { orgId, agentId } = req.params as any
+    const agent = await agentInOrg(orgId, agentId)
+    if (!agent || (agent as any).deletedAt) return reply.code(404).send({ error: 'Not found' })
+    const content = String((req.body as any)?.content ?? '').trim()
+    if (!content) return reply.code(400).send({ error: 'content is required' })
+    if (content.length > MAX_CONTENT_CHARS) {
+      return reply.code(400).send({ error: `content too long (max ${MAX_CONTENT_CHARS} chars)` })
+    }
+
+    // The message becomes a task so BOTH runtimes share one lifecycle — and so
+    // the external poll loop can see it at all. orgId comes from the PATH the
+    // membership gate authorised, never from the body (GC-0b).
+    const taskId = randomUUID()
+    await db.insert(schema.tasks).values({
+      id: taskId, agentId, orgId, title: `chat: ${content.slice(0, 80)}`,
+      input: content, status: 'pending', priority: 'medium', createdAt: new Date(),
+    } as any)
+    const userMsg = { id: randomUUID(), agentId, taskId, role: 'user' as const, content, createdAt: new Date() }
+    await db.insert(schema.messages).values(userMsg)
+
+    if (isExternalAgent(agent as any)) {
+      // Assign for the runtime's poll loop; its /result inserts the assistant
+      // reply. The placeholder output is a status, NOT a message — inserting it
+      // would put boilerplate in the thread ahead of the real reply.
+      await executeAgentTask({ agentId, taskId, input: content, conversationHistory: [] })
+      return { ok: true, async: true, taskId, message: userMsg }
+    }
+
+    // Internal: answer now, replaying the recent thread (excluding the row just
+    // written — executeAgentTask appends `input` itself, so including it would
+    // send the question twice).
+    const prior = await db.select().from(schema.messages)
+      .where(eq(schema.messages.agentId, agentId))
+      .orderBy(desc(schema.messages.createdAt), desc(schema.messages.id)).limit(HISTORY_ROWS)
+    const history = prior.reverse()
+      .filter(m => m.id !== userMsg.id && (m.role === 'user' || m.role === 'assistant') && !!m.content)
+      .map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }))
+    const result = await executeAgentTask({ agentId, taskId, input: content, conversationHistory: history })
+    const assistant = { id: randomUUID(), agentId, taskId, role: 'assistant' as const, content: result.output, createdAt: new Date() }
+    await db.insert(schema.messages).values(assistant)
+    return { ok: true, async: false, taskId, message: userMsg, reply: assistant, tokensUsed: result.tokensUsed, costUsd: result.costUsd }
+  })
+}

--- a/backend/src/routes/agent-chat.ts
+++ b/backend/src/routes/agent-chat.ts
@@ -14,7 +14,7 @@
 // the blessed paths.
 import { FastifyInstance } from 'fastify'
 import { randomUUID } from 'crypto'
-import { and, desc, eq, gt } from 'drizzle-orm'
+import { and, desc, eq, gte, sql } from 'drizzle-orm'
 import { db, schema } from '../db/client'
 import { agentInOrg } from './agent-detail'
 import { executeAgentTask } from '../services/agent-executor'
@@ -30,9 +30,20 @@ const HISTORY_ROWS = 40
 
 export async function agentChatRoutes(app: FastifyInstance) {
   // ── Read the thread ──────────────────────────────────────────────────────
-  // Newest-N returned in ascending render order. `since` (ms epoch) returns
-  // only strictly-newer rows so the UI can poll cheaply. An ascending LIMIT N
-  // without the desc-then-reverse would return the OLDEST N — wrong window.
+  // Newest-N returned in ascending render order. An ascending LIMIT N without
+  // the desc-then-reverse would return the OLDEST N — wrong window.
+  //
+  // ORDERING (audit MCC-1 #1): `createdAt` is stored at SECOND precision
+  // (drizzle integer timestamp), and message ids are random UUIDs — so id is
+  // NOT a usable tie-break. `rowid` is: it is SQLite's monotonic insertion
+  // order, and every writer of this thread (chat POST below, the agent /result
+  // handler) inserts the question before its answer. Same-second pairs
+  // therefore render in true order, deterministically.
+  //
+  // `since` (ms epoch) is a cheap-poll window, GTE at second granularity: the
+  // boundary second is RE-delivered rather than newer same-second rows being
+  // missed (gt at floored seconds silently dropped them — audit #3). Clients
+  // merge by id, so re-delivery is free and loss is not.
   app.get('/api/orgs/:orgId/agents/:agentId/chat', async (req, reply) => {
     const { orgId, agentId } = req.params as any
     const agent = await agentInOrg(orgId, agentId)
@@ -45,10 +56,10 @@ export async function agentChatRoutes(app: FastifyInstance) {
       if (!Number.isFinite(since)) return reply.code(400).send({ error: 'since must be a millisecond timestamp' })
     }
     const where = since !== null
-      ? and(eq(schema.messages.agentId, agentId), gt(schema.messages.createdAt, new Date(since)))
+      ? and(eq(schema.messages.agentId, agentId), gte(schema.messages.createdAt, new Date(since)))
       : eq(schema.messages.agentId, agentId)
     const rows = await db.select().from(schema.messages).where(where)
-      .orderBy(desc(schema.messages.createdAt), desc(schema.messages.id)).limit(limit)
+      .orderBy(desc(schema.messages.createdAt), desc(sql`rowid`)).limit(limit)
     rows.reverse()
     return {
       messages: rows,
@@ -93,16 +104,40 @@ export async function agentChatRoutes(app: FastifyInstance) {
       return { ok: true, async: true, taskId, message: userMsg }
     }
 
-    // Internal: answer now, replaying the recent thread (excluding the row just
-    // written — executeAgentTask appends `input` itself, so including it would
-    // send the question twice).
+    // Internal: answer now, replaying the recent thread as context.
+    // PROVENANCE FILTER (audit MCC-1 #4): only rows tied to a TASK are replayed.
+    // Chat and task flows always write a taskId; the two plantable writers do
+    // not — `POST …/comms/inbox/send` (same-org member can insert an
+    // assistant-role row) and the Telegram webhook (unauthenticated when no
+    // signing secret is set) both insert taskId:null. Those rows may still
+    // RENDER in the thread, but they never re-enter the model's prompt.
+    // Also excluded: the row just written (executeAgentTask appends `input`
+    // itself — including it would send the question twice).
     const prior = await db.select().from(schema.messages)
       .where(eq(schema.messages.agentId, agentId))
-      .orderBy(desc(schema.messages.createdAt), desc(schema.messages.id)).limit(HISTORY_ROWS)
+      .orderBy(desc(schema.messages.createdAt), desc(sql`rowid`)).limit(HISTORY_ROWS)
     const history = prior.reverse()
-      .filter(m => m.id !== userMsg.id && (m.role === 'user' || m.role === 'assistant') && !!m.content)
+      .filter(m => m.id !== userMsg.id && !!m.taskId && (m.role === 'user' || m.role === 'assistant') && !!m.content)
       .map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }))
-    const result = await executeAgentTask({ agentId, taskId, input: content, conversationHistory: history })
+
+    // Refusals and failures must not become "replies" (audit MCC-1 #5): a
+    // governance/budget/preflight hard-stop is a NOTICE to the operator, not
+    // the agent speaking — persisting it would pollute the thread and the next
+    // turn's history. And a THROW (budget/concurrency guards) must fail the
+    // task it already created rather than 500 with an orphaned pending row.
+    let result
+    try {
+      result = await executeAgentTask({ agentId, taskId, input: content, conversationHistory: history })
+    } catch (e: any) {
+      const msg = String(e?.message ?? 'Agent execution failed.')
+      await db.update(schema.tasks).set({ status: 'failed', output: msg } as any)
+        .where(eq(schema.tasks.id, taskId)).catch(() => {})
+      return reply.code(502).send({ error: msg, taskId })
+    }
+    const REFUSAL_PROVIDERS = new Set(['governance', 'budget', 'preflight'])
+    if (REFUSAL_PROVIDERS.has(String((result as any).provider ?? ''))) {
+      return { ok: false, async: false, taskId, message: userMsg, notice: result.output }
+    }
     const assistant = { id: randomUUID(), agentId, taskId, role: 'assistant' as const, content: result.output, createdAt: new Date() }
     await db.insert(schema.messages).values(assistant)
     return { ok: true, async: false, taskId, message: userMsg, reply: assistant, tokensUsed: result.tokensUsed, costUsd: result.costUsd }

--- a/backend/src/routes/comms.ts
+++ b/backend/src/routes/comms.ts
@@ -40,19 +40,25 @@ export async function commsRoutes(app: FastifyInstance) {
     const { orgId } = req.params as any
     const { channel, limit = '50' } = req.query as any
 
-    const messages = await db.select().from(schema.messages)
+    // MCC-1 tenancy fix: this selected from `messages` with NO org filter — every
+    // org's rows, with other orgs' agents rendered as "Unknown". Messages carry no
+    // orgId column, so scope by JOINING the org's agents (the same derivation the
+    // membership gate uses).
+    const rows = await db.select({
+        m: schema.messages,
+        agentName: schema.agents.name,
+        agentEmoji: schema.agents.avatarEmoji,
+      })
+      .from(schema.messages)
+      .innerJoin(schema.agents, eq(schema.messages.agentId, schema.agents.id))
+      .where(eq(schema.agents.orgId, orgId))
       .orderBy(desc(schema.messages.createdAt))
       .limit(Number(limit))
 
-    // Enrich with agent info
-    const agents = await db.select({ id: schema.agents.id, name: schema.agents.name, avatarEmoji: schema.agents.avatarEmoji })
-      .from(schema.agents).where(eq(schema.agents.orgId, orgId))
-    const agentMap = new Map(agents.map(a => [a.id, a]))
-
-    const enriched = messages.map(m => ({
-      ...m,
-      agentName: agentMap.get(m.agentId)?.name ?? 'Unknown',
-      agentEmoji: agentMap.get(m.agentId)?.avatarEmoji ?? '🤖',
+    const enriched = rows.map(r => ({
+      ...r.m,
+      agentName: r.agentName ?? 'Unknown',
+      agentEmoji: r.agentEmoji ?? '🤖',
     }))
 
     return { messages: enriched, total: enriched.length }

--- a/backend/src/routes/comms.ts
+++ b/backend/src/routes/comms.ts
@@ -53,7 +53,8 @@ export async function commsRoutes(app: FastifyInstance) {
       .innerJoin(schema.agents, eq(schema.messages.agentId, schema.agents.id))
       .where(eq(schema.agents.orgId, orgId))
       .orderBy(desc(schema.messages.createdAt))
-      .limit(Number(limit))
+      // Clamped: `?limit=abc` used to reach the driver as LIMIT NaN → 500.
+      .limit(Math.max(1, Math.min(Number(limit) || 50, 200)))
 
     const enriched = rows.map(r => ({
       ...r.m,

--- a/backend/src/tests/agent-chat.test.ts
+++ b/backend/src/tests/agent-chat.test.ts
@@ -1,0 +1,223 @@
+// ─── MCC-1 — org-scoped agent chat threads ───────────────────────────────────
+//
+// GET/POST /api/orgs/:orgId/agents/:agentId/chat (routes/agent-chat.ts).
+// Behavioural: real routes, real membership gate, real in-memory DB, and the
+// REAL agent-api surface for the external round-trip (claim → result → the
+// assistant reply lands in the same thread the UI polls).
+//
+// Tenancy pincer, both jaws:
+//   • an outsider (member of org B) on org A's path → 403 at the membership gate
+//   • an insider (owner of org A) naming org B's agent → 404 from agentInOrg
+// Plus the comms/inbox regression: the unified feed previously selected from
+// `messages` with NO org filter — cross-org rows are asserted ABSENT now.
+
+import { test, before, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import Fastify, { type FastifyInstance } from 'fastify'
+
+process.env.DATABASE_URL = ':memory:'
+process.env.SECRETS_ENC_KEY = 'mcc-agent-chat-key'
+delete process.env.MC_ENABLE_REMOTE_ONBOARDING
+
+let db: any, schema: any
+let app: FastifyInstance        // clerk-secured surface (chat + comms)
+let agentApp: FastifyInstance   // agent-token surface (claim/result — the real thing)
+let hashToken: (t: string) => string
+let eq: any
+
+const ORG_A = 'mcc-org-a'
+const ORG_B = 'mcc-org-b'
+const OWNER_A = 'mcc-owner-a'
+const MEMBER_A = 'mcc-member-a'
+const MEMBER_B = 'mcc-member-b'
+const EXT_A = 'mcc-ext-a'       // external (openclaw) agent in ORG_A — the chat target
+const EXT_B = 'mcc-ext-b'       // external agent in ORG_B — isolation control
+const EXT_A_TOKEN = 'mca_mcc_ext_a_token_value_0123456789abcdef'
+
+const CREATED_AT = new Date('2020-01-01T00:00:00Z')
+
+const agentRow = (id: string, orgId: string, name: string, extra: Record<string, unknown> = {}) => ({
+  id, orgId, name, role: 'Ops', personality: 'terse', llmProvider: 'anthropic',
+  llmModel: 'claude-sonnet-4-20250514', status: 'idle', agentType: 'standard',
+  runtime: 'openclaw', trustMode: 'low_trust_review', permissions: null,
+  apiTokenHash: null, deletedAt: null, deletedBy: null, createdAt: CREATED_AT, ...extra,
+})
+
+const msgRow = (id: string, agentId: string, role: string, content: string, at: Date) =>
+  ({ id, agentId, taskId: null, role, content, createdAt: at })
+
+before(async () => {
+  ;({ db, schema } = await import('../db/client'))
+  await (await import('../db/setup')).setupDatabase()
+  ;({ hashToken } = await import('../middleware/agent-token'))
+  const { agentAuth } = await import('../middleware/agent-token')
+  const { requireOrgMembership } = await import('../middleware/rbac')
+  const { agentChatRoutes } = await import('../routes/agent-chat')
+  const { commsRoutes } = await import('../routes/comms')
+  const { agentApiRoutes } = await import('../routes/agent-api')
+  const { createClerkAuth } = await import('../middleware/clerk-auth')
+  const { registerJsonBodyParser } = await import('../middleware/body-parser')
+  ;({ eq } = await import('drizzle-orm'))
+
+  await db.insert(schema.organisations).values([
+    { id: ORG_A, name: 'Org A', ownerId: OWNER_A, createdAt: new Date() },
+    { id: ORG_B, name: 'Org B', ownerId: 'mcc-owner-b', createdAt: new Date() },
+  ])
+  await db.insert(schema.orgMembers).values([
+    { id: 'mcc-o-a', orgId: ORG_A, userId: OWNER_A, role: 'owner', createdAt: new Date() },
+    { id: 'mcc-m-a', orgId: ORG_A, userId: MEMBER_A, role: 'member', createdAt: new Date() },
+    { id: 'mcc-m-b', orgId: ORG_B, userId: MEMBER_B, role: 'member', createdAt: new Date() },
+  ])
+
+  app = Fastify({ logger: false })
+  registerJsonBodyParser(app)
+  await app.register(async (secured) => {
+    secured.addHook('onRequest', createClerkAuth(async (token: string) => ({ sub: token })))
+    secured.addHook('preHandler', requireOrgMembership)
+    await secured.register(agentChatRoutes)
+    await secured.register(commsRoutes)
+  })
+  await app.ready()
+
+  agentApp = Fastify({ logger: false })
+  registerJsonBodyParser(agentApp)
+  agentApp.addHook('onRequest', agentAuth)
+  await agentApp.register(agentApiRoutes)
+  await agentApp.ready()
+})
+
+const as = (user: string | null, method: string, url: string, body?: unknown) =>
+  app.inject({
+    method: method as any, url,
+    headers: { ...(user ? { authorization: `Bearer ${user}` } : {}), 'content-type': 'application/json' },
+    payload: body === undefined ? undefined : JSON.stringify(body),
+  })
+
+const asAgent = (token: string, method: string, url: string, body?: unknown) =>
+  agentApp.inject({
+    method: method as any, url,
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    payload: body === undefined ? undefined : JSON.stringify(body),
+  })
+
+beforeEach(async () => {
+  await db.delete(schema.messages)
+  await db.delete(schema.tasks)
+  await db.delete(schema.agentRuns)
+  await db.delete(schema.agents)
+  await db.insert(schema.agents).values([
+    agentRow(EXT_A, ORG_A, 'Ext A', { apiTokenHash: hashToken(EXT_A_TOKEN) }),
+    agentRow(EXT_B, ORG_B, 'Ext B'),
+  ] as any)
+})
+
+// ── Read path ────────────────────────────────────────────────────────────────
+
+test('[MCC-1] GET returns the newest-N window in ascending render order', async () => {
+  const t = (s: number) => new Date(CREATED_AT.getTime() + s * 1000)
+  await db.insert(schema.messages).values([
+    msgRow('m1', EXT_A, 'user', 'one', t(1)),
+    msgRow('m2', EXT_A, 'assistant', 'two', t(2)),
+    msgRow('m3', EXT_A, 'user', 'three', t(3)),
+  ] as any)
+  const r = await as(MEMBER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat?limit=2`)
+  assert.equal(r.statusCode, 200)
+  const body = r.json() as any
+  // limit=2 must be the LATEST two (an ascending LIMIT would wrongly return m1,m2)
+  assert.deepEqual(body.messages.map((m: any) => m.id), ['m2', 'm3'])
+  assert.equal(body.agent.external, true)
+})
+
+test('[MCC-1] GET since returns only strictly-newer rows', async () => {
+  const t1 = new Date(CREATED_AT.getTime() + 1000)
+  const t2 = new Date(CREATED_AT.getTime() + 60_000)
+  await db.insert(schema.messages).values([
+    msgRow('m1', EXT_A, 'user', 'old', t1),
+    msgRow('m2', EXT_A, 'assistant', 'new', t2),
+  ] as any)
+  const r = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat?since=${t1.getTime()}`)
+  assert.equal(r.statusCode, 200)
+  assert.deepEqual((r.json() as any).messages.map((m: any) => m.id), ['m2'])
+  const bad = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat?since=nonsense`)
+  assert.equal(bad.statusCode, 400)
+})
+
+test('[MCC-1] tenancy pincer: outsider 403 at the gate, insider naming a foreign agent 404', async () => {
+  const outsider = await as(MEMBER_B, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`)
+  assert.equal(outsider.statusCode, 403)
+  const foreign = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_B}/chat`)
+  assert.equal(foreign.statusCode, 404)
+  const anon = await as(null, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`)
+  assert.equal(anon.statusCode, 401)
+})
+
+test('[MCC-1] soft-deleted agent is 404 on both verbs', async () => {
+  await db.update(schema.agents).set({ deletedAt: new Date(), status: 'deleted' })
+    .where(eq(schema.agents.id, EXT_A))
+  assert.equal((await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`)).statusCode, 404)
+  assert.equal((await as(OWNER_A, 'POST', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`, { content: 'hi' })).statusCode, 404)
+})
+
+// ── Send path ────────────────────────────────────────────────────────────────
+
+test('[MCC-1] POST to an external agent writes the user message and an assigned task (org from the PATH)', async () => {
+  const r = await as(MEMBER_A, 'POST', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`, { content: 'status report please' })
+  assert.equal(r.statusCode, 200)
+  const body = r.json() as any
+  assert.equal(body.async, true)
+  const task = (await db.select().from(schema.tasks).where(eq(schema.tasks.id, body.taskId)))[0]
+  assert.ok(task, 'task row exists')
+  assert.equal(task.orgId, ORG_A)
+  assert.equal(task.status, 'assigned')
+  const msgs = await db.select().from(schema.messages).where(eq(schema.messages.agentId, EXT_A))
+  assert.equal(msgs.length, 1)
+  assert.equal(msgs[0].role, 'user')
+  assert.equal(msgs[0].content, 'status report please')
+})
+
+test('[MCC-1] POST validation: empty and oversized content are refused, nothing is written', async () => {
+  assert.equal((await as(OWNER_A, 'POST', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`, { content: '  ' })).statusCode, 400)
+  assert.equal((await as(OWNER_A, 'POST', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`, { content: 'x'.repeat(8001) })).statusCode, 400)
+  assert.equal((await db.select().from(schema.messages)).length, 0)
+  assert.equal((await db.select().from(schema.tasks)).length, 0)
+})
+
+test('[MCC-1] POST cross-tenant leaves zero rows behind', async () => {
+  const r = await as(OWNER_A, 'POST', `/api/orgs/${ORG_A}/agents/${EXT_B}/chat`, { content: 'infiltrate' })
+  assert.equal(r.statusCode, 404)
+  assert.equal((await db.select().from(schema.messages)).length, 0)
+  assert.equal((await db.select().from(schema.tasks)).length, 0)
+})
+
+// ── The round-trip that makes it a CHAT: reply arrives through the thread ────
+
+test('[MCC-1] external round-trip: send → claim → result → assistant reply is in the same thread', async () => {
+  const sent = await as(OWNER_A, 'POST', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`, { content: 'ping?' })
+  assert.equal(sent.statusCode, 200)
+  const { taskId } = sent.json() as any
+
+  const claim = await asAgent(EXT_A_TOKEN, 'POST', `/api/agent/tasks/${taskId}/claim`, {})
+  assert.equal(claim.statusCode, 200)
+  const result = await asAgent(EXT_A_TOKEN, 'POST', `/api/agent/tasks/${taskId}/result`, { output: 'pong!', status: 'done' })
+  assert.equal(result.statusCode, 200)
+
+  const r = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`)
+  const msgs = (r.json() as any).messages
+  assert.deepEqual(msgs.map((m: any) => [m.role, m.content]), [['user', 'ping?'], ['assistant', 'pong!']])
+  assert.equal(msgs[1].taskId, taskId, 'reply is tied to the same task as the question')
+})
+
+// ── The comms/inbox regression ───────────────────────────────────────────────
+
+test('[MCC-1] comms/inbox is org-scoped — org B rows never appear in org A feed', async () => {
+  await db.insert(schema.messages).values([
+    msgRow('ma', EXT_A, 'assistant', 'ours', new Date()),
+    msgRow('mb', EXT_B, 'assistant', 'THEIRS', new Date()),
+  ] as any)
+  const r = await as(MEMBER_A, 'GET', `/api/orgs/${ORG_A}/comms/inbox`)
+  assert.equal(r.statusCode, 200)
+  const feed = (r.json() as any).messages
+  assert.ok(feed.some((m: any) => m.id === 'ma'), 'own org message present')
+  assert.ok(!feed.some((m: any) => m.id === 'mb'), 'foreign org message absent')
+  assert.ok(!JSON.stringify(feed).includes('THEIRS'), 'foreign content absent')
+})

--- a/backend/src/tests/agent-chat.test.ts
+++ b/backend/src/tests/agent-chat.test.ts
@@ -128,16 +128,22 @@ test('[MCC-1] GET returns the newest-N window in ascending render order', async 
   assert.equal(body.agent.external, true)
 })
 
-test('[MCC-1] GET since returns only strictly-newer rows', async () => {
+test('[MCC-1] GET since is a GTE window — boundary second re-delivered, same-second rows never missed', async () => {
   const t1 = new Date(CREATED_AT.getTime() + 1000)
   const t2 = new Date(CREATED_AT.getTime() + 60_000)
   await db.insert(schema.messages).values([
     msgRow('m1', EXT_A, 'user', 'old', t1),
-    msgRow('m2', EXT_A, 'assistant', 'new', t2),
+    msgRow('m2', EXT_A, 'assistant', 'boundary', t2),
+    msgRow('m3', EXT_A, 'user', 'same second as m2', t2),
   ] as any)
-  const r = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat?since=${t1.getTime()}`)
+  // since = the boundary second: BOTH rows in it come back (a gt at floored
+  // seconds silently dropped m3 forever — audit MCC-1 #3); clients dedupe by id.
+  const r = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat?since=${t2.getTime()}`)
   assert.equal(r.statusCode, 200)
-  assert.deepEqual((r.json() as any).messages.map((m: any) => m.id), ['m2'])
+  assert.deepEqual((r.json() as any).messages.map((m: any) => m.id).sort(), ['m2', 'm3'])
+  // a since past the newest row returns nothing
+  const empty = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat?since=${t2.getTime() + 1000}`)
+  assert.deepEqual((empty.json() as any).messages, [])
   const bad = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat?since=nonsense`)
   assert.equal(bad.statusCode, 400)
 })

--- a/backend/src/tests/boot.test.ts
+++ b/backend/src/tests/boot.test.ts
@@ -31,6 +31,7 @@ import { arturitaWalletRoutes } from '../routes/arturita-wallet'
 import { customModelRoutes } from '../routes/custom-models'
 import { agentInviteRoutes, adapterRegistryRoutes, agentInviteDocRoutes, agentJoinRoutes } from '../routes/agent-invites'
 import { activityRoutes } from '../routes/activity'
+import { agentChatRoutes } from '../routes/agent-chat'
 import { arturitaVoiceRoutes } from '../routes/arturita-voice'
 import { arturitaSttRoutes } from '../routes/arturita-stt'
 import { agentApiRoutes } from '../routes/agent-api'
@@ -67,6 +68,7 @@ test('app boots: all route groups register without collision', async () => {
     await secured.register(arturitaSttRoutes)   // MOB-5a — hosted STT
     await secured.register(agentInviteRoutes)
     await secured.register(activityRoutes)      // ACT-1 — unified activity feed
+    await secured.register(agentChatRoutes)     // MCC-1 — org-scoped agent chat threads
   })
 
   // Public / externally-called route groups.

--- a/backend/src/tests/membership-scoping.test.ts
+++ b/backend/src/tests/membership-scoping.test.ts
@@ -131,6 +131,7 @@ before(async () => {
   const { usageRoutes } = await import('../middleware/ratelimit')
   const { scheduledRoutes } = await import('../routes/scheduled')
   const { agentDetailRoutes } = await import('../routes/agent-detail')
+  const { agentChatRoutes } = await import('../routes/agent-chat')
   const { arturitaRoutes } = await import('../routes/arturita')
   const { arturitaWalletRoutes } = await import('../routes/arturita-wallet')
   const { arturitaVoiceRoutes } = await import('../routes/arturita-voice')
@@ -155,6 +156,7 @@ before(async () => {
     await secured.register(all.orgRoutes)
     await secured.register(all.agentRoutes)
     await secured.register(agentDetailRoutes)
+    await secured.register(agentChatRoutes)  // MCC-1 — the leak-guard sweep must see the chat routes
     await secured.register(all.taskRoutes)
     await secured.register(all.projectRoutes)
     await secured.register(all.costRoutes)

--- a/web/app/dashboard/ChatPanel.tsx
+++ b/web/app/dashboard/ChatPanel.tsx
@@ -1,0 +1,166 @@
+'use client'
+// MCC-1 — Chat: talk to any agent, replies included, from the Inbox area.
+//
+// One surface, two runtimes, one contract:
+//   • INTERNAL agents answer synchronously — the reply is in the POST response.
+//   • EXTERNAL agents (OpenClaw / Cursor / Claude Code…) receive the message as
+//     an assigned task their poll loop claims; their /result lands in the SAME
+//     thread, so this panel just keeps polling the GET until it appears.
+// The thread is server truth (`messages` table via the org-scoped chat routes);
+// everything client-side is a cache merged by id (lib/chat.logic).
+//
+// Colorblind-safe (DESIGN_SYSTEM v2): the user/assistant sides are told apart by
+// ALIGNMENT + label, never color alone; the awaiting-reply state is text + ⏳.
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { api } from '@/lib/api'
+import { mergeThread, awaitingReply, threadPreview, chatSendError, type ChatMsg } from '@/lib/chat.logic'
+import { tk, text, space } from './tokens'
+import { Button, Card, SectionLabel, TextArea } from './ui'
+
+type Getter = () => Promise<string | null>
+export interface ChatAgent { id: string; name: string; avatarEmoji?: string | null; status?: string; runtime?: string }
+
+const POLL_MS = 4000
+
+export default function ChatPanel({ orgId, getToken, agents }: { orgId: string; getToken: Getter; agents: ChatAgent[] }) {
+  const [sel, setSel] = useState<string | null>(agents[0]?.id ?? null)
+  const [threads, setThreads] = useState<Record<string, ChatMsg[]>>({})
+  const [meta, setMeta] = useState<Record<string, { external: boolean }>>({})
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const scroller = useRef<HTMLDivElement>(null)
+  const stickToBottom = useRef(true)
+
+  // If the roster arrives after mount, select the first agent once.
+  useEffect(() => { if (!sel && agents.length) setSel(agents[0].id) }, [agents, sel])
+
+  const load = useCallback(async (agentId: string) => {
+    try {
+      const token = await getToken()
+      const r = await api<{ messages: ChatMsg[]; agent: { external: boolean } }>(
+        `/api/orgs/${orgId}/agents/${agentId}/chat`, { token })
+      setThreads(t => ({ ...t, [agentId]: mergeThread(t[agentId] ?? [], r.messages) }))
+      setMeta(m => ({ ...m, [agentId]: { external: r.agent.external } }))
+      setErr(null)
+    } catch (e: any) { setErr(e?.message ?? 'Failed to load the thread.') }
+  }, [orgId, getToken])
+
+  // Poll the SELECTED thread — replies from external runtimes arrive out-of-band.
+  useEffect(() => {
+    if (!sel) return
+    load(sel)
+    const t = setInterval(() => load(sel), POLL_MS)
+    return () => clearInterval(t)
+  }, [sel, load])
+
+  // Keep the newest message on screen unless the operator scrolled up to read.
+  const msgs = sel ? threads[sel] ?? [] : []
+  useEffect(() => {
+    const el = scroller.current
+    if (el && stickToBottom.current) el.scrollTop = el.scrollHeight
+  }, [msgs.length, sel])
+
+  const send = useCallback(async () => {
+    if (!sel || sending) return
+    const problem = chatSendError(input)
+    if (problem) { setErr(problem); return }
+    const content = input.trim()
+    setSending(true); setErr(null)
+    try {
+      const token = await getToken()
+      const r = await api<{ message: ChatMsg; reply?: ChatMsg }>(
+        `/api/orgs/${orgId}/agents/${sel}/chat`,
+        { token, method: 'POST', body: JSON.stringify({ content }) })
+      setInput('')
+      stickToBottom.current = true
+      setThreads(t => ({ ...t, [sel]: mergeThread(t[sel] ?? [], [r.message, ...(r.reply ? [r.reply] : [])]) }))
+    } catch (e: any) { setErr(e?.message ?? 'Send failed.') }
+    finally { setSending(false) }
+  }, [sel, sending, input, orgId, getToken])
+
+  const selAgent = agents.find(a => a.id === sel) ?? null
+  const waiting = awaitingReply(msgs) && (meta[sel ?? '']?.external ?? false)
+
+  return (
+    <div style={{ display: 'flex', gap: space.xl, alignItems: 'stretch', height: 'calc(100vh - 160px)', minHeight: 360 }}>
+      {/* ── Agent thread list ── */}
+      <Card style={{ width: 240, flexShrink: 0, overflowY: 'auto', padding: space.md }}>
+        <SectionLabel>Chat</SectionLabel>
+        {agents.length === 0 && <div style={{ ...text.sm, color: tk.muted, padding: space.md }}>No agents yet — add one from the Agents page.</div>}
+        {agents.map(a => (
+          <button key={a.id} onClick={() => { stickToBottom.current = true; setSel(a.id) }}
+            aria-current={sel === a.id ? 'true' : undefined}
+            style={{
+              display: 'block', width: '100%', textAlign: 'left', cursor: 'pointer',
+              background: sel === a.id ? 'var(--accent-dim)' : 'transparent',
+              border: '1px solid ' + (sel === a.id ? 'var(--accent)' : 'transparent'),
+              borderRadius: 8, padding: `${space.sm}px ${space.md}px`, marginBottom: space.xs,
+            }}>
+            <div style={{ ...text.md, fontWeight: 600, color: tk.text }}>
+              {a.avatarEmoji ? `${a.avatarEmoji} ` : ''}{a.name}
+            </div>
+            <div style={{ ...text.sm, color: tk.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {threadPreview(threads[a.id] ?? []) || (a.runtime && a.runtime !== 'internal' ? a.runtime : 'no messages yet')}
+            </div>
+          </button>
+        ))}
+      </Card>
+
+      {/* ── Thread + composer ── */}
+      <Card style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: space.md, minWidth: 0 }}>
+        {!selAgent ? (
+          <div style={{ ...text.md, color: tk.muted, margin: 'auto' }}>Select an agent to start a conversation.</div>
+        ) : (
+          <>
+            <div style={{ ...text.md, fontWeight: 700, padding: `${space.xs}px ${space.sm}px`, borderBottom: '1px solid var(--line)' }}>
+              {selAgent.avatarEmoji ? `${selAgent.avatarEmoji} ` : ''}{selAgent.name}
+              {meta[selAgent.id]?.external && <span style={{ ...text.sm, color: tk.muted, marginLeft: space.md }}>external runtime — replies arrive via its poll loop</span>}
+            </div>
+
+            <div ref={scroller} style={{ flex: 1, overflowY: 'auto', padding: space.md }}
+              onScroll={e => {
+                const el = e.currentTarget
+                stickToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40
+              }}>
+              {msgs.length === 0 && <div style={{ ...text.sm, color: tk.muted }}>No messages yet — say hello.</div>}
+              {msgs.map(m => {
+                const mine = m.role === 'user'
+                return (
+                  <div key={m.id} style={{ display: 'flex', justifyContent: mine ? 'flex-end' : 'flex-start', marginBottom: space.sm }}>
+                    <div style={{
+                      maxWidth: '72%', borderRadius: 10, padding: `${space.sm}px ${space.lg}px`,
+                      background: mine ? 'var(--accent-dim)' : 'var(--s1)',
+                      border: '1px solid ' + (mine ? 'var(--accent)' : 'var(--line)'),
+                    }}>
+                      <div style={{ ...text.sm, color: tk.muted, marginBottom: 2 }}>
+                        {mine ? 'You' : selAgent.name} · {new Date(m.createdAt as any).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      </div>
+                      <div style={{ ...text.md, whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>{m.content}</div>
+                    </div>
+                  </div>
+                )
+              })}
+              {waiting && <div style={{ ...text.sm, color: tk.muted, padding: space.sm }}>⏳ Delivered — awaiting {selAgent.name}&apos;s reply…</div>}
+            </div>
+
+            {err && <div role="alert" style={{ ...text.sm, color: 'var(--danger)', padding: `0 ${space.sm}px ${space.xs}px` }}>{err}</div>}
+
+            <div style={{ display: 'flex', gap: space.md, alignItems: 'flex-end', borderTop: '1px solid var(--line)', paddingTop: space.md }}>
+              <TextArea value={input} onChange={e => setInput(e.target.value)} rows={2}
+                placeholder={`Message ${selAgent.name} — Enter to send, Shift+Enter for a new line`}
+                aria-label={`Message ${selAgent.name}`}
+                style={{ flex: 1, resize: 'vertical' }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() }
+                }} />
+              <Button variant="primary" onClick={send} disabled={sending || !input.trim()}>
+                {sending ? 'Sending…' : '➤ Send'}
+              </Button>
+            </div>
+          </>
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/web/app/dashboard/ChatPanel.tsx
+++ b/web/app/dashboard/ChatPanel.tsx
@@ -63,18 +63,22 @@ export default function ChatPanel({ orgId, getToken, agents }: { orgId: string; 
 
   const send = useCallback(async () => {
     if (!sel || sending) return
+    if (!input.trim()) return // Enter on an empty composer is a no-op, not an error
     const problem = chatSendError(input)
     if (problem) { setErr(problem); return }
     const content = input.trim()
     setSending(true); setErr(null)
     try {
       const token = await getToken()
-      const r = await api<{ message: ChatMsg; reply?: ChatMsg }>(
+      const r = await api<{ message: ChatMsg; reply?: ChatMsg; notice?: string }>(
         `/api/orgs/${orgId}/agents/${sel}/chat`,
         { token, method: 'POST', body: JSON.stringify({ content }) })
       setInput('')
       stickToBottom.current = true
       setThreads(t => ({ ...t, [sel]: mergeThread(t[sel] ?? [], [r.message, ...(r.reply ? [r.reply] : [])]) }))
+      // A governance/budget refusal is a NOTICE to the operator, not a reply —
+      // the server deliberately does not persist it into the thread.
+      if (r.notice) setErr(String(r.notice))
     } catch (e: any) { setErr(e?.message ?? 'Send failed.') }
     finally { setSending(false) }
   }, [sel, sending, input, orgId, getToken])
@@ -97,11 +101,14 @@ export default function ChatPanel({ orgId, getToken, agents }: { orgId: string; 
               border: '1px solid ' + (sel === a.id ? 'var(--accent)' : 'transparent'),
               borderRadius: 8, padding: `${space.sm}px ${space.md}px`, marginBottom: space.xs,
             }}>
-            <div style={{ ...text.md, fontWeight: 600, color: tk.text }}>
+            {/* Selection reads from weight + border + aria-current, not hue alone. */}
+            <div style={{ ...text.md, fontWeight: sel === a.id ? 800 : 600, color: tk.text }}>
               {a.avatarEmoji ? `${a.avatarEmoji} ` : ''}{a.name}
             </div>
             <div style={{ ...text.sm, color: tk.muted, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {threadPreview(threads[a.id] ?? []) || (a.runtime && a.runtime !== 'internal' ? a.runtime : 'no messages yet')}
+              {/* Only the selected thread is fetched — an unvisited one shows its
+                  runtime, never a false "no messages yet". */}
+              {threadPreview(threads[a.id] ?? []) || (a.runtime && a.runtime !== 'internal' ? a.runtime : ' ')}
             </div>
           </button>
         ))}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { api, API } from '@/lib/api'
 import CockpitPanel, { type CockpitSectionKey } from './CockpitPanel'
 import AssistantPanel from './AssistantPanel'
 import MemoryPanel from './MemoryPanel'
+import ChatPanel from './ChatPanel'
 import ConnectorsPanel from './ConnectorsPanel'
 import TaskDrawer from './TaskDrawer'
 import GovernancePanel from './GovernancePanel'
@@ -590,6 +591,14 @@ export default function DashboardPage() {
               const ac = tasks.filter(t => t.agentId === a.id).reduce((sum, t) => sum + (t.costUsd ?? 0), 0)
               return (<div key={a.id} style={s.costRow}><span style={{ minWidth: 120, fontSize: 14 }}>{a.avatarEmoji} {a.name}</span><div style={s.barTrack}><div style={{ ...s.barFill, width: `${Math.max(totalCost > 0 ? (ac / totalCost) * 100 : 0, 1)}%` }} /></div><span style={{ color: 'var(--accent)', fontSize: 13, minWidth: 70, textAlign: 'right' }}>${ac.toFixed(4)}</span></div>)
             })}
+          </div>
+        )}
+
+        {/* MCC-1 — Chat: direct conversation with an agent, replies included. */}
+        {tab === 'chat' && org && (
+          <div style={s.page}>
+            <h1 style={s.h1}>Chat</h1>
+            <ChatPanel orgId={org.id} getToken={getToken} agents={agents} />
           </div>
         )}
 

--- a/web/lib/chat.logic.test.ts
+++ b/web/lib/chat.logic.test.ts
@@ -24,6 +24,15 @@ test('[MCC-1] mergeThread orders by time then id, across overlapping poll window
   assert.deepEqual(t1.map(x => x.id), ['y', 'z'])
 })
 
+test('[MCC-1] same-second Q/A pair renders question before answer regardless of ids', () => {
+  // The server stores createdAt at second precision; ids are random UUIDs. An
+  // id tie-break alone would put 'aa-answer' first — the taskId+role rule bites.
+  const q = { ...m('zz-question', 'user', 'Q', 7), taskId: 'task-1' }
+  const ans = { ...m('aa-answer', 'assistant', 'A', 7), taskId: 'task-1' }
+  assert.deepEqual(mergeThread([q], [ans]).map(x => x.id), ['zz-question', 'aa-answer'])
+  assert.deepEqual(mergeThread([ans], [q]).map(x => x.id), ['zz-question', 'aa-answer'])
+})
+
 test('[MCC-1] awaitingReply is true only when the user spoke last', () => {
   assert.equal(awaitingReply([]), false)
   assert.equal(awaitingReply([m('a', 'user', 'hi', 1)]), true)

--- a/web/lib/chat.logic.test.ts
+++ b/web/lib/chat.logic.test.ts
@@ -1,0 +1,45 @@
+// MCC-1 — chat-thread logic tests (node --test, no jest/vitest — house rule).
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mergeThread, awaitingReply, threadPreview, chatSendError, type ChatMsg } from './chat.logic.ts'
+
+const m = (id: string, role: string, content: string, t: number): ChatMsg =>
+  ({ id, role, content, createdAt: new Date(2026, 0, 1, 0, 0, t).toISOString() })
+
+test('[MCC-1] mergeThread dedupes by id — server copy wins over the optimistic one', () => {
+  const optimistic = m('x', 'user', 'draft copy', 1)
+  const server = { ...m('x', 'user', 'server copy', 1), taskId: 't1' }
+  const out = mergeThread([optimistic], [server])
+  assert.equal(out.length, 1)
+  assert.equal(out[0].content, 'server copy')
+  assert.equal(out[0].taskId, 't1')
+})
+
+test('[MCC-1] mergeThread orders by time then id, across overlapping poll windows', () => {
+  const a = [m('a', 'user', 'one', 1), m('b', 'assistant', 'two', 2)]
+  const b = [m('b', 'assistant', 'two', 2), m('c', 'user', 'three', 3)]
+  assert.deepEqual(mergeThread(a, b).map(x => x.id), ['a', 'b', 'c'])
+  // same-second messages keep a stable id order (no flicker between polls)
+  const t1 = mergeThread([m('z', 'user', 'zz', 5)], [m('y', 'assistant', 'yy', 5)])
+  assert.deepEqual(t1.map(x => x.id), ['y', 'z'])
+})
+
+test('[MCC-1] awaitingReply is true only when the user spoke last', () => {
+  assert.equal(awaitingReply([]), false)
+  assert.equal(awaitingReply([m('a', 'user', 'hi', 1)]), true)
+  assert.equal(awaitingReply([m('a', 'user', 'hi', 1), m('b', 'assistant', 'yo', 2)]), false)
+})
+
+test('[MCC-1] threadPreview squeezes whitespace and truncates with an ellipsis', () => {
+  assert.equal(threadPreview([m('a', 'user', '  hello\n\n  world ', 1)]), 'hello world')
+  const long = threadPreview([m('a', 'user', 'x'.repeat(200), 1)], 10)
+  assert.equal(long.length, 10)
+  assert.ok(long.endsWith('…'))
+  assert.equal(threadPreview([]), '')
+})
+
+test('[MCC-1] chatSendError mirrors the server rules', () => {
+  assert.ok(chatSendError('   '))
+  assert.ok(chatSendError('x'.repeat(8001)))
+  assert.equal(chatSendError('fine'), null)
+})

--- a/web/lib/chat.logic.ts
+++ b/web/lib/chat.logic.ts
@@ -12,17 +12,32 @@ export interface ChatMsg {
 
 export const msgTime = (m: ChatMsg): number => new Date(m.createdAt as any).getTime()
 
+const ROLE_ORDER: Record<string, number> = { user: 0, assistant: 1 }
+
 /**
- * Merge a freshly-polled window into what's on screen, deduped by id, ordered by
- * (createdAt, id). Dedupe matters twice: the optimistic append after POST will
- * reappear in the next poll, and the newest-N windows of consecutive polls
- * overlap almost entirely.
+ * Merge a freshly-polled window into what's on screen, deduped by id. Dedupe
+ * matters twice: the optimistic append after POST reappears in the next poll,
+ * and consecutive newest-N windows overlap almost entirely.
+ *
+ * Ordering: (createdAt, then question-before-answer within a task, then id).
+ * The server stores createdAt at SECOND precision, so a Q/A pair routinely
+ * shares a timestamp — and message ids are random UUIDs, useless as a
+ * tie-break (audit MCC-1 #1). Within one taskId the user's question always
+ * precedes the assistant's answer, which mirrors the server's rowid order.
  */
 export function mergeThread(existing: ChatMsg[], incoming: ChatMsg[]): ChatMsg[] {
   const byId = new Map<string, ChatMsg>()
   for (const m of existing) byId.set(m.id, m)
   for (const m of incoming) byId.set(m.id, m) // server copy wins over optimistic
-  return [...byId.values()].sort((a, b) => (msgTime(a) - msgTime(b)) || String(a.id).localeCompare(String(b.id)))
+  return [...byId.values()].sort((a, b) => {
+    const dt = msgTime(a) - msgTime(b)
+    if (dt) return dt
+    if (a.taskId && a.taskId === b.taskId) {
+      const dr = (ROLE_ORDER[a.role] ?? 2) - (ROLE_ORDER[b.role] ?? 2)
+      if (dr) return dr
+    }
+    return String(a.id).localeCompare(String(b.id))
+  })
 }
 
 /**

--- a/web/lib/chat.logic.ts
+++ b/web/lib/chat.logic.ts
@@ -1,0 +1,53 @@
+// MCC-1 — pure chat-thread logic for the Chat surface (web has no jest/vitest;
+// these run under node --test). Kept out of the component so merging and the
+// awaiting-reply decision are unit-tested without React.
+
+export interface ChatMsg {
+  id: string
+  role: string
+  content: string
+  taskId?: string | null
+  createdAt: string | number | Date
+}
+
+export const msgTime = (m: ChatMsg): number => new Date(m.createdAt as any).getTime()
+
+/**
+ * Merge a freshly-polled window into what's on screen, deduped by id, ordered by
+ * (createdAt, id). Dedupe matters twice: the optimistic append after POST will
+ * reappear in the next poll, and the newest-N windows of consecutive polls
+ * overlap almost entirely.
+ */
+export function mergeThread(existing: ChatMsg[], incoming: ChatMsg[]): ChatMsg[] {
+  const byId = new Map<string, ChatMsg>()
+  for (const m of existing) byId.set(m.id, m)
+  for (const m of incoming) byId.set(m.id, m) // server copy wins over optimistic
+  return [...byId.values()].sort((a, b) => (msgTime(a) - msgTime(b)) || String(a.id).localeCompare(String(b.id)))
+}
+
+/**
+ * Is the thread waiting on the agent? True when the newest message is the
+ * user's. Drives the "…awaiting reply" indicator for external runtimes — their
+ * answer arrives via their poll loop, seconds-to-minutes later.
+ */
+export function awaitingReply(messages: ChatMsg[]): boolean {
+  if (!messages.length) return false
+  return messages[messages.length - 1].role === 'user'
+}
+
+/** One-line preview for the agent list — newest message, squeezed. */
+export function threadPreview(messages: ChatMsg[], max = 64): string {
+  const last = messages[messages.length - 1]
+  if (!last) return ''
+  const flat = String(last.content ?? '').replace(/\s+/g, ' ').trim()
+  return flat.length > max ? `${flat.slice(0, max - 1)}…` : flat
+}
+
+/** Validation mirror of the server's rules — refuse before the round-trip. */
+export const MAX_CHAT_CONTENT = 8000
+export function chatSendError(content: string): string | null {
+  const trimmed = content.trim()
+  if (!trimmed) return 'Message is empty.'
+  if (trimmed.length > MAX_CHAT_CONTENT) return `Message is too long (max ${MAX_CHAT_CONTENT} characters).`
+  return null
+}

--- a/web/lib/navModel.test.ts
+++ b/web/lib/navModel.test.ts
@@ -7,10 +7,12 @@ import {
   parseCollapsed, serializeCollapsed, toggleCollapsed, type NavGroupId,
 } from './navModel.ts'
 
-// The 14 dashboard tabs that must ALL stay reachable after the re-fold.
+// The dashboard tabs that must ALL stay reachable after the re-fold
+// (14 at the P2 re-fold; +chat with MCC-1).
 const EXISTING_TABS = [
   'overview', 'cockpit', 'assistant', 'memory', 'agents', 'tasks',
   'projects', 'skills', 'costs', 'comms', 'connectors', 'governance', 'usage', 'settings',
+  'chat', // MCC-1
 ]
 
 // P1 — surfaces taken off the rail entirely. Still routable, never rendered in the sidebar.
@@ -21,6 +23,7 @@ const REMOVED_FROM_RAIL = ['search', 'goals', 'pipelines', 'workspaces', 'artifa
 const FOLDED: Record<string, string> = {
   budgets: 'costs',
   plugins: 'connectors',
+  chat: 'inbox', // MCC-1 — talk to an agent, replies included
   tasks: 'inbox', // P2 — tasks + approvals are one area
   comms: 'inbox',
   adapters: 'settings',
@@ -98,6 +101,7 @@ test('[P1-nav] each parent page exposes exactly the expected tab bar, itself fir
   // is the log, and they sit side by side under one rail entry.
   assert.deepEqual(navPageTabs('inbox'), [
     { id: 'inbox', label: 'Inbox' },
+    { id: 'chat', label: 'Chat' }, // MCC-1
     { id: 'tasks', label: 'Tasks' },
     { id: 'comms', label: 'Comms' },
   ])
@@ -119,6 +123,16 @@ test('[P1-nav] each parent page exposes exactly the expected tab bar, itself fir
 
 // P2 — the operator asked for tasks folded under Inbox and for "Tasks" to reach
 // the tasks + approvals dashboard. These are that ask, locked down.
+test('[MCC-1] Chat is folded under Inbox, renders a real tab, and keeps Inbox lit', () => {
+  const railIds = allNavItems().map(i => i.id)
+  assert.equal(railIds.includes('chat'), false, 'Chat is not its own rail entry')
+  assert.equal(isHidden('chat'), false, 'Chat is not an off-rail surface')
+  assert.equal(navParentId('chat'), 'inbox')
+  assert.equal(navSelectedId('chat'), 'inbox')
+  assert.equal(findNavItem('chat')?.kind, 'tab', 'Chat renders the real Chat surface, not a placeholder')
+  assert.equal(findNavItem('chat')?.label, 'Chat')
+})
+
 test('[P2-nav] Tasks is folded under Inbox and clicking it keeps Inbox lit', () => {
   const railIds = allNavItems().map(i => i.id)
   assert.equal(railIds.includes('tasks'), false, 'Tasks is not its own rail entry')

--- a/web/lib/navModel.ts
+++ b/web/lib/navModel.ts
@@ -91,6 +91,10 @@ export const NAV_GROUPS: NavGroup[] = [
       {
         id: 'inbox', label: 'Inbox', icon: '📥', kind: 'section', section: 'inbox', paperclip: 'Inbox',
         tabs: [
+          // MCC-1 — direct conversation with an agent (thread + composer), replies
+          // included. Hosted here because "talk to my office" and "what needs me"
+          // are the same area of attention.
+          { id: 'chat', label: 'Chat', icon: '💬', kind: 'tab', paperclip: 'Board Chat / DMs', beyond: true },
           { id: 'tasks', label: 'Tasks', icon: '📋', kind: 'tab', paperclip: 'Issues / Tasks' },
           { id: 'comms', label: 'Comms', icon: '📬', kind: 'tab', paperclip: 'Communications', beyond: true },
         ],


### PR DESCRIPTION
## What

Talk to any agent from Mission Control, replies included — the missing conversational surface.

- **Backend**: org-scoped GET/POST /api/orgs/:orgId/agents/:agentId/chat (agentInOrg tenancy, soft-delete 404, newest-N window with rowid tie-break, GTE since polling, 8k cap). Sending rides the existing task machinery: internal agents answer synchronously with server-built history; external agents get an assigned task their poll loop claims — their /result already lands the reply in the same thread. Governance/budget refusals come back as notices, not fake replies.
- **Tenancy fix**: comms/inbox selected every org's messages (no org filter) — now scoped by joining the org's agents; limit clamped.
- **Prompt-safety**: replayed history is provenance-filtered to taskId-tagged rows, so rows planted via comms/inbox-send or the Telegram webhook render but never re-enter the model's prompt.
- **Web**: Chat tab hosted under Inbox (navModel + tripwire tests), ChatPanel (threads/bubbles/composer, 4s polling), colorblind-safe.
- **Mobile**: Chat segment on the Inbox screen (ChatPane), same routes, logic parity-pinned against the web by test.

## Audit

Independent audit ran on the first commit: verdict BLOCK (same-second ordering flake, guard-harness drift, GT-vs-GTE since, replay provenance, refusal handling). All findings fixed in d0eae4e; audit NIT follow-ups flagged, not scheduled: Telegram webhook fails OPEN without a signing secret (pre-existing), and messages carry no author column so all user rows render as You.

## Tests

Backend 1907 pass (11 new MCC-1 behavioural tests incl. claim-result round-trip, tenancy pincer, GTE-window, comms scoping; chat routes added to boot + leak-guard harnesses) · web 340 pass + build clean · mobile 371 pass + typecheck + export clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dC6rwteH8xveZVmrJfhbZ