### PR TITLE
feat(MCC-2): webhook fail-closed in prod + honest chat author attribution

### DIFF
--- a/apps/mobile/src/api.ts
+++ b/apps/mobile/src/api.ts
@@ -768,7 +768,7 @@ export const Api = {
   // the reply arrives later through its poll loop (the response says `async:
   // true`), so the screen keeps polling the GET — never invents a reply.
   agentChat: (base: string, token: string, orgId: string, agentId: string) =>
-    api<{ messages: ChatMsgLite[]; agent: { id: string; name: string; external: boolean } }>(
+    api<{ viewer?: string | null; messages: ChatMsgLite[]; agent: { id: string; name: string; external: boolean } }>(
       base,
       `/api/orgs/${orgId}/agents/${agentId}/chat`,
       { token },

--- a/apps/mobile/src/chat.test.ts
+++ b/apps/mobile/src/chat.test.ts
@@ -44,3 +44,17 @@ test('[MCC-1] awaitingReply / threadPreview / chatSendError agree with the web',
   }
   assert.equal(phone.MAX_CHAT_CONTENT, web.MAX_CHAT_CONTENT)
 })
+
+test('[MCC-2] authorLabel agrees with the web', () => {
+  const rows: any[] = [
+    { ...m('a', 'user', 'hi', 1), authorUser: 'user_me' },
+    { ...m('b', 'user', 'yo', 2), authorUser: 'user_other' },
+    m('c', 'user', 'legacy', 3),
+    { ...m('d', 'assistant', 'reply', 4), authorUser: null },
+  ]
+  for (const row of rows) {
+    for (const viewer of ['user_me', 'user_other', null, undefined]) {
+      assert.equal(phone.authorLabel(row, viewer as any), web.authorLabel(row, viewer as any))
+    }
+  }
+})

--- a/apps/mobile/src/chat.ts
+++ b/apps/mobile/src/chat.ts
@@ -9,7 +9,16 @@ export interface ChatMsgLite {
   role: string
   content: string
   taskId?: string | null
+  /** MCC-2 — Clerk user id of the human author of a user-role row (null on
+   *  assistant/legacy/webhook rows). */
+  authorUser?: string | null
   createdAt: string | number | Date
+}
+
+/** MCC-2 — "You" only when the row's author IS the viewer; else "Member".
+ *  Fail toward "Member": a row that can't prove it's yours must not claim to be. */
+export function authorLabel(m: ChatMsgLite, viewer: string | null | undefined): 'You' | 'Member' {
+  return m.authorUser && viewer && m.authorUser === viewer ? 'You' : 'Member'
 }
 
 export const msgTime = (m: ChatMsgLite): number => new Date(m.createdAt as any).getTime()

--- a/apps/mobile/src/screens/ChatPane.tsx
+++ b/apps/mobile/src/screens/ChatPane.tsx
@@ -26,7 +26,7 @@ import {
 } from 'react-native'
 import { Api, type Agent } from '../api'
 import { useAuth } from '../auth'
-import { awaitingReply, chatSendError, mergeThread, threadPreview, type ChatMsgLite } from '../chat'
+import { authorLabel, awaitingReply, chatSendError, mergeThread, threadPreview, type ChatMsgLite } from '../chat'
 import { font, space, theme } from '../theme'
 import { Banner, Empty, Loading } from '../ui'
 
@@ -41,6 +41,8 @@ export default function ChatPane() {
   const [input, setInput] = useState('')
   const [sending, setSending] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // MCC-2 — who is looking (server-supplied). Drives the You/Member labels.
+  const [viewer, setViewer] = useState<string | null>(null)
   const scroller = useRef<ScrollView>(null)
 
   // Roster once; select the first agent so the pane opens on a real thread.
@@ -68,6 +70,7 @@ export default function ChatPane() {
       const r = await Api.agentChat(apiUrl, token, orgId, agentId)
       setThreads((t) => ({ ...t, [agentId]: mergeThread(t[agentId] ?? [], r.messages) }))
       setExternal((x) => ({ ...x, [agentId]: r.agent.external }))
+      setViewer(r.viewer ?? null)
       setError(null)
     } catch (e: any) { setError(e?.message ?? 'Failed to load the thread.') }
   }, [apiUrl, getToken, orgId])
@@ -142,12 +145,16 @@ export default function ChatPane() {
       <ScrollView ref={scroller} style={s.thread} contentContainerStyle={{ padding: space.lg }}>
         {msgs.length === 0 && <Empty text={selAgent ? `No messages with ${selAgent.name} yet — say hello.` : 'Select an agent.'} />}
         {msgs.map((m) => {
-          const mine = m.role === 'user'
+          // MCC-2 — right-aligned "You" only for rows THIS viewer wrote; another
+          // member's (or a legacy/webhook) row sits left as "Member".
+          const isUser = m.role === 'user'
+          const mine = isUser && authorLabel(m, viewer) === 'You'
+          const label = isUser ? authorLabel(m, viewer) : selAgent?.name ?? 'Agent'
           return (
             <View key={m.id} style={[s.bubbleRow, { justifyContent: mine ? 'flex-end' : 'flex-start' }]}>
               <View style={[s.bubble, mine ? s.bubbleMine : s.bubbleTheirs]}>
                 <Text style={s.bubbleMeta}>
-                  {mine ? 'You' : selAgent?.name ?? 'Agent'} · {new Date(m.createdAt as any).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                  {label} · {new Date(m.createdAt as any).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                 </Text>
                 <Text style={s.bubbleText}>{m.content}</Text>
               </View>

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -104,6 +104,10 @@ export const messages = sqliteTable('messages', {
   taskId: text('task_id'),
   role: text('role').notNull(),
   content: text('content').notNull(),
+  // MCC-2 — WHO wrote a user-role row (Clerk user id). The thread is org-shared,
+  // so without this every member's message rendered as "You" to every viewer.
+  // Nullable: assistant rows and legacy/webhook rows carry none.
+  authorUser: text('author_user'),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
 })
 

--- a/backend/src/db/setup.ts
+++ b/backend/src/db/setup.ts
@@ -7,7 +7,7 @@ export async function setupDatabase() {
     `CREATE TABLE IF NOT EXISTS departments (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, name TEXT NOT NULL, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS projects (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, description TEXT, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS agents (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, department_id TEXT, name TEXT NOT NULL, role TEXT NOT NULL, personality TEXT, cv TEXT, terms_of_reference TEXT, llm_provider TEXT NOT NULL DEFAULT 'anthropic', llm_model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514', skills TEXT DEFAULT '[]', status TEXT NOT NULL DEFAULT 'idle', avatar_emoji TEXT DEFAULT '🤖', agent_type TEXT NOT NULL DEFAULT 'standard', advisor_persona TEXT, memory_long_term TEXT, persona TEXT, expertise TEXT, advisor_ids TEXT, runtime TEXT NOT NULL DEFAULT 'internal', external_endpoint TEXT, api_token_hash TEXT, last_heartbeat_at INTEGER, heartbeat_status TEXT DEFAULT 'unknown', contact_channel TEXT, reports_to TEXT, title TEXT, job_description TEXT, deleted_at INTEGER, deleted_by TEXT, created_at INTEGER NOT NULL)`,
-    `CREATE TABLE IF NOT EXISTS messages (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, task_id TEXT, role TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL)`,
+    `CREATE TABLE IF NOT EXISTS messages (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, task_id TEXT, role TEXT NOT NULL, content TEXT NOT NULL, author_user TEXT, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, org_id TEXT NOT NULL, project_id TEXT, title TEXT NOT NULL, input TEXT, output TEXT, status TEXT NOT NULL DEFAULT 'pending', priority TEXT NOT NULL DEFAULT 'medium', kanban_column TEXT DEFAULT 'todo', llm_model TEXT, tokens_used INTEGER, cost_usd REAL, duration_ms INTEGER, assigned_to TEXT, due_at INTEGER, parent_task_id TEXT, created_at INTEGER NOT NULL, completed_at INTEGER)`,
     `CREATE TABLE IF NOT EXISTS skills (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, domain TEXT NOT NULL, content TEXT NOT NULL, source TEXT NOT NULL DEFAULT 'github', github_path TEXT, org_id TEXT, last_synced_at INTEGER, created_at INTEGER NOT NULL)`,
     `CREATE TABLE IF NOT EXISTS knowledge_items (id TEXT PRIMARY KEY, org_id TEXT NOT NULL, name TEXT NOT NULL, type TEXT NOT NULL, mime_type TEXT, external_id TEXT, external_url TEXT, parent_id TEXT, content TEXT, backend TEXT NOT NULL DEFAULT 'google_drive', created_at INTEGER NOT NULL)`,
@@ -36,6 +36,8 @@ export async function setupDatabase() {
     `ALTER TABLE organisations ADD COLUMN preferred_llm TEXT`,
     `ALTER TABLE organisations ADD COLUMN deploy_config TEXT DEFAULT '{}'`,
     `ALTER TABLE organisations ADD COLUMN budget_monthly_usd REAL`,
+    // MCC-2: chat author attribution (also in the CREATE string above — the setup.ts trap)
+    `ALTER TABLE messages ADD COLUMN author_user TEXT`,
     // Sprint 4: agent profile fields
     `ALTER TABLE tasks ADD COLUMN parent_task_id TEXT`,
     `ALTER TABLE agents ADD COLUMN persona TEXT`,

--- a/backend/src/routes/agent-chat.ts
+++ b/backend/src/routes/agent-chat.ts
@@ -62,6 +62,9 @@ export async function agentChatRoutes(app: FastifyInstance) {
       .orderBy(desc(schema.messages.createdAt), desc(sql`rowid`)).limit(limit)
     rows.reverse()
     return {
+      // MCC-2 — the viewer's own id rides along so clients can label "You" vs
+      // "Member" honestly (the thread is org-shared; author is per-row).
+      viewer: (req as any).auth?.userId ?? (req as any).userId ?? null,
       messages: rows,
       agent: {
         id: agent.id, name: agent.name,
@@ -93,7 +96,9 @@ export async function agentChatRoutes(app: FastifyInstance) {
       id: taskId, agentId, orgId, title: `chat: ${content.slice(0, 80)}`,
       input: content, status: 'pending', priority: 'medium', createdAt: new Date(),
     } as any)
-    const userMsg = { id: randomUUID(), agentId, taskId, role: 'user' as const, content, createdAt: new Date() }
+    // MCC-2 — record WHO sent it (the Clerk user the membership gate authorised).
+    const authorUser = (req as any).auth?.userId ?? (req as any).userId ?? null
+    const userMsg = { id: randomUUID(), agentId, taskId, role: 'user' as const, content, authorUser, createdAt: new Date() }
     await db.insert(schema.messages).values(userMsg)
 
     if (isExternalAgent(agent as any)) {

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -393,9 +393,14 @@ export async function agentRoutes(app: FastifyInstance) {
   app.delete('/api/agents/:agentId', async (_req, reply) => {
     return reply.code(410).send({ error: 'Gone. Use DELETE /api/orgs/:orgId/agents/:agentId (owner-gated).' })
   })
-  app.get('/api/agents/:agentId/messages', async (req) => {
-    const { agentId } = req.params as any
-    return { messages: await db.select().from(schema.messages).where(eq(schema.messages.agentId, agentId)) }
+  // MCC-2 (audit finding 2) — retired. This read was tenant-BLIND: no :orgId in
+  // the path means requireOrgMembership skips (the documented R-4 trap), so any
+  // authenticated user of any org could read any agent's thread — and with
+  // author attribution it would have leaked Clerk user ids cross-tenant. The
+  // AAD-1 pattern: 410, pointing at the org-scoped route. Only the frozen
+  // legacy app/ tree ever called it.
+  app.get('/api/agents/:agentId/messages', async (_req, reply) => {
+    return reply.code(410).send({ error: 'Gone. Use GET /api/orgs/:orgId/agents/:agentId/chat (org-scoped).' })
   })
   app.post('/api/agents/:agentId/skills', async (req) => {
     const { agentId } = req.params as any
@@ -409,39 +414,20 @@ export async function agentRoutes(app: FastifyInstance) {
     if (!current.includes(skill.name)) await db.update(schema.agents).set({ skills: [...current, skill.name] }).where(eq(schema.agents.id, agentId))
     return { ok: true }
   })
-  app.post('/api/agents/:agentId/chat', async (req, reply) => {
-    const { agentId } = req.params as any
-    const { input, history } = req.body as any
-    const agent = await db.query.agents.findFirst({ where: eq(schema.agents.id, agentId) })
-    if (!agent) return reply.code(404).send({ error: 'Not found' })
-    const taskId = randomUUID()
-    await db.insert(schema.tasks).values({ id: taskId, agentId, orgId: agent.orgId, title: input.slice(0, 100), input, status: 'pending', priority: 'medium', createdAt: new Date() })
-    await db.insert(schema.messages).values({ id: randomUUID(), agentId, taskId, role: 'user', content: input, createdAt: new Date() })
-    const result = await executeAgentTask({ agentId, taskId, input, conversationHistory: history ?? [] })
-    await db.insert(schema.messages).values({ id: randomUUID(), agentId, taskId, role: 'assistant', content: result.output, createdAt: new Date() })
-    return { output: result.output, taskId, tokensUsed: result.tokensUsed, costUsd: result.costUsd, budgetWarning: result.budgetWarning }
+  // MCC-2 (audit finding 3) — both legacy chat writers retired. They were
+  // tenant-blind (no :orgId → the membership gate's R-4 skip), trusted a
+  // CLIENT-SUPPLIED history array straight into the model, and wrote
+  // unattributed user rows that — unlike webhook rows — carried a taskId and so
+  // PASSED the MCC-1 provenance filter into future prompts. A member of org A
+  // could inject prompt-context into org B's agent and spend its budget. The
+  // org-scoped POST /api/orgs/:orgId/agents/:agentId/chat solves all three;
+  // only the frozen legacy app/ tree ever called these.
+  app.post('/api/agents/:agentId/chat', async (_req, reply) => {
+    return reply.code(410).send({ error: 'Gone. Use POST /api/orgs/:orgId/agents/:agentId/chat (org-scoped).' })
   })
-  app.get('/api/agents/:agentId/stream', { websocket: true }, async (socket: any, req: any) => {
-    socket.on('message', async (raw: Buffer) => {
-      try {
-        const { input, history } = JSON.parse(raw.toString())
-        const { agentId } = req.params
-        const agent = await db.query.agents.findFirst({ where: eq(schema.agents.id, agentId) })
-        if (!agent) { socket.send(JSON.stringify({ type: 'error', data: 'Agent not found' })); return }
-        const taskId = randomUUID()
-        await db.insert(schema.tasks).values({ id: taskId, agentId, orgId: agent.orgId, title: input.slice(0, 100), input, status: 'pending', priority: 'medium', createdAt: new Date() })
-        await db.insert(schema.messages).values({ id: randomUUID(), agentId, taskId, role: 'user', content: input, createdAt: new Date() })
-        socket.send(JSON.stringify({ type: 'start', taskId }))
-        await executeAgentTask({
-          agentId, taskId, input, conversationHistory: history ?? [],
-          onToken: (token) => socket.send(JSON.stringify({ type: 'token', data: token })),
-          onDone: async (result) => {
-            await db.insert(schema.messages).values({ id: randomUUID(), agentId, taskId, role: 'assistant', content: result.output, createdAt: new Date() })
-            socket.send(JSON.stringify({ type: 'done', taskId, tokensUsed: result.tokensUsed, costUsd: result.costUsd, budgetWarning: result.budgetWarning }))
-          },
-        })
-      } catch (err: any) { socket.send(JSON.stringify({ type: 'error', data: err.message })) }
-    })
+  app.get('/api/agents/:agentId/stream', { websocket: true }, async (socket: any) => {
+    socket.send(JSON.stringify({ type: 'error', data: 'Gone. Use POST /api/orgs/:orgId/agents/:agentId/chat (org-scoped).' }))
+    socket.close()
   })
   app.get('/api/orgs/:orgId/agents/advisors', async (req) => {
     const { orgId } = req.params as any

--- a/backend/src/routes/comms.ts
+++ b/backend/src/routes/comms.ts
@@ -4,7 +4,7 @@ import { db, schema } from '../db/client'
 import { eq, desc, and } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
 import { getGoogleConnectorCfg } from './connectors'
-import { checkWebhook, deriveWebhookSecret } from '../services/webhook-auth'
+import { checkWebhook, deriveWebhookSecret, webhookFailClosed } from '../services/webhook-auth'
 import { assertAgentInOrg } from '../services/tenant-guard'
 
 // Signing secret for per-org inbound webhook receivers. Falls back to the legacy
@@ -218,8 +218,11 @@ export async function commsWebhookRoutes(app: FastifyInstance) {
     const { orgId } = req.params as any
 
     // Shared-secret check: Telegram echoes the registered secret_token here.
+    // MCC-2: in production a MISSING signing secret refuses the delivery (fail
+    // closed) — this receiver writes user-role rows into agent threads, so an
+    // open posture in prod was unauthenticated message injection.
     const provided = req.headers['x-telegram-bot-api-secret-token'] as string | undefined
-    const { authorized } = checkWebhook(telegramSigningSecret(), 'telegram', orgId, provided)
+    const { authorized } = checkWebhook(telegramSigningSecret(), 'telegram', orgId, provided, webhookFailClosed(process.env.NODE_ENV))
     if (!authorized) return reply.code(403).send({ error: 'Invalid webhook signature' })
 
     const update = req.body as any

--- a/backend/src/routes/jira-webhook.ts
+++ b/backend/src/routes/jira-webhook.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from 'fastify'
 import { db, schema } from '../db/client'
 import { eq, and } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
-import { checkWebhook, deriveWebhookSecret } from '../services/webhook-auth'
+import { checkWebhook, deriveWebhookSecret, webhookFailClosed } from '../services/webhook-auth'
 
 // Signing secret for the per-org Jira receiver. Jira Cloud can't set a custom
 // header, so the secret rides in the URL query (?secret=…) that webhook-url mints.
@@ -32,7 +32,9 @@ export async function jiraWebhookRoutes(app: FastifyInstance) {
     // Shared-secret check: the secret rides in the URL query Jira was configured
     // with (webhook-url mints it), or an x-webhook-secret header for other posters.
     const provided = (req.query as any)?.secret ?? (req.headers['x-webhook-secret'] as string | undefined)
-    const { authorized } = checkWebhook(jiraSigningSecret(), 'jira', orgId, provided)
+    // MCC-2: same fail-closed rule as the Telegram receiver — prod refuses when
+    // no signing secret is configured, instead of accepting anything.
+    const { authorized } = checkWebhook(jiraSigningSecret(), 'jira', orgId, provided, webhookFailClosed(process.env.NODE_ENV))
     if (!authorized) return reply.code(403).send({ error: 'Invalid webhook signature' })
 
     const payload = req.body as any

--- a/backend/src/routes/telegram-webhook.ts
+++ b/backend/src/routes/telegram-webhook.ts
@@ -7,6 +7,7 @@ import { db, schema } from '../db/client'
 import { eq } from 'drizzle-orm'
 import { randomUUID } from 'crypto'
 import { TelegramBot, formatAgentResponse } from '../services/telegram-bot'
+import { webhookFailClosed } from '../services/webhook-auth'
 import { executeAgentTask } from '../services/agent-executor'
 import {
   parseCommand, handleStart, handleStatus, handleAgents,
@@ -17,7 +18,14 @@ import {
 export async function telegramWebhookRoutes(app: FastifyInstance) {
   // POST /api/telegram/webhook — receive Telegram updates
   app.post('/api/telegram/webhook', async (req, reply) => {
-    const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET
+    // MCC-2 (audit finding 1): same fail-closed rule as the per-org receivers.
+    // This route resolves an org from the chat id and DRIVES executeAgentTask —
+    // an open posture in prod was unauthenticated task injection + LLM spend.
+    // Honours WEBHOOK_SIGNING_SECRET as fallback, like routes/comms.ts does.
+    const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET ?? process.env.WEBHOOK_SIGNING_SECRET
+    if (!webhookSecret && webhookFailClosed(process.env.NODE_ENV)) {
+      return reply.code(403).send({ error: 'Webhook signing secret not configured' })
+    }
     if (webhookSecret) {
       const headerSecret = req.headers['x-telegram-bot-api-secret-token']
       if (headerSecret !== webhookSecret) {

--- a/backend/src/services/webhook-auth.ts
+++ b/backend/src/services/webhook-auth.ts
@@ -53,8 +53,10 @@ export function checkWebhook(
   return { authorized: verifyWebhookSecret(provided, expected), enforced: true }
 }
 
-/** Production runs fail CLOSED on a missing signing secret; everything else
- *  keeps the dev-friendly open posture. Route layers pass this in. */
+/** When does a missing signing secret REFUSE deliveries? For any explicit
+ *  non-dev environment — matching only the literal 'production' would let a
+ *  typo ('prod') or a staging env silently reopen an internet-facing receiver
+ *  (audit MCC-2 #4). Unset/empty NODE_ENV keeps the local-dev open posture. */
 export function webhookFailClosed(nodeEnv: string | undefined | null): boolean {
-  return nodeEnv === 'production'
+  return !!nodeEnv && nodeEnv !== 'development' && nodeEnv !== 'test'
 }

--- a/backend/src/services/webhook-auth.ts
+++ b/backend/src/services/webhook-auth.ts
@@ -31,16 +31,30 @@ export function verifyWebhookSecret(provided: string | undefined | null, expecte
 }
 
 /** Decide whether an inbound webhook delivery is authorized.
- *  - No serverSecret configured → verification disabled (dev/local): authorized,
- *    enforced=false. Mirrors the global Telegram receiver's opt-in behaviour.
+ *  - No serverSecret configured:
+ *      · failClosed=false (dev/local) → authorized, enforced=false — the
+ *        historical opt-in behaviour, kept so local runs need no secret.
+ *      · failClosed=true (production) → REFUSED. These receivers write
+ *        user-role rows into agent threads that MCC-1 renders and replays; an
+ *        unset secret in prod was an unauthenticated message-injection door
+ *        (audit MCC-1 #4b). The route passes failClosed from NODE_ENV.
  *  - serverSecret configured → `provided` must equal the derived per-org token. */
 export function checkWebhook(
   serverSecret: string | undefined | null,
   channel: WebhookChannel,
   orgId: string,
   provided: string | undefined | null,
+  failClosed = false,
 ): { authorized: boolean; enforced: boolean } {
-  if (!serverSecret) return { authorized: true, enforced: false }
+  if (!serverSecret) return failClosed
+    ? { authorized: false, enforced: true }
+    : { authorized: true, enforced: false }
   const expected = deriveWebhookSecret(serverSecret, channel, orgId)
   return { authorized: verifyWebhookSecret(provided, expected), enforced: true }
+}
+
+/** Production runs fail CLOSED on a missing signing secret; everything else
+ *  keeps the dev-friendly open posture. Route layers pass this in. */
+export function webhookFailClosed(nodeEnv: string | undefined | null): boolean {
+  return nodeEnv === 'production'
 }

--- a/backend/src/tests/agent-chat.test.ts
+++ b/backend/src/tests/agent-chat.test.ts
@@ -179,6 +179,20 @@ test('[MCC-1] POST to an external agent writes the user message and an assigned 
   assert.equal(msgs.length, 1)
   assert.equal(msgs[0].role, 'user')
   assert.equal(msgs[0].content, 'status report please')
+  // MCC-2 — the row records WHO sent it (the gate-authorised Clerk user)…
+  assert.equal((msgs[0] as any).authorUser, MEMBER_A)
+})
+
+test('[MCC-2] GET returns the viewer id, and rows carry their author', async () => {
+  await as(MEMBER_A, 'POST', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`, { content: 'from the member' })
+  // …and a DIFFERENT viewer reading the shared thread sees the author is not them.
+  const r = await as(OWNER_A, 'GET', `/api/orgs/${ORG_A}/agents/${EXT_A}/chat`)
+  const body = r.json() as any
+  assert.equal(body.viewer, OWNER_A)
+  const row = body.messages.find((m: any) => m.content === 'from the member')
+  assert.ok(row, 'the member message is in the thread')
+  assert.equal(row.authorUser, MEMBER_A)
+  assert.notEqual(row.authorUser, body.viewer)
 })
 
 test('[MCC-1] POST validation: empty and oversized content are refused, nothing is written', async () => {

--- a/backend/src/tests/webhook-auth.test.ts
+++ b/backend/src/tests/webhook-auth.test.ts
@@ -2,6 +2,11 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import Fastify from 'fastify'
 
+// MCC-2 — the routes read NODE_ENV at request time and fail CLOSED for any
+// explicit non-dev env. The "stays open without a secret" parity tests below
+// assert the DEV posture, so pin the env rather than inherit the runner's.
+process.env.NODE_ENV = 'test'
+
 import { deriveWebhookSecret, verifyWebhookSecret, checkWebhook, webhookFailClosed } from '../services/webhook-auth'
 import { commsWebhookRoutes } from '../routes/comms'
 import { jiraWebhookRoutes } from '../routes/jira-webhook'
@@ -62,12 +67,15 @@ test('[MCC-2] checkWebhook fails CLOSED in production when no secret is configur
   assert.deepEqual(checkWebhook(secret, 'telegram', 'org-1', good, true), { authorized: true, enforced: true })
 })
 
-test('[MCC-2] webhookFailClosed is true only for production', () => {
+test('[MCC-2] webhookFailClosed: closed for any explicit non-dev env, open for local dev', () => {
   assert.equal(webhookFailClosed('production'), true)
+  assert.equal(webhookFailClosed('prod'), true, 'a typo must not reopen the receiver')
+  assert.equal(webhookFailClosed('staging'), true)
   assert.equal(webhookFailClosed('development'), false)
   assert.equal(webhookFailClosed('test'), false)
   assert.equal(webhookFailClosed(undefined), false)
   assert.equal(webhookFailClosed(null), false)
+  assert.equal(webhookFailClosed(''), false)
 })
 
 test('[MCA-85] checkWebhook: configured secret enforces the correct token', () => {

--- a/backend/src/tests/webhook-auth.test.ts
+++ b/backend/src/tests/webhook-auth.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import Fastify from 'fastify'
 
-import { deriveWebhookSecret, verifyWebhookSecret, checkWebhook } from '../services/webhook-auth'
+import { deriveWebhookSecret, verifyWebhookSecret, checkWebhook, webhookFailClosed } from '../services/webhook-auth'
 import { commsWebhookRoutes } from '../routes/comms'
 import { jiraWebhookRoutes } from '../routes/jira-webhook'
 
@@ -42,6 +42,32 @@ test('[MCA-85] verifyWebhookSecret matches only the exact token', () => {
 test('[MCA-85] checkWebhook: no server secret → verification disabled (dev)', () => {
   const r = checkWebhook(undefined, 'telegram', 'org-1', undefined)
   assert.deepEqual(r, { authorized: true, enforced: false })
+})
+
+test('[MCC-2] checkWebhook fails CLOSED in production when no secret is configured', () => {
+  // These receivers write user-role rows into agent threads MCC-1 renders and
+  // replays — an open posture in prod was unauthenticated message injection.
+  assert.deepEqual(
+    checkWebhook(undefined, 'telegram', 'org-1', undefined, true),
+    { authorized: false, enforced: true },
+  )
+  // …and a caller-provided "secret" cannot talk its way past a missing config.
+  assert.deepEqual(
+    checkWebhook(undefined, 'telegram', 'org-1', 'anything', true),
+    { authorized: false, enforced: true },
+  )
+  // A configured secret behaves exactly as before, failClosed or not.
+  const secret = 'srv'
+  const good = deriveWebhookSecret(secret, 'telegram', 'org-1')
+  assert.deepEqual(checkWebhook(secret, 'telegram', 'org-1', good, true), { authorized: true, enforced: true })
+})
+
+test('[MCC-2] webhookFailClosed is true only for production', () => {
+  assert.equal(webhookFailClosed('production'), true)
+  assert.equal(webhookFailClosed('development'), false)
+  assert.equal(webhookFailClosed('test'), false)
+  assert.equal(webhookFailClosed(undefined), false)
+  assert.equal(webhookFailClosed(null), false)
 })
 
 test('[MCA-85] checkWebhook: configured secret enforces the correct token', () => {

--- a/web/app/dashboard/ChatPanel.tsx
+++ b/web/app/dashboard/ChatPanel.tsx
@@ -13,7 +13,7 @@
 // ALIGNMENT + label, never color alone; the awaiting-reply state is text + ⏳.
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '@/lib/api'
-import { mergeThread, awaitingReply, threadPreview, chatSendError, type ChatMsg } from '@/lib/chat.logic'
+import { mergeThread, awaitingReply, threadPreview, chatSendError, authorLabel, type ChatMsg } from '@/lib/chat.logic'
 import { tk, text, space } from './tokens'
 import { Button, Card, SectionLabel, TextArea } from './ui'
 
@@ -29,6 +29,8 @@ export default function ChatPanel({ orgId, getToken, agents }: { orgId: string; 
   const [input, setInput] = useState('')
   const [sending, setSending] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  // MCC-2 — who is looking. Server-supplied on the GET; drives You/Member labels.
+  const [viewer, setViewer] = useState<string | null>(null)
   const scroller = useRef<HTMLDivElement>(null)
   const stickToBottom = useRef(true)
 
@@ -38,10 +40,11 @@ export default function ChatPanel({ orgId, getToken, agents }: { orgId: string; 
   const load = useCallback(async (agentId: string) => {
     try {
       const token = await getToken()
-      const r = await api<{ messages: ChatMsg[]; agent: { external: boolean } }>(
+      const r = await api<{ viewer?: string | null; messages: ChatMsg[]; agent: { external: boolean } }>(
         `/api/orgs/${orgId}/agents/${agentId}/chat`, { token })
       setThreads(t => ({ ...t, [agentId]: mergeThread(t[agentId] ?? [], r.messages) }))
       setMeta(m => ({ ...m, [agentId]: { external: r.agent.external } }))
+      setViewer(r.viewer ?? null)
       setErr(null)
     } catch (e: any) { setErr(e?.message ?? 'Failed to load the thread.') }
   }, [orgId, getToken])
@@ -132,7 +135,11 @@ export default function ChatPanel({ orgId, getToken, agents }: { orgId: string; 
               }}>
               {msgs.length === 0 && <div style={{ ...text.sm, color: tk.muted }}>No messages yet — say hello.</div>}
               {msgs.map(m => {
-                const mine = m.role === 'user'
+                // MCC-2 — right-aligned "You" only for rows THIS viewer wrote;
+                // another member's (or a legacy/webhook) row sits left as "Member".
+                const isUser = m.role === 'user'
+                const mine = isUser && authorLabel(m, viewer) === 'You'
+                const label = isUser ? authorLabel(m, viewer) : selAgent.name
                 return (
                   <div key={m.id} style={{ display: 'flex', justifyContent: mine ? 'flex-end' : 'flex-start', marginBottom: space.sm }}>
                     <div style={{
@@ -141,7 +148,7 @@ export default function ChatPanel({ orgId, getToken, agents }: { orgId: string; 
                       border: '1px solid ' + (mine ? 'var(--accent)' : 'var(--line)'),
                     }}>
                       <div style={{ ...text.sm, color: tk.muted, marginBottom: 2 }}>
-                        {mine ? 'You' : selAgent.name} · {new Date(m.createdAt as any).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                        {label} · {new Date(m.createdAt as any).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                       </div>
                       <div style={{ ...text.md, whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}>{m.content}</div>
                     </div>

--- a/web/lib/chat.logic.test.ts
+++ b/web/lib/chat.logic.test.ts
@@ -1,7 +1,7 @@
 // MCC-1 — chat-thread logic tests (node --test, no jest/vitest — house rule).
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { mergeThread, awaitingReply, threadPreview, chatSendError, type ChatMsg } from './chat.logic.ts'
+import { mergeThread, awaitingReply, threadPreview, chatSendError, authorLabel, type ChatMsg } from './chat.logic.ts'
 
 const m = (id: string, role: string, content: string, t: number): ChatMsg =>
   ({ id, role, content, createdAt: new Date(2026, 0, 1, 0, 0, t).toISOString() })
@@ -45,6 +45,16 @@ test('[MCC-1] threadPreview squeezes whitespace and truncates with an ellipsis',
   assert.equal(long.length, 10)
   assert.ok(long.endsWith('…'))
   assert.equal(threadPreview([]), '')
+})
+
+test('[MCC-2] authorLabel: "You" only when the author IS the viewer, fails toward "Member"', () => {
+  const mine = { ...m('a', 'user', 'hi', 1), authorUser: 'user_me' }
+  const theirs = { ...m('b', 'user', 'yo', 2), authorUser: 'user_other' }
+  const legacy = m('c', 'user', 'old row', 3) // no author (pre-MCC-2 / webhook)
+  assert.equal(authorLabel(mine, 'user_me'), 'You')
+  assert.equal(authorLabel(theirs, 'user_me'), 'Member')
+  assert.equal(authorLabel(legacy, 'user_me'), 'Member')
+  assert.equal(authorLabel(mine, null), 'Member') // no viewer known → never claim "You"
 })
 
 test('[MCC-1] chatSendError mirrors the server rules', () => {

--- a/web/lib/chat.logic.ts
+++ b/web/lib/chat.logic.ts
@@ -7,7 +7,20 @@ export interface ChatMsg {
   role: string
   content: string
   taskId?: string | null
+  /** MCC-2 — Clerk user id of the human who wrote a user-role row. Null on
+   *  assistant rows and on legacy/webhook rows. */
+  authorUser?: string | null
   createdAt: string | number | Date
+}
+
+/**
+ * MCC-2 — label for a user-role row. The thread is org-shared, so "You" is only
+ * honest when the row's author IS the viewer; anything else (another member, a
+ * legacy row, a webhook-injected row) is "Member". Fail toward "Member": a row
+ * that can't prove it's yours must not claim to be.
+ */
+export function authorLabel(m: ChatMsg, viewer: string | null | undefined): 'You' | 'Member' {
+  return m.authorUser && viewer && m.authorUser === viewer ? 'You' : 'Member'
 }
 
 export const msgTime = (m: ChatMsg): number => new Date(m.createdAt as any).getTime()


### PR DESCRIPTION
## What

Closes the two follow-ups flagged in the MCC-1 audit, plus what its own audit surfaced.

- **Fail closed**: all three inbound webhook receivers (per-org Telegram, per-org Jira, and the GLOBAL Telegram receiver that drives executeAgentTask) now refuse deliveries in any explicit non-dev environment when no signing secret is configured. Previously an unset secret meant unauthenticated message/task injection into agent threads and LLM spend.
- **Author attribution**: messages.author_user records the gate-authorised Clerk user; the chat GET returns the viewer id; web + mobile label rows You/Member honestly (fail toward Member) and only the viewer's own rows right-align. Parity-pinned on both clients.
- **Legacy route retirement (audit)**: GET /api/agents/:agentId/messages, POST /api/agents/:agentId/chat and WS /stream retired to 410 - all three were tenant-blind (the R-4 gate skip), the chat pair trusted client-supplied history, and their rows passed the provenance filter into prompts. Only the frozen legacy app/ tree called them.

## Ops note

After deploy, prod webhooks REQUIRE a signing secret: WEBHOOK_SIGNING_SECRET will be set on Fly alongside this merge; any previously-registered Telegram/Jira webhook must be re-registered with the minted secret to keep delivering (none are believed active).

## Tests

Backend 1910 pass (fail-closed matrix incl. typo-env, author persistence + cross-viewer read, NODE_ENV-pinned parity tests) · web 341 + build · mobile 372 + typecheck. Independent audit ran on the first commit; all findings addressed in the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dC6rwteH8xveZVmrJfhbZ