### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+Root operating guide is `CLAUDE.md` (+ `backend/CLAUDE.md`, `web/CLAUDE.md`). This file
+adds only the durable, non-obvious environment notes that live agents need.
+
+## Cursor Cloud specific instructions
+
+This is an npm-workspaces monorepo, but **each workspace installs from its own lockfile**
+(`backend/`, `web/`, `app/`, `apps/mobile/`, `apps/desktop/`). There is no root install.
+The startup update script runs `npm install` in `backend/` and `web/` (the primary E2E
+stack). Node 22 is required and already present.
+
+### Services (dev)
+
+| Service | Dir | Dev command | Port | Standard commands |
+|---|---|---|---|---|
+| Backend API (Fastify + Drizzle + libSQL/Turso) | `backend/` | `npm run dev` | 3001 | see `backend/CLAUDE.md` (`npm test`, `npm run evals`, `npm run typecheck`) |
+| Web dashboard (Next.js 15) — PRIMARY UI | `web/` | `npm run dev` | 3000 | see `web/CLAUDE.md` (`npm test`, `npm run build`, `npm run typecheck`) |
+
+- Backend boots self-contained: with no `.env` it uses a local SQLite file (`DATABASE_URL=file:./dev.db`), auto-creates the schema on boot, and reports readiness at `GET /api/health` (`db:"connected"`). Optional integrations (Anthropic/OpenAI/Gemini, Clerk, Pinecone, Redis, Google, Jira) are each guarded by an env-var check and are skipped when unset — agents can't run real LLM work without `ANTHROPIC_API_KEY`, but everything else boots.
+- `web` reads the backend URL from `NEXT_PUBLIC_API_URL` (default `http://localhost:3001`).
+
+### Lint is NOT a CI gate (don't chase it)
+
+`.github/workflows/ci.yml` gates only **typecheck + test + build** (installing with
+`npm install --legacy-peer-deps`). The `npm run lint` scripts are not wired: `backend`'s
+`eslint` binary isn't installed, and `web`'s `next lint` prompts interactively because no
+ESLint config exists. Use `npm run typecheck` as the static gate, not `npm run lint`.
+
+### Running a live, signed-in dashboard needs Clerk (gotcha)
+
+The live `web` dashboard (`/dashboard`) calls Clerk's `useAuth` unconditionally
+(`web/app/dashboard/page.tsx`). Two consequences in a normal cloud dev tree:
+
+- **Hosted mode**: set `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` + `CLERK_SECRET_KEY` (dev instance) and sign in. Without a key the dashboard bounces to `/` (no session).
+- **Packaged/loopback web mode is NOT runnable from a plain `npm install` tree.** Its keyless fallback only triggers when `@clerk/nextjs` fails to `require()` (as in the Electron packaged build that strips Clerk). Here the package resolves, so `useAuth` runs without a `<ClerkProvider>` and the dashboard throws a client-side exception. Do not "fix" this in source — it's by design for the packaged build.
+- The landing page `/` has no Clerk dependency and renders fine keyless (useful smoke check that `web` is serving).
+
+### Exercising core functionality locally WITHOUT Clerk (backend packaged profile)
+
+To create orgs/agents/tasks end-to-end with zero external secrets, run the **backend** in
+the `packaged` profile and drive the REST API with the loopback bearer:
+
+```bash
+cd backend
+MC_DEPLOYMENT_PROFILE=packaged \
+SECRETS_ENC_KEY=<real-non-default> \
+RUN_TOKEN_SECRET=<real-non-default-DISTINCT-from-enc> \
+MC_LOOPBACK_SESSION_SECRET=<real-non-default> \
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8081 \
+npm run dev
+```
+
+- The fail-closed guard (`backend/src/services/secret-keys.ts`) refuses to boot if any of the three keys is missing/empty/a known dev default, or if `RUN_TOKEN_SECRET == SECRETS_ENC_KEY`. Use three distinct real strings.
+- On boot it idempotently seeds org `local-org` owned by user `local-operator`.
+- Authenticate every secured API call with `Authorization: Bearer <MC_LOOPBACK_SESSION_SECRET>`; a missing/wrong bearer is `401`. Example: `curl -H "Authorization: Bearer <secret>" http://localhost:3001/api/orgs`.
+- If you also want the packaged web build to talk to it, the packaged web sends the literal bearer `mc-loopback` (`web/app/dashboard/page.tsx`), so set `MC_LOOPBACK_SESSION_SECRET=mc-loopback` — but note the packaged web caveat above (it won't run from a normal npm tree).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and verifies the local development environment for the 7Ei Mission Control monorepo, and captures the durable, non-obvious learnings in a new `AGENTS.md` (`## Cursor Cloud specific instructions`).

The only code/file change here is the new `AGENTS.md`. No application source was modified.

## Environment set up (primary E2E stack)

- Node 22 (already present). Each workspace installs from its own lockfile (no root install).
- Installed deps for `backend/` and `web/`.
- Startup update script (submitted separately): `npm install --legacy-peer-deps` in `backend/` and `web/`.

## Verification (all green)

| Workspace | Command | Result |
|---|---|---|
| backend | `npm run typecheck` | clean |
| backend | `npm test` | 1910 passed, 0 failed |
| backend | `npm run evals` | 11/11 scenarios |
| web | `npm run typecheck` | clean |
| web | `npm test` | 341 passed, 0 failed |
| web | `npm run build` | production build passed |

Note: `npm run lint` is **not** a CI gate in either workspace (`backend` has no `eslint` installed; `web`'s `next lint` prompts interactively with no config). CI (`.github/workflows/ci.yml`) gates typecheck + test + build.

## Running the app + hello-world (core functionality)

- `backend` runs on `:3001` (`npm run dev`), self-contained on a local SQLite file; `GET /api/health` → `db:"connected"`.
- `web` runs on `:3000` (`npm run dev`); the landing page renders and serves the real product.
- The live `/dashboard` requires Clerk (see AGENTS.md gotcha). To exercise core functionality without external secrets, I ran the backend in the `packaged` (loopback) profile and drove the REST API:
  - Seeded org `local-org` owned by `local-operator` on boot.
  - Loopback bearer auth verified (401 without/with wrong token, 200 with the configured secret).
  - Created an agent (**Ada**) and a **task** ("Hello World - verify dev environment") assigned to her; both persist and read back.

## Demo

Web landing page served by the local Next.js dev server:

[web_landing_clean_demo.mp4](https://cursor.com/agents/bc-d4a350ab-af48-4c4e-b850-abac324069bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_landing_clean_demo.mp4)

Backend packaged-profile API hello-world evidence: `backend_hello_world_api.log`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4a350ab-af48-4c4e-b850-abac324069bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4a350ab-af48-4c4e-b850-abac324069bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

